### PR TITLE
Moved the registering of Modules to register()

### DIFF
--- a/src/LaravelModulesServiceProvider.php
+++ b/src/LaravelModulesServiceProvider.php
@@ -23,8 +23,6 @@ class LaravelModulesServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->registerNamespaces();
-
-        $this->registerModules();
     }
 
     /**
@@ -43,6 +41,7 @@ class LaravelModulesServiceProvider extends ServiceProvider
         $this->registerServices();
         $this->setupStubPath();
         $this->registerProviders();
+        $this->registerModules();
     }
 
     /**


### PR DESCRIPTION
For your consideration:

Module service providers should be allows to register binding via register() at the same time as all over service providers. This doesn't change the timing of the boot() functionality.

The use case I ran into on this is the registering order of the bindings, I have service providers for different traffic sources (base on the url being used to access the site) These service providers need to be able to register bindings last in order to override the defaults. So that ABC.com binds Products to ABCProducts for that sites product behavior differences. With modules not binding until the boot phase, it makes modules always override any other service providers register() method.