### PR TITLE
Take first from providers and reuse it

### DIFF
--- a/src/Commands/PublishConfigurationCommand.php
+++ b/src/Commands/PublishConfigurationCommand.php
@@ -44,10 +44,9 @@ class PublishConfigurationCommand extends Command
      */
     private function getServiceProviderForModule($module)
     {
-        foreach ($this->laravel['modules']->enabled() as $moduleObject) {
-            if ($module == $moduleObject->getName() && count($moduleObject->providers) == 1) {
-                return $moduleObject->providers[0];
-            }
+        $concreteModule = $this->laravel['modules']->find($module);
+        if ($concreteModule && count($concreteModule->providers) == 1) {
+            return $concreteModule->providers[0];
         }
         $namespace = $this->laravel['config']->get('modules.namespace');
         $studlyName = studly_case($module);

--- a/src/Commands/PublishConfigurationCommand.php
+++ b/src/Commands/PublishConfigurationCommand.php
@@ -44,6 +44,11 @@ class PublishConfigurationCommand extends Command
      */
     private function getServiceProviderForModule($module)
     {
+        foreach ($this->laravel['modules']->enabled() as $moduleObject) {
+            if ($module == $moduleObject->getName() && count($moduleObject->providers) == 1) {
+                return $moduleObject->providers[0];
+            }
+        }
         $namespace = $this->laravel['config']->get('modules.namespace');
         $studlyName = studly_case($module);
 

--- a/tests/Commands/PublishConfigurationCommandTest.php
+++ b/tests/Commands/PublishConfigurationCommandTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Nwidart\Modules\Tests\Commands;
+
+use Illuminate\Foundation\Console\VendorPublishCommand;
+use Nwidart\Modules\Repository;
+use Nwidart\Modules\Tests\BaseTestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class PublishConfigurationCommandTest
+ * @package Nwidart\Modules\Tests\Commands
+ */
+class PublishConfigurationCommandTest extends BaseTestCase
+{
+    /** @test */
+    public function module_having_one_service_provider_will_publish_it()
+    {
+        $mock = $this->createMock(Repository::class);
+        $module = new \stdClass();
+        $serviceProvider = 'Vendor1/PackageNamespace/ServiceProvider';
+        $module->providers = [
+            $serviceProvider,
+        ];
+
+        $mock->expects($this->once())
+            ->method('find')
+            ->willReturn($module);
+
+        $this->app->instance('modules', $mock);
+
+        $arguments = [
+            '--provider' => $serviceProvider,
+            '--force' => false,
+            '--tag' => [
+                'config',
+            ],
+            'command' => 'vendor:publish',
+        ];
+
+        $this->mockLaravelPublish($arguments);
+
+        $this->artisan('module:publish-config', ['module' => 'Blog']);
+    }
+
+    /** @test */
+    public function module_having_two_service_providers_will_publish_default_service_provider_from_module_name()
+    {
+        $mock = $this->createMock(Repository::class);
+        $module = new \stdClass();
+        $module->providers = [
+            'Vendor1/PackageNamespace/ServiceProvider',
+            'Vendor2/PackageNamespace/ServiceProvider',
+        ];
+
+        $mock->expects($this->once())
+            ->method('find')
+            ->willReturn($module);
+
+        $this->app->instance('modules', $mock);
+
+        $moduleName = 'Blog';
+        $arguments = [
+            '--provider' => 'Modules\\' . $moduleName . '\Providers\\' . $moduleName . 'ServiceProvider',
+            '--force' => false,
+            '--tag' => [
+                'config',
+            ],
+            'command' => 'vendor:publish',
+        ];
+
+        $this->mockLaravelPublish($arguments);
+
+        $this->artisan('module:publish-config', ['module' => $moduleName]);
+    }
+
+    /**
+     * @param array $arguments
+     * @throws \PHPUnit_Framework_Exception
+     * @throws \PHPUnit_Framework_MockObject_RuntimeException
+     */
+    private function mockLaravelPublish(array $arguments)
+    {
+        $command = $this->createMock(VendorPublishCommand::class);
+
+        $command->expects($this->once())
+            ->method('isEnabled')
+            ->will($this->returnValue(true));
+        $command->expects($this->once())
+            ->method('getName')
+            ->will($this->returnValue('vendor:publish'));
+        $command->expects($this->once())
+            ->method('getDefinition')
+            ->will($this->returnValue(!null));
+        $command->expects($this->once())
+            ->method('getAliases')
+            ->will($this->returnValue([]));
+
+        $command->expects($this->once())
+            ->method('run')
+            ->with(
+                new ArrayInput($arguments),
+                $this->isInstanceOf(OutputInterface::class)
+            );
+
+        $this->app->instance('command.vendor.publish', $command);
+    }
+}

--- a/tests/Commands/PublishConfigurationCommandTest.php
+++ b/tests/Commands/PublishConfigurationCommandTest.php
@@ -95,7 +95,7 @@ class PublishConfigurationCommandTest extends BaseTestCase
                 '--provider' => $serviceProvider1,
             ];
         $inputArgument2 = $this->getInputArgumentBase() + [
-                '--provider' => $serviceProvider1,
+                '--provider' => $serviceProvider2,
             ];
 
         $this->mockLaravelPublish([$inputArgument1, $inputArgument2]);

--- a/tests/Commands/PublishConfigurationCommandTest.php
+++ b/tests/Commands/PublishConfigurationCommandTest.php
@@ -30,16 +30,11 @@ class PublishConfigurationCommandTest extends BaseTestCase
 
         $this->app->instance('modules', $mock);
 
-        $arguments = [
-            '--provider' => $serviceProvider,
-            '--force' => false,
-            '--tag' => [
-                'config',
-            ],
-            'command' => 'vendor:publish',
-        ];
+        $inputArgument = $this->getInputArgumentBase() + [
+                '--provider' => $serviceProvider,
+            ];
 
-        $this->mockLaravelPublish([$arguments]);
+        $this->mockLaravelPublish([$inputArgument]);
 
         $this->artisan('module:publish-config', ['module' => 'Blog']);
     }
@@ -61,16 +56,11 @@ class PublishConfigurationCommandTest extends BaseTestCase
         $this->app->instance('modules', $mock);
 
         $moduleName = 'Blog';
-        $arguments = [
-            '--provider' => 'Modules\\' . $moduleName . '\Providers\\' . $moduleName . 'ServiceProvider',
-            '--force' => false,
-            '--tag' => [
-                'config',
-            ],
-            'command' => 'vendor:publish',
-        ];
+        $inputArgument = $this->getInputArgumentBase() + [
+                '--provider' => 'Modules\\' . $moduleName . '\Providers\\' . $moduleName . 'ServiceProvider',
+            ];
 
-        $this->mockLaravelPublish([$arguments]);
+        $this->mockLaravelPublish([$inputArgument]);
 
         $this->artisan('module:publish-config', ['module' => $moduleName]);
     }
