### PR TITLE
Lumen support

### DIFF
--- a/src/LaravelModulesServiceProvider.php
+++ b/src/LaravelModulesServiceProvider.php
@@ -2,37 +2,17 @@
 
 namespace Nwidart\Modules;
 
-use Illuminate\Support\ServiceProvider;
-use Nwidart\Modules\Providers\BootstrapServiceProvider;
-use Nwidart\Modules\Providers\ConsoleServiceProvider;
-use Nwidart\Modules\Providers\ContractsServiceProvider;
 use Nwidart\Modules\Support\Stub;
 
-class LaravelModulesServiceProvider extends ServiceProvider
+class LaravelModulesServiceProvider extends ModulesServiceProvider
 {
-    /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
-     */
-    protected $defer = false;
-
     /**
      * Booting the package.
      */
     public function boot()
     {
         $this->registerNamespaces();
-
         $this->registerModules();
-    }
-
-    /**
-     * Register all modules.
-     */
-    protected function registerModules()
-    {
-        $this->app->register(BootstrapServiceProvider::class);
     }
 
     /**
@@ -50,55 +30,12 @@ class LaravelModulesServiceProvider extends ServiceProvider
      */
     public function setupStubPath()
     {
-        $this->app->booted(function ($app) {
-            Stub::setBasePath(__DIR__ . '/Commands/stubs');
+        Stub::setBasePath(__DIR__ . '/Commands/stubs');
 
+        $this->app->booted(function ($app) {
             if ($app['modules']->config('stubs.enabled') === true) {
                 Stub::setBasePath($app['modules']->config('stubs.path'));
             }
         });
-    }
-
-    /**
-     * Register package's namespaces.
-     */
-    protected function registerNamespaces()
-    {
-        $configPath = __DIR__ . '/../config/config.php';
-        $this->mergeConfigFrom($configPath, 'modules');
-        $this->publishes([
-            $configPath => config_path('modules.php'),
-        ], 'config');
-    }
-
-    /**
-     * Register the service provider.
-     */
-    protected function registerServices()
-    {
-        $this->app->singleton('modules', function ($app) {
-            $path = $app['config']->get('modules.paths.modules');
-
-            return new Repository($app, $path);
-        });
-    }
-
-    /**
-     * Get the services provided by the provider.
-     *
-     * @return array
-     */
-    public function provides()
-    {
-        return ['modules'];
-    }
-
-    /**
-     * Register providers.
-     */
-    protected function registerProviders()
-    {
-        $this->app->register(ConsoleServiceProvider::class);
-        $this->app->register(ContractsServiceProvider::class);
     }
 }

--- a/src/LumenModulesServiceProvider.php
+++ b/src/LumenModulesServiceProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Nwidart\Modules;
+
+use Nwidart\Modules\Support\Stub;
+
+class LumenModulesServiceProvider extends ModulesServiceProvider
+{
+    /**
+     * Booting the package.
+     */
+    public function boot()
+    {
+        $this->setupStubPath();
+    }
+
+    /**
+     * Register all modules.
+     */
+    public function register()
+    {
+        $this->registerNamespaces();
+        $this->registerServices();
+        $this->registerModules();
+        $this->registerProviders();
+    }
+
+    /**
+     * Setup stub path.
+     */
+    public function setupStubPath()
+    {
+        Stub::setBasePath(__DIR__ . '/Commands/stubs');
+
+        if (app('modules')->config('stubs.enabled') === true) {
+            Stub::setBasePath(app('modules')->config('stubs.path'));
+        }
+    }
+}

--- a/src/Module.php
+++ b/src/Module.php
@@ -2,8 +2,8 @@
 
 namespace Nwidart\Modules;
 
+use Illuminate\Container\Container;
 use Illuminate\Foundation\AliasLoader;
-use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
@@ -13,9 +13,9 @@ class Module extends ServiceProvider
     use Macroable;
 
     /**
-     * The laravel application instance.
+     * The laravel|lumen application instance.
      *
-     * @var Application
+     * @var \Illuminate\Foundation\Application|\Laravel\Lumen\Application
      */
     protected $app;
 
@@ -41,11 +41,11 @@ class Module extends ServiceProvider
     /**
      * The constructor.
      *
-     * @param Application $app
+     * @param Container $app
      * @param $name
      * @param $path
      */
-    public function __construct(Application $app, $name, $path)
+    public function __construct(Container $app, $name, $path)
     {
         parent::__construct($app);
         $this->name = $name;
@@ -55,7 +55,7 @@ class Module extends ServiceProvider
     /**
      * Get laravel instance.
      *
-     * @return \Illuminate\Foundation\Application
+     * @return \Illuminate\Foundation\Application|\Laravel\Lumen\Application
      */
     public function getLaravel()
     {

--- a/src/ModulesServiceProvider.php
+++ b/src/ModulesServiceProvider.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Nwidart\Modules;
+
+use Illuminate\Support\ServiceProvider;
+use Nwidart\Modules\Providers\BootstrapServiceProvider;
+use Nwidart\Modules\Providers\ConsoleServiceProvider;
+use Nwidart\Modules\Providers\ContractsServiceProvider;
+
+abstract class ModulesServiceProvider extends ServiceProvider
+{
+    /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = false;
+
+    /**
+     * Booting the package.
+     */
+    public function boot()
+    {
+    }
+
+    /**
+     * Register all modules.
+     */
+    public function register()
+    {
+    }
+
+    /**
+     * Register all modules.
+     */
+    protected function registerModules()
+    {
+        $this->app->register(BootstrapServiceProvider::class);
+    }
+
+    /**
+     * Register package's namespaces.
+     */
+    protected function registerNamespaces()
+    {
+        $configPath = __DIR__ . '/../config/config.php';
+
+        $this->mergeConfigFrom($configPath, 'modules');
+        $this->publishes([
+            $configPath => config_path('modules.php'),
+        ], 'config');
+    }
+
+    /**
+     * Register the service provider.
+     */
+    protected function registerServices()
+    {
+        $this->app->singleton('modules', function ($app) {
+            $path = $app['config']->get('modules.paths.modules');
+
+            return new Repository($app, $path);
+        });
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return ['modules'];
+    }
+
+    /**
+     * Register providers.
+     */
+    protected function registerProviders()
+    {
+        $this->app->register(ConsoleServiceProvider::class);
+        $this->app->register(ContractsServiceProvider::class);
+    }
+}

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -3,7 +3,7 @@
 namespace Nwidart\Modules;
 
 use Countable;
-use Illuminate\Foundation\Application;
+use Illuminate\Container\Container;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Nwidart\Modules\Contracts\RepositoryInterface;
@@ -19,7 +19,7 @@ class Repository implements RepositoryInterface, Countable
     /**
      * Application instance.
      *
-     * @var Application
+     * @var \Illuminate\Foundation\Application|\Laravel\Lumen\Application
      */
     protected $app;
 
@@ -45,10 +45,10 @@ class Repository implements RepositoryInterface, Countable
     /**
      * The constructor.
      *
-     * @param Application $app
+     * @param Container $app
      * @param string|null $path
      */
-    public function __construct(Application $app, $path = null)
+    public function __construct(Container $app, $path = null)
     {
         $this->app = $app;
         $this->path = $path;


### PR DESCRIPTION
Support for Lumen:

- Instead of injecting laravels application refactored to Illuminate\Container\Container that is extentend by both laravels and lumen applications.
- In Lumen case namespaces ( haven't tested on laravel since I left it as it is ) must be loaded before registering module provider since it needs some configuration values. Loading these in boot() method will fail to init provider.
- Requested changes from old PR.