### PR TITLE
Add Macroable trait to module repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,19 @@ Update dependencies for the specified module.
 Module::update('hello');
 ```
 
+Add a macro to the module repository.
+
+```php
+Module::macro('hello', function() {
+    echo "I'm a macro";
+});
+
+Call a macro from the module repository.
+
+```php
+Module::hello();
+```
+
 <a name="entity"></a>
 ## Module Entity
 

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -5,6 +5,7 @@ namespace Nwidart\Modules;
 use Countable;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
 use Nwidart\Modules\Contracts\RepositoryInterface;
 use Nwidart\Modules\Exceptions\ModuleNotFoundException;
 use Nwidart\Modules\Process\Installer;
@@ -12,6 +13,8 @@ use Nwidart\Modules\Process\Updater;
 
 class Repository implements RepositoryInterface, Countable
 {
+    use Macroable;
+
     /**
      * Application instance.
      *

--- a/tests/ModuleFacadeTest.php
+++ b/tests/ModuleFacadeTest.php
@@ -13,4 +13,24 @@ class ModuleFacadeTest extends BaseTestCase
 
         $this->assertTrue(is_array($modules));
     }
+
+    /** @test */
+    public function it_creates_macros_via_facade()
+    {
+        $modules = Module::macro('testMacro', function () {
+            return true;
+        });
+
+        $this->assertTrue(Module::hasMacro('testMacro'));
+    }
+
+    /** @test */
+    public function it_calls_macros_via_facade()
+    {
+        $modules = Module::macro('testMacro', function () {
+            return 'a value';
+        });
+
+        $this->assertEquals('a value', Module::testMacro());
+    }
 }


### PR DESCRIPTION
At my job, we use this library a lot in a very large project, and if there's one thing that would be extremely useful in creating custom functionality that extends your library, it's being able to define custom macros onto the repository.

This PR adds two tests for the Macroable trait, and adds the Macroable trait to the repository.