### PR TITLE
Fixed typo in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,13 +603,13 @@ $module->getExtraPath('Assets');
 Disable the specified module.
 
 ```
-$module->enable();
+$module->disable();
 ```
 
 Enable the specified module.
 
 ```
-$module->disable();
+$module->enable();
 ```
 
 Delete the specified module.


### PR DESCRIPTION
It seems the description and the code for Enabling/Disabling a module was wrong. I believe the correct ones are:
Disable the specified module.
 $module->disable();
  Enable the specified module.
 $module->enable();