### PR TITLE
Improve config publishing

### DIFF
--- a/src/Commands/PublishConfigurationCommand.php
+++ b/src/Commands/PublishConfigurationCommand.php
@@ -2,6 +2,7 @@
 
 namespace Nwidart\Modules\Commands;
 
+use Module;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -42,25 +43,17 @@ class PublishConfigurationCommand extends Command
 
     /**
      * @param string $module
-     * @return string
-     */
-    private function getServiceProviderForModule($module)
-    {
-        $studlyName = studly_case($module);
-
-        return "Modules\\$studlyName\\Providers\\{$studlyName}ServiceProvider";
-    }
-
-    /**
-     * @param string $module
      */
     private function publishConfiguration($module)
     {
-        $this->call('vendor:publish', [
-            '--provider' => $this->getServiceProviderForModule($module),
-            '--force' => $this->option('force'),
-            '--tag' => ['config'],
-        ]);
+        foreach(Module::get('core')->get('providers') as $provider) {
+			$this->call('vendor:publish',
+						[
+							'--provider' => $provider,
+							'--force' => $this->option('force'),
+							'--tag' => ['config'],
+						]);
+		}
     }
 
     /**

--- a/src/Commands/PublishConfigurationCommand.php
+++ b/src/Commands/PublishConfigurationCommand.php
@@ -46,7 +46,7 @@ class PublishConfigurationCommand extends Command
      */
     private function publishConfiguration($module)
     {
-        foreach(Module::get('core')->get('providers') as $provider) {
+        foreach(Module::get($module)->get('providers') as $provider) {
 			$this->call('vendor:publish',
 						[
 							'--provider' => $provider,

--- a/src/Commands/stubs/scaffold/provider.stub
+++ b/src/Commands/stubs/scaffold/provider.stub
@@ -44,7 +44,7 @@ class $CLASS$ extends ServiceProvider
     {
         $this->publishes([
             __DIR__.'/../$PATH_CONFIG$/config.php' => config_path('$LOWER_NAME$.php'),
-        ]);
+        ], 'config');
         $this->mergeConfigFrom(
             __DIR__.'/../$PATH_CONFIG$/config.php', '$LOWER_NAME$'
         );


### PR DESCRIPTION
I had some issues publishing configs from a module using `php artisan module:publish-config` since i was using a custom namespace, i.e. not "Modules\...".
Additionally the service provider stub that is generated does not tag config files correctly for this command.
