### PR TITLE
Remove code duplication

### DIFF
--- a/src/Laravel/Repository.php
+++ b/src/Laravel/Repository.php
@@ -10,40 +10,8 @@ class Repository extends BaseRepository
     /**
      * {@inheritdoc}
      */
-    public function scan()
+    protected function createModule(...$args)
     {
-        $paths = $this->getScanPaths();
-
-        $modules = [];
-
-        foreach ($paths as $key => $path) {
-            $manifests = $this->app['files']->glob("{$path}/module.json");
-
-            is_array($manifests) || $manifests = [];
-
-            foreach ($manifests as $manifest) {
-                $name = Json::make($manifest)->get('name');
-
-                $modules[$name] = new Module($this->app, $name, dirname($manifest));
-            }
-        }
-
-        return $modules;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function formatCached($cached)
-    {
-        $modules = [];
-
-        foreach ($cached as $name => $module) {
-            $path = $module["path"];
-
-            $modules[$name] = new Module($this->app, $name, $path);
-        }
-
-        return $modules;
+        return new Module(...$args);
     }
 }

--- a/src/Lumen/Repository.php
+++ b/src/Lumen/Repository.php
@@ -10,40 +10,8 @@ class Repository extends BaseRepository
     /**
      * {@inheritdoc}
      */
-    public function scan()
+    protected function createModule(...$args)
     {
-        $paths = $this->getScanPaths();
-
-        $modules = [];
-
-        foreach ($paths as $key => $path) {
-            $manifests = $this->app['files']->glob("{$path}/module.json");
-
-            is_array($manifests) || $manifests = [];
-
-            foreach ($manifests as $manifest) {
-                $name = Json::make($manifest)->get('name');
-
-                $modules[$name] = new Module($this->app, $name, dirname($manifest));
-            }
-        }
-
-        return $modules;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function formatCached($cached)
-    {
-        $modules = [];
-
-        foreach ($cached as $name => $module) {
-            $path = $module["path"];
-
-            $modules[$name] = new Module($this->app, $name, $path);
-        }
-
-        return $modules;
+        return new Module(...$args);
     }
 }


### PR DESCRIPTION
`Lumen/Repository.php` and `Laravel/Repository.php` were exact copies. It was unnecessary code duplication. I  moved `scan` and `formatChached` function back to the abstract parent repository.