### PR TITLE
adds module name to disable/enable events, further standardizes events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "~5.7",
-    "mockery/mockery": "~0.9",
+    "mockery/mockery": "~0.9.3",
     "orchestra/testbench": "^3.1|^3.2|^3.3|^3.4",
     "phpro/grumphp": "^0.11",
     "friendsofphp/php-cs-fixer": "^2.4"

--- a/src/Module.php
+++ b/src/Module.php
@@ -362,11 +362,11 @@ class Module extends ServiceProvider
      */
     public function disable()
     {
-        $this->app['events']->fire('module.disabling', [$this]);
+        $this->fireEvent('disabling');
 
         $this->setActive(0);
 
-        $this->app['events']->fire('module.disabled', [$this]);
+        $this->fireEvent('disabled');
     }
 
     /**
@@ -374,11 +374,11 @@ class Module extends ServiceProvider
      */
     public function enable()
     {
-        $this->app['events']->fire('module.enabling', [$this]);
+        $this->fireEvent('enabling');
 
         $this->setActive(1);
 
-        $this->app['events']->fire('module.enabled', [$this]);
+        $this->fireEvent('enabled');
     }
 
     /**

--- a/tests/ModuleTest.php
+++ b/tests/ModuleTest.php
@@ -116,4 +116,26 @@ class ModuleTest extends BaseTestCase
         $this->assertFalse($this->module->notActive());
         $this->assertFalse($this->module->disabled());
     }
+
+    /** @test */
+    public function it_fires_events_when_module_is_disabled()
+    {
+        $this->expectsEvents([
+            sprintf('modules.%s.disabling', $this->module->getLowerName()),
+            sprintf('modules.%s.disabled', $this->module->getLowerName()),
+        ]);
+
+        $this->module->disable();
+    }
+
+    /** @test */
+    public function it_fires_events_when_module_is_enabled()
+    {
+        $this->expectsEvents([
+            sprintf('modules.%s.enabling', $this->module->getLowerName()),
+            sprintf('modules.%s.enabled', $this->module->getLowerName()),
+        ]);
+
+        $this->module->enable();
+    }
 }


### PR DESCRIPTION
It would be helpful to be able to hook into a specific event when a module is enabled or disabled. This changes these events to simply call the already existing `fireEvent` which I figured would help standardize the event names.