### PR TITLE
Fixed Module::asset();

### DIFF
--- a/src/Repository.php
+++ b/src/Repository.php
@@ -480,7 +480,7 @@ class Repository implements RepositoryInterface, Countable
     {
         list($name, $url) = explode(':', $asset);
 
-        $baseUrl = str_replace(public_path(), '', $this->getAssetsPath());
+        $baseUrl = str_replace(public_path() . DIRECTORY_SEPARATOR, '', $this->getAssetsPath());
 
         $url = $this->app['url']->asset($baseUrl . "/{$name}/" . $url);
 


### PR DESCRIPTION
Remove a frist slash.

Before fixed:

```
Module::asset('system:css/app.css');
// http://localhost:8000/\modules/system/css/app.css
```

After fixed:

```
Module::asset('system:css/app.css');
// http://localhost:8000/modules/system/css/app.css
```