### PR TITLE
Adjusted case of module base path to fit folder structure

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -62,7 +62,7 @@ return [
         |
         */
 
-        'modules' => base_path('Modules'),
+        'modules' => base_path('modules'),
         /*
         |--------------------------------------------------------------------------
         | Modules assets path


### PR DESCRIPTION
Folder structure looked strange to me after creating a module, guess that's a typo. According to the readme (sections "Folder Structure" and "Autoloading") modules it is meant to be lowercase. On a case sensitive file system, this is crucial, because namespaces can't be autoloaded.