### PR TITLE
Change default namespace for Mailables to match Laravel default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All Notable changes to `laravel-modules` will be documented in this file.
 - Adding show method on resource controller
 - Added check for cached routes to not load them multiple times
 
+### Changed
+
+- Changed default namespace for Mailables to `Mail` to match Laravel default
+
 ## 1.15.0 - 2017-01-12
 
 ### Added

--- a/config/config.php
+++ b/config/config.php
@@ -111,7 +111,7 @@ return [
             'views' => 'Resources/views',
             'test' => 'Tests',
             'jobs' => 'Jobs',
-            'emails' => 'Emails',
+            'mail' => 'Mail',
             'notifications' => 'Notifications',
         ],
     ],

--- a/src/Commands/GenerateMailCommand.php
+++ b/src/Commands/GenerateMailCommand.php
@@ -63,7 +63,7 @@ class GenerateMailCommand extends GeneratorCommand
     {
         $path = $this->laravel['modules']->getModulePath($this->getModuleName());
 
-        $mailPath = $this->laravel['modules']->config('paths.generator.emails', 'Emails');
+        $mailPath = $this->getDefaultNamespace();
 
         return $path . $mailPath . '/' . $this->getFileName() . '.php';
     }
@@ -81,6 +81,6 @@ class GenerateMailCommand extends GeneratorCommand
      */
     public function getDefaultNamespace()
     {
-        return $this->laravel['modules']->config('paths.generator.emails', 'Emails');
+        return $this->laravel['modules']->config('paths.generator.mail', 'Mail');
     }
 }

--- a/tests/Commands/GenerateMailCommandTest.php
+++ b/tests/Commands/GenerateMailCommandTest.php
@@ -34,7 +34,7 @@ class GenerateMailCommandTest extends BaseTestCase
     {
         $this->artisan('module:make-mail', ['name' => 'SomeMail', 'module' => 'Blog']);
 
-        $this->assertTrue(is_file($this->modulePath . '/Emails/SomeMail.php'));
+        $this->assertTrue(is_file($this->modulePath . '/Mail/SomeMail.php'));
     }
 
     /** @test */
@@ -42,7 +42,7 @@ class GenerateMailCommandTest extends BaseTestCase
     {
         $this->artisan('module:make-mail', ['name' => 'SomeMail', 'module' => 'Blog']);
 
-        $file = $this->finder->get($this->modulePath . '/Emails/SomeMail.php');
+        $file = $this->finder->get($this->modulePath . '/Mail/SomeMail.php');
 
         $this->assertEquals($this->expectedContent(), $file);
     }
@@ -52,7 +52,7 @@ class GenerateMailCommandTest extends BaseTestCase
         return <<<TEXT
 <?php
 
-namespace Modules\Blog\Emails;
+namespace Modules\Blog\Mail;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;


### PR DESCRIPTION
I would have sworn they had Mailables in an `Email` directory when they first came out, but maybe I was just projecting...