### PR TITLE
Fix #338, introduce command for creating factories

### DIFF
--- a/src/Commands/MakeFactoryCommand.php
+++ b/src/Commands/MakeFactoryCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Nwidart\Modules\Commands;
+
+use Illuminate\Support\Str;
+use Nwidart\Modules\Support\Stub;
+use Nwidart\Modules\Traits\ModuleCommandTrait;
+use Symfony\Component\Console\Input\InputArgument;
+
+class MakeFactoryCommand extends GeneratorCommand
+{
+    use ModuleCommandTrait;
+
+    /**
+     * The name of argument name.
+     *
+     * @var string
+     */
+    protected $argumentName = 'name';
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'module:make-factory';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new model factory for the specified module.';
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return array(
+            array('name', InputArgument::REQUIRED, 'The name of the factory.'),
+            array('module', InputArgument::OPTIONAL, 'The name of module will be used.'),
+        );
+    }
+
+    /**
+     * @return mixed
+     */
+    protected function getTemplateContents()
+    {
+        $module = $this->laravel['modules']->findOrFail($this->getModuleName());
+
+        return (new Stub('/factory.stub'))->render();
+    }
+
+    /**
+     * @return mixed
+     */
+    protected function getDestinationFilePath()
+    {
+        $path = $this->laravel['modules']->getModulePath($this->getModuleName());
+
+        // $factoryPath = $this->laravel['modules']->config('paths.generator.factories');
+
+        return $path . 'Database/factories/' . $this->getFileName();
+    }
+
+    /**
+     * @return string
+     */
+    private function getFileName()
+    {
+        return Str::studly($this->argument('name')) . '.php';
+    }
+}

--- a/src/Commands/stubs/factory.stub
+++ b/src/Commands/stubs/factory.stub
@@ -1,0 +1,9 @@
+<?php
+
+use Faker\Generator as Faker;
+
+$factory->define(Model::class, function (Faker $faker) {
+    return [
+        //
+    ];
+});

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -19,6 +19,7 @@ use Nwidart\Modules\Commands\GenerateRouteProviderCommand;
 use Nwidart\Modules\Commands\InstallCommand;
 use Nwidart\Modules\Commands\ListCommand;
 use Nwidart\Modules\Commands\MakeCommand;
+use Nwidart\Modules\Commands\MakeFactoryCommand;
 use Nwidart\Modules\Commands\MakeRequestCommand;
 use Nwidart\Modules\Commands\MigrateCommand;
 use Nwidart\Modules\Commands\MigrateRefreshCommand;
@@ -48,6 +49,7 @@ class ConsoleServiceProvider extends ServiceProvider
      */
     protected $commands = [
         MakeCommand::class,
+        MakeFactoryCommand::class,
         CommandCommand::class,
         ControllerCommand::class,
         DisableCommand::class,

--- a/tests/Commands/MakeFactoryCommandTest.php
+++ b/tests/Commands/MakeFactoryCommandTest.php
@@ -30,21 +30,14 @@ class MakeFactoryCommandTest extends BaseTestCase
     }
 
     /** @test */
-    public function it_generates_a_new_factory_class()
+    public function it_makes_factory()
     {
         $this->artisan('module:make-factory', ['name' => 'PostFactory', 'module' => 'Blog']);
-
-        $this->assertTrue(is_file($this->modulePath . '/Database/factories/PostFactory.php'));
-    }
-
-    /** @test */
-    public function it_generated_correct_file_with_content()
-    {
-        $this->artisan('module:make-factory', ['name' => 'PostFactory', 'module' => 'Blog']);
-
-        $file = $this->finder->get($this->modulePath . '/Database/factories/PostFactory.php');
         
-        $this->assertEquals($this->expectedContent(), $file);
+        $factoryFile = $this->modulePath . '/Database/factories/PostFactory.php';
+
+        $this->assertTrue(is_file($factoryFile), 'Factory file was not created.');   
+        $this->assertEquals($this->expectedContent(), $this->finder->get($factoryFile), 'Content of factory file is not correct.');
     }
 
     private function expectedContent()

--- a/tests/Commands/MakeFactoryCommandTest.php
+++ b/tests/Commands/MakeFactoryCommandTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Nwidart\Modules\Tests\Commands;
+
+use Nwidart\Modules\Tests\BaseTestCase;
+
+class MakeFactoryCommandTest extends BaseTestCase
+{
+    /**
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    private $finder;
+    /**
+     * @var string
+     */
+    private $modulePath;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->modulePath = base_path('modules/Blog');
+        $this->finder = $this->app['files'];
+        $this->artisan('module:make', ['name' => ['Blog']]);
+    }
+
+    public function tearDown()
+    {
+        $this->finder->deleteDirectory($this->modulePath);
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_generates_a_new_factory_class()
+    {
+        $this->artisan('module:make-factory', ['name' => 'PostFactory', 'module' => 'Blog']);
+
+        $this->assertTrue(is_file($this->modulePath . '/Database/factories/PostFactory.php'));
+    }
+
+    /** @test */
+    public function it_generated_correct_file_with_content()
+    {
+        $this->artisan('module:make-factory', ['name' => 'PostFactory', 'module' => 'Blog']);
+
+        $file = $this->finder->get($this->modulePath . '/Database/factories/PostFactory.php');
+        
+        $this->assertEquals($this->expectedContent(), $file);
+    }
+
+    private function expectedContent()
+    {
+        return <<<TEXT
+<?php
+
+use Faker\Generator as Faker;
+
+\$factory->define(Model::class, function (Faker \$faker) {
+    return [
+        //
+    ];
+});
+
+TEXT;
+    }
+}


### PR DESCRIPTION
So far it does not support `--model` argument; just a stub

Path is not configurable since there are already some places ([service provider stub](https://github.com/nWidart/laravel-modules/blob/master/src/Commands/stubs/scaffold/provider.stub#L99)), where `/Database/factories` path is hard-coded, thus possible BC.

---

Made new issue for content that was here.
