### PR TITLE
include files while booting app.

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -174,6 +174,8 @@ abstract class Module extends ServiceProvider
             $this->registerTranslation();
         }
 
+        $this->registerFiles();
+
         $this->fireEvent('boot');
     }
 
@@ -245,8 +247,6 @@ abstract class Module extends ServiceProvider
         $this->registerAliases();
 
         $this->registerProviders();
-
-        $this->registerFiles();
 
         $this->fireEvent('register');
     }


### PR DESCRIPTION
In some situations, files of the module need to access to config of the module, but right now files include in the register method when config of modules doesn’t load yet ( it's will be available only if Laravel config is cached)

So, I think files are best to include on boot function to ensure config of modules will be available.

any suggestion is welcome.