### PR TITLE
fix bug: module:migrate-reset and module:migrate-rollback don't use t…

### DIFF
--- a/src/Commands/MigrateResetCommand.php
+++ b/src/Commands/MigrateResetCommand.php
@@ -61,6 +61,12 @@ class MigrateResetCommand extends Command
 
         $migrator = new Migrator($module);
 
+        $database = $this->option('database');
+
+        if (!empty($database)) {
+            $migrator->setDatabase($database);
+        }
+
         $migrated = $migrator->reset();
 
         if (count($migrated)) {

--- a/src/Commands/MigrateRollbackCommand.php
+++ b/src/Commands/MigrateRollbackCommand.php
@@ -61,6 +61,12 @@ class MigrateRollbackCommand extends Command
 
         $migrator = new Migrator($module);
 
+        $database = $this->option('database');
+
+        if (!empty($database)) {
+            $migrator->setDatabase($database);
+        }
+
         $migrated = $migrator->rollback();
 
         if (count($migrated)) {

--- a/src/Migrations/Migrator.php
+++ b/src/Migrations/Migrator.php
@@ -22,6 +22,13 @@ class Migrator
     protected $laravel;
 
     /**
+     * The database connection to be used
+     *
+     * @var string
+     */
+    protected $database = '';
+
+    /**
      * Create new instance.
      *
      * @param \Nwidart\Modules\Module $module
@@ -30,6 +37,20 @@ class Migrator
     {
         $this->module = $module;
         $this->laravel = $module->getLaravel();
+    }
+
+    /**
+     * Set the database connection to be used
+     *
+     * @param $database
+     *
+     * @return $this
+     */
+    public function setDatabase($database)
+    {
+        if (is_string($database) && $database) {
+            $this->database = $database;
+        }
     }
 
     /**
@@ -200,7 +221,7 @@ class Migrator
      */
     public function table()
     {
-        return $this->laravel['db']->table(config('database.migrations'));
+        return $this->database ? $this->laravel['db']->connection($this->database)->table(config('database.migrations')) : $this->laravel['db']->table(config('database.migrations'));
     }
 
     /**


### PR DESCRIPTION
hi there,
i look carefully into the code and i found:
1. this problem only locates in  migrate-reset and migrate-rollback command
2. laravel itself provide db connection choose function
so i fix this bug by:
1. add a property(and a set method) in the Migrator class
2. use the connection in the table() function
3. set the connection in the two command's relate function
hope this will work!