### PR TITLE
Fix wrong path for registerFactories() in prvoider.stub

### DIFF
--- a/src/Commands/stubs/scaffold/provider.stub
+++ b/src/Commands/stubs/scaffold/provider.stub
@@ -95,7 +95,7 @@ class $CLASS$ extends ServiceProvider
     public function registerFactories()
     {
         if (! app()->environment('production')) {
-            app(Factory::class)->load(__DIR__ . '/Database/factories');
+            app(Factory::class)->load(__DIR__ . '/../Database/factories');
         }
     }
 


### PR DESCRIPTION
Previously, app was search for factories in `Module/Providers/Database/factories` instead of `Module/Database/factories`