### PR TITLE
Update to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "~6.0",
-    "mockery/mockery": "~0.9",
+    "mockery/mockery": "~1.0",
     "orchestra/testbench": "^3.5",
     "friendsofphp/php-cs-fixer": "^2.7",
     "laravel/framework": "5.5.*",


### PR DESCRIPTION
I've updated `mockery/mockery` to [`~1.0`](https://github.com/mockery/mockery/releases/tag/1.0)