### PR TITLE
Fix Issues #465 Add namespace for custom config seeder path

### DIFF
--- a/src/Commands/SeedCommand.php
+++ b/src/Commands/SeedCommand.php
@@ -160,10 +160,10 @@ class SeedCommand extends Command
      * Report the exception to the exception handler.
      *
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
-     * @param  \Exception  $e
+     * @param  \Throwable  $e
      * @return void
      */
-    protected function renderException($output, \Exception $e)
+    protected function renderException($output, \Throwable $e)
     {
         $this->laravel[ExceptionHandler::class]->renderForConsole($output, $e);
     }
@@ -171,10 +171,10 @@ class SeedCommand extends Command
     /**
      * Report the exception to the exception handler.
      *
-     * @param  \Exception  $e
+     * @param  \Throwable  $e
      * @return void
      */
-    protected function reportException(\Exception $e)
+    protected function reportException(\Throwable $e)
     {
         $this->laravel[ExceptionHandler::class]->report($e);
     }

--- a/src/Commands/SeedMakeCommand.php
+++ b/src/Commands/SeedMakeCommand.php
@@ -66,7 +66,7 @@ class SeedMakeCommand extends GeneratorCommand
     protected function getTemplateContents()
     {
         $module = $this->laravel['modules']->findOrFail($this->getModuleName());
-
+ 
         return (new Stub('/seeder.stub', [
             'NAME' => $this->getSeederName(),
             'MODULE' => $this->getModuleName(),
@@ -99,5 +99,15 @@ class SeedMakeCommand extends GeneratorCommand
         $end = $this->option('master') ? 'DatabaseSeeder' : 'TableSeeder';
 
         return Str::studly($this->argument('name')) . $end;
+    }
+
+    /**
+     * Get default namespace.
+     *
+     * @return string
+     */
+    public function getDefaultNamespace() : string
+    {
+        return $this->laravel['modules']->config('paths.generator.seeder.path', 'Database/Seeders');
     }
 }

--- a/src/Commands/stubs/seeder.stub
+++ b/src/Commands/stubs/seeder.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace $NAMESPACE$\Database\Seeders;
+namespace $NAMESPACE$;
 
 use Illuminate\Database\Seeder;
 use Illuminate\Database\Eloquent\Model;


### PR DESCRIPTION
Error before: 
`Type error: Argument 1 passed to Nwidart\Modules\Commands\SeedCommand::reportException() must be an instance of Exception, instance of Error given, called in /home/vagrant/sites/pq/ vendor/nwidart/laravel-modules/src/Commands/SeedCommand.php on line 50`

- plus -
add namespace to config('seeder') custom