### PR TITLE
use default stub if override not exists

### DIFF
--- a/src/Support/Stub.php
+++ b/src/Support/Stub.php
@@ -71,7 +71,9 @@ class Stub
      */
     public function getPath()
     {
-        return static::getBasePath() . $this->path;
+        $path = static::getBasePath() . $this->path;
+
+        return file_exists($path) ? $path : __DIR__ . '/../Commands/stubs' . $this->path;
     }
 
     /**

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -20,9 +20,11 @@ class StubTest extends BaseTestCase
     public function tearDown()
     {
         parent::tearDown();
-        if ($this->finder->exists(base_path('my-command.php'))) {
-            $this->finder->delete(base_path('my-command.php'));
-        }
+        $this->finder->delete([
+            base_path('my-command.php'),
+            base_path('stub-override-exists.php'),
+            base_path('stub-override-not-exists.php')
+        ]);
     }
 
     /** @test */
@@ -71,5 +73,36 @@ class StubTest extends BaseTestCase
         $stub->setPath('/new-path/');
 
         $this->assertTrue(str_contains($stub->getPath(), 'Commands/stubs/new-path/'));
+    }
+
+    /** @test */
+    public function use_default_stub_if_override_not_exists()
+    {
+        $stub = new Stub('/command.stub', [
+            'COMMAND_NAME' => 'my:command',
+            'NAMESPACE' => 'Blog\Commands',
+            'CLASS' => 'MyCommand',
+        ]);
+
+        $stub->setBasePath(__DIR__ . '/stubs');
+
+        $stub->saveTo(base_path(), 'stub-override-not-exists.php');
+
+        $this->assertTrue($this->finder->exists(base_path('stub-override-not-exists.php')));
+    }
+
+    /** @test */
+    public function use_override_stub_if_exists()
+    {
+        $stub = new Stub('/model.stub', [
+            'NAME' => 'Name',
+        ]);
+
+        $stub->setBasePath(__DIR__ . '/stubs');
+
+        $stub->saveTo(base_path(), 'stub-override-exists.php');
+
+        $this->assertTrue($this->finder->exists(base_path('stub-override-exists.php')));
+        $this->assertEquals('stub-override', $this->finder->get(base_path('stub-override-exists.php')));
     }
 }

--- a/tests/stubs/model.stub
+++ b/tests/stubs/model.stub
@@ -1,0 +1,1 @@
+stub-override


### PR DESCRIPTION
If somebody overrides stub path in the config, he should copy new stubs with every new release of the package to add missing stub,

This PR fixes this problem by check if stub file exists on override path use it or use default stub form package folder as a fallback.

I add some test unit for that to make sure everything is work.

thanks