### PR TITLE
added package auto discovery for laravel 5.5

### DIFF
--- a/src/Commands/stubs/composer.stub
+++ b/src/Commands/stubs/composer.stub
@@ -7,6 +7,16 @@
             "email": "$AUTHOR_EMAIL$"
         }
     ],
+    "extra": {
+        "laravel": {
+            "providers": [
+                "$MODULE_NAMESPACE$\\$STUDLY_NAME$\\Providers\\$STUDLY_NAME$ServiceProvider"
+            ],
+            "aliases": {
+                
+            }
+        }
+    },
     "autoload": {
         "psr-4": {
             "$MODULE_NAMESPACE$\\$STUDLY_NAME$\\": ""


### PR DESCRIPTION
left provider on json.stub (module.json) for anybody who prefers running under Modules directory instead of /vendor (composer packages)