### PR TITLE
Fix non well formed numeric value

### DIFF
--- a/src/Commands/SeedCommand.php
+++ b/src/Commands/SeedCommand.php
@@ -12,7 +12,9 @@ use Nwidart\Modules\Traits\ModuleCommandTrait;
 use RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Debug\Exception\FatalThrowableError;
+use Symfony\Component\Debug\Exception\Fatal
+    
+    ableError;
 
 class SeedCommand extends Command
 {
@@ -47,9 +49,7 @@ class SeedCommand extends Command
                 array_walk($modules, [$this, 'moduleSeed']);
                 $this->info('All modules seeded.');
             }
-        } catch (\Exception $e) {
-            $e = new FatalThrowableError($e);
-
+        } catch (\Throwable $e) {
             $this->reportException($e);
 
             $this->renderException($this->getOutput(), $e);

--- a/src/Commands/SeedCommand.php
+++ b/src/Commands/SeedCommand.php
@@ -12,9 +12,6 @@ use Nwidart\Modules\Traits\ModuleCommandTrait;
 use RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Debug\Exception\Fatal
-    
-    ableError;
 
 class SeedCommand extends Command
 {


### PR DESCRIPTION
When a row in the database doesn't exist, you get a 

      A non well formed numeric value encountered

This is because you're catching an exception rather than throwable