### PR TITLE
Returns the parameter `--class` to the `SeedCommand`.

### DIFF
--- a/src/Commands/SeedCommand.php
+++ b/src/Commands/SeedCommand.php
@@ -199,6 +199,7 @@ class SeedCommand extends Command
     protected function getOptions()
     {
         return [
+            ['class', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder.'],
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to seed.'],
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
         ];


### PR DESCRIPTION
This changes allows use `--class` option to specify a specific seeder class to run individually.

Example:
`php artisan module:seed User --class=Modules\User\Database\Seeders\UserRoleDatabaseSeeder`.
