### PR TITLE
Change list command to give the name of the module, not the studly cased form

### DIFF
--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -42,7 +42,7 @@ class ListCommand extends Command
 
         foreach ($this->getModules() as $module) {
             $rows[] = [
-                $module->getStudlyName(),
+                $module->getName(),
                 $module->enabled() ? 'Enabled' : 'Disabled',
                 $module->get('order'),
                 $module->getPath(),


### PR DESCRIPTION
From the discussion of https://github.com/nWidart/laravel-modules/issues/160