### PR TITLE
Revise json cache

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -26,7 +26,7 @@ class Collection extends BaseCollection
     {
         return array_map(function ($value) {
             if ($value instanceof Module) {
-                return $value->moduleJson->getAttributes();
+                return $value->json()->getAttributes();
             }
 
             return $value instanceof Arrayable ? $value->toArray() : $value;

--- a/tests/ModuleTest.php
+++ b/tests/ModuleTest.php
@@ -71,7 +71,7 @@ class ModuleTest extends BaseTestCase
     /** @test */
     public function it_reads_module_json_files()
     {
-        $jsonModule = $this->module->moduleJson;
+        $jsonModule = $this->module->json();
         $composerJson = $this->module->json('composer.json');
 
         $this->assertInstanceOf(Json::class, $jsonModule);


### PR DESCRIPTION
The project I work on has various instances of the codebase, with modules enabled and disabled according to client needs. To avoid conflicts, we do not have the module.json checked into the project repo, but rather manage those files through some custom logic in Laravel. The changes introduced in 1.25 force modules to have a valid json file when they are initialized, which means that there is never a chance for Laravel to act on any undeployed module configs, since the missing files trigger a File Missing exception.

This PR solves this problem by moving the json requirement back into `json()`, and additionally improves performance by also caching any other files requested. 