### PR TITLE
added views tag to ServiceProvider stub

### DIFF
--- a/src/Commands/stubs/scaffold/provider.stub
+++ b/src/Commands/stubs/scaffold/provider.stub
@@ -66,7 +66,7 @@ class $CLASS$ extends ServiceProvider
 
         $this->publishes([
             $sourcePath => $viewPath
-        ]);
+        ],'views');
 
         $this->loadViewsFrom(array_merge(array_map(function ($path) {
             return $path . '/modules/$LOWER_NAME$';

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_correct_service_provider_content__1.php
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_correct_service_provider_content__1.php
@@ -66,7 +66,7 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->publishes([
             $sourcePath => $viewPath
-        ]);
+        ],\'views\');
 
         $this->loadViewsFrom(array_merge(array_map(function ($path) {
             return $path . \'/modules/blog\';

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_module_namespace_using_studly_case__1.php
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_module_namespace_using_studly_case__1.php
@@ -66,7 +66,7 @@ class ModuleNameServiceProvider extends ServiceProvider
 
         $this->publishes([
             $sourcePath => $viewPath
-        ]);
+        ],\'views\');
 
         $this->loadViewsFrom(array_merge(array_map(function ($path) {
             return $path . \'/modules/modulename\';

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_module_resources__1.php
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_module_resources__1.php
@@ -66,7 +66,7 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->publishes([
             $sourcePath => $viewPath
-        ]);
+        ],\'views\');
 
         $this->loadViewsFrom(array_merge(array_map(function ($path) {
             return $path . \'/modules/blog\';

--- a/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_can_change_the_default_namespace__1.php
+++ b/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_can_change_the_default_namespace__1.php
@@ -66,7 +66,7 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->publishes([
             $sourcePath => $viewPath
-        ]);
+        ],\'views\');
 
         $this->loadViewsFrom(array_merge(array_map(function ($path) {
             return $path . \'/modules/blog\';

--- a/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_can_have_custom_migration_resources_location_paths__1.php
+++ b/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_can_have_custom_migration_resources_location_paths__1.php
@@ -66,7 +66,7 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->publishes([
             $sourcePath => $viewPath
-        ]);
+        ],\'views\');
 
         $this->loadViewsFrom(array_merge(array_map(function ($path) {
             return $path . \'/modules/blog\';

--- a/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_generates_a_master_service_provider_with_resource_loading__1.php
+++ b/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_generates_a_master_service_provider_with_resource_loading__1.php
@@ -66,7 +66,7 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->publishes([
             $sourcePath => $viewPath
-        ]);
+        ],\'views\');
 
         $this->loadViewsFrom(array_merge(array_map(function ($path) {
             return $path . \'/modules/blog\';


### PR DESCRIPTION
for easy calling from artisan like

```
php artisan vendor:publish --provider="YourNamespace\YourServiceProvider" --tag="views"
```