### PR TITLE
Allow symlinks in module path

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -48,7 +48,7 @@ abstract class Module extends ServiceProvider
     {
         parent::__construct($app);
         $this->name = $name;
-        $this->path = realpath($path);
+        $this->path = $path;
     }
 
     /**

--- a/tests/LaravelModuleTest.php
+++ b/tests/LaravelModuleTest.php
@@ -20,6 +20,18 @@ class ModuleTest extends BaseTestCase
         $this->module = new TestingModule($this->app, 'Recipe Name', __DIR__ . '/stubs/valid/Recipe');
     }
 
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        symlink(__DIR__ . '/stubs/valid', __DIR__ . '/stubs/valid_symlink');
+    }
+
+    public static function tearDownAfterClass()
+    {
+        parent::tearDownAfterClass();
+        unlink(__DIR__ . '/stubs/valid_symlink');
+    }
+
     /** @test */
     public function it_gets_module_name()
     {
@@ -60,6 +72,18 @@ class ModuleTest extends BaseTestCase
     public function it_gets_module_path()
     {
         $this->assertEquals(__DIR__ . '/stubs/valid/Recipe', $this->module->getPath());
+    }
+
+    /** @test */
+    public function it_gets_module_path_with_symlink()
+    {
+        // symlink created in setUpBeforeClass
+
+        $this->module = new TestingModule($this->app, 'Recipe Name', __DIR__ . '/stubs/valid_symlink/Recipe');
+
+        $this->assertEquals(__DIR__ . '/stubs/valid_symlink/Recipe', $this->module->getPath());
+
+        // symlink deleted in tearDownAfterClass
     }
 
     /** @test */


### PR DESCRIPTION
I couldn't figure out what was gravitano's rational behind using `realpath()` when constructing a `Module` class. It seems unnecessary to me. It wouldn't be an issue though, but this caused me trouble when I added modules behind symlinks, as `realpath` returns an absolute path with resolved symlinks. Removing `realpath` doesn't seem to break anything, but solves my issue.