### PR TITLE
RouteProvider stub - use boot() instead of before()

### DIFF
--- a/src/Commands/stubs/route-provider.stub
+++ b/src/Commands/stubs/route-provider.stub
@@ -19,10 +19,9 @@ class $CLASS$ extends ServiceProvider
      *
      * Register any model bindings or pattern based filters.
      *
-     * @param  Router $router
      * @return void
      */
-    public function before(Router $router)
+    public function boot()
     {
         //
     }

--- a/tests/Commands/__snapshots__/RouteProviderMakeCommandTest__it_can_change_the_default_namespace__1.php
+++ b/tests/Commands/__snapshots__/RouteProviderMakeCommandTest__it_can_change_the_default_namespace__1.php
@@ -19,10 +19,9 @@ class RouteServiceProvider extends ServiceProvider
      *
      * Register any model bindings or pattern based filters.
      *
-     * @param  Router $router
      * @return void
      */
-    public function before(Router $router)
+    public function boot()
     {
         //
     }

--- a/tests/Commands/__snapshots__/RouteProviderMakeCommandTest__it_generated_correct_file_with_content__1.php
+++ b/tests/Commands/__snapshots__/RouteProviderMakeCommandTest__it_generated_correct_file_with_content__1.php
@@ -19,10 +19,9 @@ class RouteServiceProvider extends ServiceProvider
      *
      * Register any model bindings or pattern based filters.
      *
-     * @param  Router $router
      * @return void
      */
-    public function before(Router $router)
+    public function boot()
     {
         //
     }


### PR DESCRIPTION
Modules\XXX\Providers\RouteServiceProvider is stubbed with `before()` that isn't actually called. Changing this to `boot()`.

Discussed in https://github.com/nWidart/laravel-modules/issues/424