### PR TITLE
Clarify installation instructions for Laravel 5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,25 @@ To install through Composer, by run the following command:
 composer require nwidart/laravel-modules
 ```
 
-The package will automatically register a service provider and alias.
+In Laravel 5.5+, this package will automatically register a service provider and alias. If you are running Laravel 5.4, you will need to add them manually by editing your `config/app.php` as follows:
+
+``` php
+'providers' => [
+  Nwidart\Modules\LaravelModulesServiceProvider::class,
+],
+
+'aliases' => [
+  'Module' => Nwidart\Modules\Facades\Module::class,
+],
+```
 
 Optionally, publish the package's configuration file by running:
 
 ``` bash
 php artisan vendor:publish --provider="Nwidart\Modules\LaravelModulesServiceProvider"
 ```
+
+This creates `config/modules.php`, which allows you to customize what files and folders will be generated for each module by default, among [other options](https://nwidart.com/laravel-modules/v2/basic-usage/configuration). 
 
 ### Autoloading
 


### PR DESCRIPTION
I haven't yet gotten around to updating my project to Laravel 5.5, and I haven't been following Laravel news, so I wasn't aware of these developments:

https://laravel-news.com/package-auto-discovery
https://medium.com/@taylorotwell/package-auto-discovery-in-laravel-5-5-ea9e3ab20518

This PR essentially reverses 7a8b50b, while differentiating between Laravel 5.5 and 5.4. I think it's worthwhile to include, since AFACT, it's the only tidbit preventing its compatibility with version `2.0^` of this package. Plus, I think it's still relevant to whomever might be using version `1.0^`. IIRC, during my installation today, I found the solution by stumbling over the legacy pingpong labs repo. Might as well keep it here until Laravel 5.4 is at least one more version out-of-date.

I also added a teaser re: config options to the readme, both due to today's inquiry (#366) and because I first heard about this project via an (outdated) discussion, where one party was critiquing the package for generating too many folders by default. I think people will want to know that functionality is easily tweakable.