### PR TITLE
Fix Laravel Mix

### DIFF
--- a/src/Commands/stubs/package.stub
+++ b/src/Commands/stubs/package.stub
@@ -11,6 +11,7 @@
     },
     "devDependencies": {
         "cross-env": "^5.1.4",
-        "laravel-mix": "^2.0"
+        "laravel-mix": "^2.1",
+        "laravel-mix-merge-manifest": "^0.1.1"
     }
 }

--- a/src/Commands/stubs/views/master.stub
+++ b/src/Commands/stubs/views/master.stub
@@ -7,13 +7,13 @@
         <title>Module $STUDLY_NAME$</title>
 
        <!-- Laravel Mix - CSS File -->
-       <!-- <link rel="stylesheet" href="{{ mix('css/app.css','modules/$LOWER_NAME$') }}"> -->
+       <!-- <link rel="stylesheet" href="{{ mix('css/$LOWER_NAME$.css') }}"> -->
 
     </head>
     <body>
         @yield('content')
 
         <!-- Laravel Mix - JS File -->
-        <!-- <script src="{{ mix('js/app.js', 'modules/$LOWER_NAME$') }}"></script> -->
+        <!-- <script src="{{ mix('js/$LOWER_NAME$.js') }}"></script> -->
     </body>
 </html>

--- a/src/Commands/stubs/webpack.stub
+++ b/src/Commands/stubs/webpack.stub
@@ -1,10 +1,10 @@
 const { mix } = require('laravel-mix');
+require('laravel-mix-merge-manifest');
 
-mix.setPublicPath('public')
-    .copy('public', __dirname + '/../../public/modules/$LOWER_NAME$')
+mix.setPublicPath('../../public').mergeManifest();
 
-mix.js(__dirname + '/Resources/assets/js/app.js', 'public/js')
-    .sass( __dirname + '/Resources/assets/sass/app.scss', 'public/css');
+mix.js(__dirname + '/Resources/assets/js/app.js', 'js/$LOWER_NAME$.js')
+    .sass( __dirname + '/Resources/assets/sass/app.scss', 'css/$LOWER_NAME$.css');
 
 if (mix.inProduction()) {
     mix.version();

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_webpack_file__1.php
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_webpack_file__1.php
@@ -1,10 +1,10 @@
 <?php return 'const { mix } = require(\'laravel-mix\');
+require(\'laravel-mix-merge-manifest\');
 
-mix.setPublicPath(\'public\')
-    .copy(\'public\', __dirname + \'/../../public/modules/blog\')
+mix.setPublicPath(\'../../public\').mergeManifest();
 
-mix.js(__dirname + \'/Resources/assets/js/app.js\', \'public/js\')
-    .sass( __dirname + \'/Resources/assets/sass/app.scss\', \'public/css\');
+mix.js(__dirname + \'/Resources/assets/js/app.js\', \'js/blog.js\')
+    .sass( __dirname + \'/Resources/assets/sass/app.scss\', \'css/blog.css\');
 
 if (mix.inProduction()) {
     mix.version();


### PR DESCRIPTION
- Fix css relative urls by changing the route folder
- Prevents every build from deleting previous Mix config file

I used custom [extension](https://github.com/KABBOUCHI/laravel-mix-merge-manifest) to fix the second issue, I'll remove it once Laravel Mix merges this [PR#1453](https://github.com/JeffreyWay/laravel-mix/pull/1453)

