### PR TITLE
include files while booting app.

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -171,5 +171,13 @@ return [
     */
     'register' => [
         'translations' => true,
+        /**
+         * load files on boot or register method
+         *
+         * Note: boot not compatible with asgardcms
+         *
+         * @example boot|register
+         */
+        'files' => 'register',
     ],
 ];

--- a/src/Module.php
+++ b/src/Module.php
@@ -174,6 +174,10 @@ abstract class Module extends ServiceProvider
             $this->registerTranslation();
         }
 
+        if ($this->isLoadFilesOnBoot()) {
+            $this->registerFiles();
+        }
+
         $this->fireEvent('boot');
     }
 
@@ -246,7 +250,9 @@ abstract class Module extends ServiceProvider
 
         $this->registerProviders();
 
-        $this->registerFiles();
+        if ($this->isLoadFilesOnBoot() === false) {
+            $this->registerFiles();
+        }
 
         $this->fireEvent('register');
     }
@@ -419,5 +425,17 @@ abstract class Module extends ServiceProvider
     public function __get($key)
     {
         return $this->get($key);
+    }
+
+    /**
+     * Check if can load files of module on boot method.
+     *
+     * @return bool
+     */
+    protected function isLoadFilesOnBoot()
+    {
+        return config('modules.register.files', 'register') === 'boot' &&
+            // force register method if option == boot && app is AsgardCms
+            !class_exists('\Modules\Core\Foundation\AsgardCms');
     }
 }


### PR DESCRIPTION
in some situations, files of the module need to access to config of the module, but right now files include in the register method when config of modules doesn’t load yet ( it's will be available only if Laravel config is cached)

So, I think included files is best to load on boot function to ensure config of modules will be available.

by default will be included files on register method but can change this behavior from config of package `config/modules.php`

```php
    /*
    |--------------------------------------------------------------------------
    | Choose what laravel-modules will register as custom namespaces.
    | Setting one to false will require you to register that part
    | in your own Service Provider class.
    |--------------------------------------------------------------------------
    */
    'register' => [
        .....
        /**
         * load files on boot or register method
         *
         * Note: boot not compatible with asgardcms
         *
         * @example boot|register
         */
        'files' => 'boot',
        ......
    ],
```

Because includes files on boot method doesn't compatible with AsgardCms, register method will force when the app is AsgardCms.

any suggestion is welcome.