### PR TITLE
added 5.5.* to required list of Laravel versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   ],
   "require": {
     "php": ">=5.5",
-    "laravel/framework": "5.1.*|5.2.*|5.3.*|5.4.*"
+    "laravel/framework": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.7",


### PR DESCRIPTION
Tried using this with `5.5-*` and found it wouldn't install. Added `5.5.*` to the required versions list and everything worked fine with using my forked branch as the Composer repository / source.