### PR TITLE
Respect module order in reverse migrations

### DIFF
--- a/src/Commands/MigrateResetCommand.php
+++ b/src/Commands/MigrateResetCommand.php
@@ -27,21 +27,28 @@ class MigrateResetCommand extends Command
     protected $description = 'Reset the modules migrations.';
 
     /**
+     * @var \Nwidart\Modules\Repository
+     */
+    protected $module;
+
+    /**
      * Execute the console command.
      *
      * @return mixed
      */
     public function fire()
     {
-        $module = $this->argument('module');
+        $this->module = $this->laravel['modules'];
 
-        if (!empty($module)) {
-            $this->reset($module);
+        $name = $this->argument('module');
+
+        if (!empty($name)) {
+            $this->reset($name);
 
             return;
         }
 
-        foreach (array_reverse($this->laravel['modules']->all()) as $module) {
+        foreach ($this->module->getOrdered($this->option('direction')) as $module) {
             $this->line('Running for module: <info>' . $module->getName() . '</info>');
 
             $this->reset($module);
@@ -56,7 +63,7 @@ class MigrateResetCommand extends Command
     public function reset($module)
     {
         if (is_string($module)) {
-            $module = $this->laravel['modules']->findOrFail($module);
+            $module = $this->module->findOrFail($module);
         }
 
         $migrator = new Migrator($module);
@@ -100,6 +107,7 @@ class MigrateResetCommand extends Command
     protected function getOptions()
     {
         return array(
+            array('direction', 'd', InputOption::VALUE_OPTIONAL, 'The direction of ordering.', 'desc'),
             array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
             array('force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'),
             array('pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'),

--- a/src/Commands/MigrateRollbackCommand.php
+++ b/src/Commands/MigrateRollbackCommand.php
@@ -27,21 +27,28 @@ class MigrateRollbackCommand extends Command
     protected $description = 'Rollback the modules migrations.';
 
     /**
+     * @var \Nwidart\Modules\Repository
+     */
+    protected $module;
+
+    /**
      * Execute the console command.
      *
      * @return mixed
      */
     public function fire()
     {
-        $module = $this->argument('module');
+        $this->module = $this->laravel['modules'];
 
-        if (!empty($module)) {
-            $this->rollback($module);
+        $name = $this->argument('module');
+
+        if (!empty($name)) {
+            $this->rollback($name);
 
             return;
         }
 
-        foreach (array_reverse($this->laravel['modules']->all()) as $module) {
+        foreach ($this->module->getOrdered($this->option('direction')) as $module) {
             $this->line('Running for module: <info>' . $module->getName() . '</info>');
 
             $this->rollback($module);
@@ -56,7 +63,7 @@ class MigrateRollbackCommand extends Command
     public function rollback($module)
     {
         if (is_string($module)) {
-            $module = $this->laravel['modules']->findOrFail($module);
+            $module = $this->module->findOrFail($module);
         }
 
         $migrator = new Migrator($module);
@@ -100,6 +107,7 @@ class MigrateRollbackCommand extends Command
     protected function getOptions()
     {
         return array(
+            array('direction', 'd', InputOption::VALUE_OPTIONAL, 'The direction of ordering.', 'desc'),
             array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
             array('force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'),
             array('pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'),


### PR DESCRIPTION
Based on #96, commands like `module:migrate-rollback` and `module:migrate-reset` does not respect order parameter of modules as `module:migrate` does.

Also instead of all modules it will run only on enabled ones.

Added `--direction`/`--d` command to both commands defaulting to `desc` (all enabled modules in reverse order).
