### PR TITLE
fixed modules don't load from vendor folder

### DIFF
--- a/src/Repository.php
+++ b/src/Repository.php
@@ -105,8 +105,9 @@ abstract class Repository implements RepositoryInterface, Countable
         if ($this->config('scan.enabled')) {
             $paths = array_merge($paths, $this->config('scan.paths'));
         }
+
         $paths = array_map(function ($path) {
-            return str_finish($path, '/*');
+            return ends_with($path, '/*') ? $path : str_finish($path, '/*');
         }, $paths);
 
         return $paths;


### PR DESCRIPTION
by default, scan path includes all modules from vendor folder via `vendor/*/*` path

```php
    'scan' => [
        'enabled' => false,
        'paths' => [
            base_path('vendor/*/*'),
        ],
    ],
```

But `str_finish` convert the path to `vendor/*` because it removes all `/*` from path to force add only one `/*` in the end, and this cause module doesn’t load from vendor folder, so this PR to check if path end with `/*` already skip adding `/*` to the end.