### PR TITLE
Generate folders recursively

### DIFF
--- a/src/Commands/SetupCommand.php
+++ b/src/Commands/SetupCommand.php
@@ -64,7 +64,7 @@ class SetupCommand extends Command
     protected function generateDirectory($dir, $success, $error)
     {
         if (!$this->laravel['files']->isDirectory($dir)) {
-            $this->laravel['files']->makeDirectory($dir);
+            $this->laravel['files']->makeDirectory($dir, 0755, true, true);
 
             $this->info($success);
 


### PR DESCRIPTION
If you provide a more deep path than default, it will fail if any folder parent doesn't exists.
So a simple commit to fix that