### PR TITLE
Remove unnecessary loops in register and provides

### DIFF
--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -81,9 +81,7 @@ class ConsoleServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        foreach ($this->commands as $command) {
-            $this->commands($command);
-        }
+        $this->commands($this->commands);
     }
 
     /**
@@ -91,11 +89,7 @@ class ConsoleServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        $provides = [];
-
-        foreach ($this->commands as $command) {
-            $provides[] = $command;
-        }
+        $provides = $this->commands;
 
         return $provides;
     }


### PR DESCRIPTION
`$this->commands()` will accept an array and do the loop itself.

`provides()` returns an array, which the commands are already in.