### PR TITLE
Addded Event and Listener Generation Commands

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -97,6 +97,8 @@ return [
             'assets' => 'Assets',
             'config' => 'Config',
             'command' => 'Console',
+	    'event' => 'Events',
+            'listener' => 'Listeners', 	
             'migration' => 'Database/Migrations',
             'model' => 'Entities',
             'repository' => 'Repositories',

--- a/src/Commands/GenerateEventCommand.php
+++ b/src/Commands/GenerateEventCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Nwidart\Modules\Commands;
+
+use Nwidart\Modules\Commands\GeneratorCommand;
+use Nwidart\Modules\Traits\ModuleCommandTrait;
+use Pingpong\Support\Stub;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+class GenerateEventCommand extends GeneratorCommand
+{
+    use ModuleCommandTrait;
+
+    protected $argumentName = 'name';
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'module:make-event';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate a new Event Class for the specified module';
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['name', InputArgument::REQUIRED, 'The name of the command.'],
+            ['module', InputArgument::OPTIONAL, 'The name of module will be used.'],
+        ];
+
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['example', null, InputOption::VALUE_OPTIONAL, 'An example option.', null],
+        ];
+    }
+
+    public function getTemplateContents()
+    {
+        $module = $this->laravel['modules']->findOrFail($this->getModuleName());
+
+        return (new Stub('/event.stub', [
+            'NAMESPACE' => $this->getClassNamespace($module) . "\\" . config("modules.paths.generator.event"),
+            "CLASS" => $this->getClass(),
+            'DUMMYNAMESPACE' => $this->laravel->getNamespace() . "Events"
+        ]))->render();
+    }
+
+    public function getDestinationFilePath()
+    {
+        $path = $this->laravel['modules']->getModulePath($this->getModuleName());
+
+        $seederPath = $this->laravel['modules']->config('paths.generator.event');
+
+        return $path . $seederPath . '/' . $this->getFileName() . '.php';
+
+    }
+
+    /**
+     * @return string
+     */
+    protected function getFileName()
+    {
+        return studly_case($this->argument('name'));
+    }
+
+
+}

--- a/src/Commands/GenerateListenerCommand.php
+++ b/src/Commands/GenerateListenerCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Nwidart\Modules\Commands;
+
+use Nwidart\Modules\Commands\GeneratorCommand;
+use Nwidart\Modules\Module;
+use Nwidart\Modules\Traits\ModuleCommandTrait;
+use Pingpong\Support\Stub;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+class GenerateListenerCommand extends GeneratorCommand
+{
+    use ModuleCommandTrait;
+
+    protected $argumentName = 'name';
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'module:make-listener';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate a new Listener Class for the specified module';
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['name', InputArgument::REQUIRED, 'The name of the command.'],
+            ['module', InputArgument::OPTIONAL, 'The name of module will be used.'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['event', null, InputOption::VALUE_REQUIRED, 'An example option.', null],
+        ];
+    }
+
+    protected function getTemplateContents()
+    {
+        $module = $this->laravel['modules']->findOrFail($this->getModuleName());
+
+        return (new Stub('/listener.stub', [
+            'NAMESPACE' => $this->getClassNamespace($module) . "\\" . config("modules.paths.generator.listener"),
+            "EVENTNAME" => $this->getEventName($module),
+            "EVENTSHORTENEDNAME" => $this->option('event'),
+            "CLASS" => $this->getClass(),
+            'DUMMYNAMESPACE' => $this->laravel->getNamespace() . "Events"
+        ]))->render();
+
+    }
+
+    protected function getDestinationFilePath()
+    {
+        $path = $this->laravel['modules']->getModulePath($this->getModuleName());
+
+        $seederPath = $this->laravel['modules']->config('paths.generator.listener');
+
+        return $path . $seederPath . '/' . $this->getFileName() . '.php';
+
+    }
+
+    /**
+     * @return string
+     */
+    protected function getFileName()
+    {
+        return studly_case($this->argument('name'));
+    }
+
+    public function fire()
+    {
+        if (!$this->option('event')) {
+            return $this->error("The --event option is neccessary");
+        }
+
+        parent::fire();
+    }
+
+    protected function getEventName(Module $module)
+    {
+        return $this->getClassNamespace($module) . "\\" . config("modules.paths.generator.event") . "\\" . $this->option('event');
+    }
+}

--- a/src/Commands/stubs/event.stub
+++ b/src/Commands/stubs/event.stub
@@ -1,0 +1,30 @@
+<?php
+
+namespace $NAMESPACE$;
+
+use Illuminate\Queue\SerializesModels;
+
+class $CLASS$
+{
+    use SerializesModels;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the channels the event should be broadcast on.
+     *
+     * @return array
+     */
+    public function broadcastOn()
+    {
+        return [];
+    }
+}

