### PR TITLE
Use trim for namespace in GeneratorCommand so you can set the 'module…

### DIFF
--- a/src/Commands/GeneratorCommand.php
+++ b/src/Commands/GeneratorCommand.php
@@ -92,6 +92,6 @@ abstract class GeneratorCommand extends Command
 
         $namespace .= '\\' . $extra;
 
-        return rtrim($namespace, '\\');
+        return trim($namespace, '\\');
     }
 }


### PR DESCRIPTION
Use trim for namespace in GeneratorCommand so you can set the 'modules.namespace' config to an empty string