### PR TITLE
added support for a new migrate.path configuration setting to the mod…

### DIFF
--- a/src/Commands/MigrateCommand.php
+++ b/src/Commands/MigrateCommand.php
@@ -80,7 +80,9 @@ class MigrateCommand extends Command
      */
     protected function getPath($module)
     {
-        $path = $module->getExtraPath(config('modules.paths.generator.migration'));
+        $config = $module->get('migrate', ['path' => config('modules.paths.generator.migration')]);
+
+        $path = $module->getExtraPath($config['path']);
 
         return str_replace(base_path(), '', $path);
     }

--- a/src/Commands/MigrateCommand.php
+++ b/src/Commands/MigrateCommand.php
@@ -80,9 +80,11 @@ class MigrateCommand extends Command
      */
     protected function getPath($module)
     {
-        $config = $module->get('migrate', ['path' => config('modules.paths.generator.migration')]);
+        $config = $module->get('migrate');
 
-        $path = $module->getExtraPath($config['path']);
+        $path = (is_array($config) && array_key_exists('path', $config)) ? $config['path'] : config('modules.paths.generator.migration');
+
+        $path = $module->getExtraPath($path);
 
         return str_replace(base_path(), '', $path);
     }

--- a/src/Commands/MigrateCommand.php
+++ b/src/Commands/MigrateCommand.php
@@ -80,7 +80,7 @@ class MigrateCommand extends Command
      */
     protected function getPath($module)
     {
-        $config = $module->get('migrate');
+        $config = $module->get('migration');
 
         $path = (is_array($config) && array_key_exists('path', $config)) ? $config['path'] : config('modules.paths.generator.migration');
 

--- a/src/Commands/SeedCommand.php
+++ b/src/Commands/SeedCommand.php
@@ -54,7 +54,7 @@ class SeedCommand extends Command
 
         foreach ($this->module->getOrdered() as $module) {
             $name = $module->getName();
-            $config = $module->get('migrate');
+            $config = $module->get('migration');
             if(is_array($config) && array_key_exists('seeds', $config)) {
                 foreach((array)$config['seeds'] as $class) {
                     if (class_exists($class)) {

--- a/src/Commands/SeedCommand.php
+++ b/src/Commands/SeedCommand.php
@@ -54,12 +54,21 @@ class SeedCommand extends Command
 
         foreach ($this->module->getOrdered() as $module) {
             $name = $module->getName();
-
-            if (class_exists($this->getSeederName($name))) {
-                $this->dbseed($name);
-
-                $this->info("Module [$name] seeded.");
+            $config = $module->get('migrate');
+            if(is_array($config) && array_key_exists('seeds', $config)) {
+                foreach((array)$config['seeds'] as $class) {
+                    if (class_exists($class)) {
+                        $this->dbseed($class);
+                    } else {
+                        return $this->error("Class [$class] does not exist");
+                    }
+                }
+            } else {
+                if (class_exists($this->getSeederName($name))) {
+                    $this->dbseed($name);
+                }
             }
+            $this->info("Module [$name] seeded.");
         }
 
         return $this->info('All modules seeded.');


### PR DESCRIPTION
I've implemented this change-set in order to further decouple each module from the core application's configuration settings. 

The current behavior of the `module:migrate` command requires that all modules incorporate a uniform directory structure where the location of each module's migration scripts are determined by fetching `config('modules.paths.generator.migration')` then appending it to each module's base path.

This may pose a problem when multiple vendors who are utilizing different configuration settings try to share modules of code.

The solution I'm proposing involves adding support for an optional `migration.path` setting to the module.json files which will override the default behavior which was described above.

```
{
    migration: {
        path: "src/database/migrations" 
    }
}
```
--------------------

Update: 

I've also just added support for an additional seeds parameter:

```
{
    migration: {
        seeds: [className, ...]
    }
}
```

This setting should serve as an explicit override for the (current) default behavior of `module:seed`:
```
public function getSeederName($name)
    {
        $name = Str::studly($name);

        $namespace = $this->laravel['modules']->config('namespace');

        return $namespace . '\\' . $name . '\Database\Seeders\\' . $name . 'DatabaseSeeder';
    }
```
As you can see this command works a little bit differently from `module:migrate`.  

The name of each module is passed through an `Str::studly` method and then appended to the `modules.namespace` app configuration setting.  

The `Database\Seeders` segment of the namespace is hardcoded which is also less than ideal hence the optional override.  