--- a/src/Commands/stubs/listener.stub
+++ b/src/Commands/stubs/listener.stub
@@ -1,0 +1,31 @@
+<?php
+
+namespace $NAMESPACE$;
+
+use $EVENTNAME$;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class $CLASS$
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param \$EVENTNAME$ $event
+     * @return void
+     */
+    public function handle(\$EVENTNAME$ $event)
+    {
+        //
+    }
+}

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -8,6 +8,8 @@ use Nwidart\Modules\Commands\ControllerCommand;
 use Nwidart\Modules\Commands\DisableCommand;
 use Nwidart\Modules\Commands\DumpCommand;
 use Nwidart\Modules\Commands\EnableCommand;
+use Nwidart\Modules\Commands\GenerateEventCommand;
+use Nwidart\Modules\Commands\GenerateListenerCommand;
 use Nwidart\Modules\Commands\GenerateMiddlewareCommand;
 use Nwidart\Modules\Commands\GenerateProviderCommand;
 use Nwidart\Modules\Commands\GenerateRouteProviderCommand;
@@ -46,6 +48,8 @@ class ConsoleServiceProvider extends ServiceProvider
         ControllerCommand::class,
         DisableCommand::class,
         EnableCommand::class,
+        GenerateEventCommand::class,
+        GenerateListenerCommand::class,
         GenerateMiddlewareCommand::class,
         GenerateProviderCommand::class,
         GenerateRouteProviderCommand::class,

--- a/tests/Commands/GenerateEventCommandTest.php
+++ b/tests/Commands/GenerateEventCommandTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Nwidart\Modules\Tests\Commands;
+
+use Nwidart\Modules\Tests\BaseTestCase;
+
+class GenerateEventCommandTest extends BaseTestCase
+{
+    /**
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    private $finder;
+
+    /**
+     * @var string
+     */
+    private $modulePath;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->modulePath = base_path('modules/Blog');
+        $this->finder = $this->app['files'];
+        $this->artisan('module:make', ['name' => ['Blog']]);
+    }
+
+    public function tearDown()
+    {
+        $this->finder->deleteDirectory($this->modulePath);
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_generates_a_new_event_class()
+    {
+        $this->artisan('module:make-event', ['name' => 'PostWasCreated', 'module' => 'Blog']);
+
+        $this->assertTrue(is_file($this->modulePath . '/Events/PostWasCreated.php'));
+    }
+
+    /** @test */
+    public function it_generated_correct_file_with_content()
+    {
+        $this->artisan('module:make-event', ['name' => 'PostWasCreated', 'module' => 'Blog']);
+
+        $file = $this->finder->get($this->modulePath . '/Events/PostWasCreated.php');
+
+        $this->assertEquals($this->expectedContent(), $file);
+    }
+
+    private function expectedContent()
+    {
+        return <<<TEXT
+<?php
+
+namespace Modules\Blog\Events;
+
+use Illuminate\Queue\SerializesModels;
+
+class PostWasCreated
+{
+    use SerializesModels;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the channels the event should be broadcast on.
+     *
+     * @return array
+     */
+    public function broadcastOn()
+    {
+        return [];
+    }
+}
+
+TEXT;
+
+    }
+
+}

--- a/tests/Commands/GenerateListenerCommandTest.php
+++ b/tests/Commands/GenerateListenerCommandTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Nwidart\Modules\Tests\Commands;
+
+use Nwidart\Modules\Tests\BaseTestCase;
+
+class GenerateListenerCommandTest extends BaseTestCase
+{
+    /**
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    private $finder;
+
+    /**
+     * @var string
+     */
+    private $modulePath;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->modulePath = base_path('modules/Blog');
+        $this->finder = $this->app['files'];
+        $this->artisan('module:make', ['name' => ['Blog']]);
+    }
+
+    public function tearDown()
+    {
+        $this->finder->deleteDirectory($this->modulePath);
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_generates_a_new_event_class()
+    {
+        $this->artisan('module:make-listener',
+            ['name' => 'NotifyUsersOfANewPost', 'module' => 'Blog', '--event' => 'UserWasCreated']);
+
+        $this->assertTrue(is_file($this->modulePath . '/Listeners/NotifyUsersOfANewPost.php'));
+    }
+
+    /** @test */
+    public function it_generated_correct_file_with_content()
+    {
+        $this->artisan('module:make-listener',
+            ['name' => 'NotifyUsersOfANewPost', 'module' => 'Blog', '--event' => 'UserWasCreated']);
+
+        $file = $this->finder->get($this->modulePath . '/Listeners/NotifyUsersOfANewPost.php');
+
+        $this->assertEquals($this->expectedContent(), $file);
+    }
+
+    private function expectedContent()
+    {
+        $event = '$event';
+        return <<<TEXT
+<?php
+
+namespace Modules\Blog\Listeners;
+
+use Modules\Blog\Events\UserWasCreated;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class NotifyUsersOfANewPost
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param \Modules\Blog\Events\UserWasCreated $event
+     * @return void
+     */
+    public function handle(\Modules\Blog\Events\UserWasCreated $event)
+    {
+        //
+    }
+}
+
+TEXT;
+
+    }
+
+}


### PR DESCRIPTION
They follow the same convention as the default commands artisan ships with, e.g the Listener command requires an `--event` option to be present.