### PR TITLE
Fixed a number of bugs in the module:migrate + module:seed commands

### DIFF
--- a/src/Commands/MigrateCommand.php
+++ b/src/Commands/MigrateCommand.php
@@ -3,6 +3,7 @@
 namespace Nwidart\Modules\Commands;
 
 use Illuminate\Console\Command;
+use Nwidart\Modules\Module;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -39,7 +40,8 @@ class MigrateCommand extends Command
         $name = $this->argument('module');
 
         if ($name) {
-            return $this->migrate($name);
+            $module = $this->module->findOrFail($name);
+            return $this->migrate($module);
         }
 
         foreach ($this->module->getOrdered($this->option('direction')) as $module) {
@@ -52,14 +54,12 @@ class MigrateCommand extends Command
     /**
      * Run the migration from the specified module.
      *
-     * @param string $name
+     * @param Module $module
      *
      * @return mixed
      */
-    protected function migrate($name)
+    protected function migrate(Module $module)
     {
-        $module = $this->module->findOrFail($name);
-
         $this->call('migrate', [
             '--path' => $this->getPath($module),
             '--database' => $this->option('database'),
@@ -68,7 +68,7 @@ class MigrateCommand extends Command
         ]);
 
         if ($this->option('seed')) {
-            $this->call('module:seed', ['module' => $name]);
+            $this->call('module:seed', ['module' => $module->getName()]);
         }
     }
 

--- a/src/Commands/MigrateCommand.php
+++ b/src/Commands/MigrateCommand.php
@@ -3,6 +3,7 @@
 namespace Nwidart\Modules\Commands;
 
 use Illuminate\Console\Command;
+use Nwidart\Modules\Migrations\Migrator;
 use Nwidart\Modules\Module;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -60,8 +61,9 @@ class MigrateCommand extends Command
      */
     protected function migrate(Module $module)
     {
+        $path = str_replace(base_path(), '', (new Migrator($module))->getPath());
         $this->call('migrate', [
-            '--path' => $this->getPath($module),
+            '--path' => $path,
             '--database' => $this->option('database'),
             '--pretend' => $this->option('pretend'),
             '--force' => $this->option('force'),
@@ -70,23 +72,6 @@ class MigrateCommand extends Command
         if ($this->option('seed')) {
             $this->call('module:seed', ['module' => $module->getName()]);
         }
-    }
-
-    /**
-     * Get migration path for specific module.
-     *
-     * @param  \Nwidart\Modules\Module $module
-     * @return string
-     */
-    protected function getPath($module)
-    {
-        $config = $module->get('migration');
-
-        $path = (is_array($config) && array_key_exists('path', $config)) ? $config['path'] : config('modules.paths.generator.migration');
-
-        $path = $module->getExtraPath($path);
-
-        return str_replace(base_path(), '', $path);
     }
 
     /**

--- a/src/Commands/PublishMigrationCommand.php
+++ b/src/Commands/PublishMigrationCommand.php
@@ -3,6 +3,7 @@
 namespace Nwidart\Modules\Commands;
 
 use Illuminate\Console\Command;
+use Nwidart\Modules\Migrations\Migrator;
 use Nwidart\Modules\Publishing\MigrationPublisher;
 use Symfony\Component\Console\Input\InputArgument;
 
@@ -49,7 +50,7 @@ class PublishMigrationCommand extends Command
      */
     public function publish($module)
     {
-        with(new MigrationPublisher($module))
+        with(new MigrationPublisher(new Migrator($module)))
             ->setRepository($this->laravel['modules'])
             ->setConsole($this)
             ->publish();

--- a/src/Commands/SeedCommand.php
+++ b/src/Commands/SeedCommand.php
@@ -85,8 +85,6 @@ class SeedCommand extends Command
      * @param Module $module
      *
      * @return void
-     *
-     * @throws RuntimeException
      */
     public function moduleSeed(Module $module)
     {

--- a/src/Commands/SeedCommand.php
+++ b/src/Commands/SeedCommand.php
@@ -113,7 +113,7 @@ class SeedCommand extends Command
     /**
      * Seed the specified module.
      *
-     * @parama string  $className
+     * @param string $className
      *
      * @return array
      */

--- a/src/Migrations/Migrator.php
+++ b/src/Migrations/Migrator.php
@@ -38,9 +38,11 @@ class Migrator
      */
     public function getPath()
     {
-        return $this->module->getExtraPath(
-            config('modules.paths.generator.migration')
-        );
+        $config = $this->module->get('migration');
+
+        $path = (is_array($config) && array_key_exists('path', $config)) ? $config['path'] : config('modules.paths.generator.migration');
+
+        return $this->module->getExtraPath($path);
     }
 
     /**
@@ -177,7 +179,6 @@ class Migrator
     public function requireFiles(array $files)
     {
         $path = $this->getPath();
-
         foreach ($files as $file) {
             $this->laravel['files']->requireOnce($path . '/' . $file . '.php');
         }
@@ -254,8 +255,7 @@ class Migrator
     {
         $query = $this->table()
             ->where('batch', $this->getLastBatchNumber($migrations))
-            ->whereIn('migration', $migrations)
-            ;
+            ->whereIn('migration', $migrations);
 
         $result = $query->orderBy('migration', 'desc')->get();
 

--- a/src/Migrations/Migrator.php
+++ b/src/Migrations/Migrator.php
@@ -32,6 +32,14 @@ class Migrator
     }
 
     /**
+     * @return Module
+     */
+    public function getModule()
+    {
+        return $this->module;
+    }
+
+    /**
      * Get migration path.
      *
      * @return string

--- a/src/Publishing/MigrationPublisher.php
+++ b/src/Publishing/MigrationPublisher.php
@@ -2,8 +2,25 @@
 
 namespace Nwidart\Modules\Publishing;
 
+use Nwidart\Modules\Migrations\Migrator;
+
 class MigrationPublisher extends AssetPublisher
 {
+    /**
+     * @var Migrator
+     */
+    private $migrator;
+
+    /**
+     * MigrationPublisher constructor.
+     * @param Migrator $migrator
+     */
+    public function __construct(Migrator $migrator)
+    {
+        $this->migrator = $migrator;
+        parent::__construct($migrator->getModule());
+    }
+
     /**
      * Get destination path.
      *
@@ -21,6 +38,6 @@ class MigrationPublisher extends AssetPublisher
      */
     public function getSourcePath()
     {
-        return $this->getModule()->getExtraPath($this->repository->config('paths.generator.migration'));
+        return $this->migrator->getPath();
     }
 }


### PR DESCRIPTION
Refactored the "module:seed" command logic in order to reduce code duplication.

Fixed an existing bug which would cause the "module:migrate" command to throw an offset warning if the --seed option is specified.  

Fixed a newly introduced bug(my bad) where the SeedCommand:dbseed() method would append the base module namespace to the FQN of a seeder class.  This would only occur if the user had provided an explicit classname using the optional "migration.seeds" argument.  

Removed the "class option" from "module:seed" since it should logically only be set from within the dbSeed($class) method which in turn issues each of these calls directly to the "db:seed" command.  

Removed the "all option" from "module:seed" since it actually wasn't being used for anything. 
ie: The existing behavior for this command is to seed all modules if the module argument is not specified.

Removed the MigrateCommand:getPath() method in favor of (Migrator($module))->getPath() which has been updated to account for the additional logic.

Note: Since the Laravel "migrate" command requires a path which is relative to the base_root() module:migrate will still executing a string replacement on the result.

--------------

Update: 

In order to further reduce code duplication I made some more changes to the MigrationPublisher class which will now accept Migrator as a class dependency.

Calls to the MigrationPublisher:getSourcePath() method should be delegated to the Migrator:getPath().

Note:  It doesn't look like this class even needs to extend the AssetPublisher.  It could probably just extend Publisher but I decided to leave it as is for now.  