@@ -101,32 +91,25 @@ class PublishConfigurationCommandTest extends BaseTestCase
 
         $this->app->instance('modules', $mock);
 
-        $argumentsBase = [
-            '--force' => false,
-            '--tag' => [
-                'config',
-            ],
-            'command' => 'vendor:publish',
-        ];
-        $arguments1 = $argumentsBase + [
+        $inputArgument1 = $this->getInputArgumentBase() + [
                 '--provider' => $serviceProvider1,
             ];
-        $arguments2 = $argumentsBase + [
+        $inputArgument2 = $this->getInputArgumentBase() + [
                 '--provider' => $serviceProvider1,
             ];
 
-        $this->mockLaravelPublish([$arguments1, $arguments2]);
+        $this->mockLaravelPublish([$inputArgument1, $inputArgument2]);
 
         $this->artisan('module:publish-config');
     }
 
     /**
-     * @param array $arguments
+     * @param array $inputArguments
      * @throws \InvalidArgumentException
      * @throws \PHPUnit_Framework_Exception
      * @throws \PHPUnit_Framework_MockObject_RuntimeException
      */
-    private function mockLaravelPublish(array $arguments)
+    private function mockLaravelPublish(array $inputArguments)
     {
         $command = $this->createMock(VendorPublishCommand::class);
 
@@ -143,17 +126,17 @@ class PublishConfigurationCommandTest extends BaseTestCase
             ->method('getAliases')
             ->will($this->returnValue([]));
 
-        $values = [];
-        foreach ($arguments as $argument) {
-            $values[] = [
-                new ArrayInput($argument),
+        $consecutiveValues = [];
+        foreach ($inputArguments as $inputArgument) {
+            $consecutiveValues[] = [
+                new ArrayInput($inputArgument),
                 $this->isInstanceOf(OutputInterface::class),
             ];
         }
-        $command->expects($this->exactly(count($arguments)))
+        $command->expects($this->exactly(count($inputArguments)))
             ->method('run')
             ->withConsecutive(
-                ...$values
+                ...$consecutiveValues
             );
         $this->app->extend('command.vendor.publish', function() use ($command) {
             return $command;
@@ -172,13 +155,25 @@ class PublishConfigurationCommandTest extends BaseTestCase
     {
         $mockBuilder = $this->getMockBuilder('TestModule')
             ->setMethods(['getName']);
-        $PHPUnitFrameworkMockObjectMockBuilder = $mockBuilder
-            ->getMock();
-        $module1 = $PHPUnitFrameworkMockObjectMockBuilder;
-        $module1->method('getName')
+        $module = $mockBuilder->getMock();
+        $module->method('getName')
             ->willReturn($name);
-        $module1->providers = $providers;
+        $module->providers = $providers;
 
-        return $module1;
+        return $module;
+    }
+
+    /**
+     * @return array
+     */
+    private function getInputArgumentBase()
+    {
+        return [
+            '--force' => false,
+            '--tag' => [
+                'config',
+            ],
+            'command' => 'vendor:publish',
+        ];
     }
 }


### PR DESCRIPTION
Take first from providers and reuse it, instead of generating misleading paths when having multiple namespaced vendors

fixing https://github.com/nWidart/laravel-modules/issues/202