### PR TITLE
Added an option to prefix table migrations with the module's name.

### DIFF
--- a/src/Commands/ModelMakeCommand.php
+++ b/src/Commands/ModelMakeCommand.php
@@ -86,6 +86,7 @@ class ModelMakeCommand extends GeneratorCommand
         return [
             ['fillable', null, InputOption::VALUE_OPTIONAL, 'The fillable attributes.', null],
             ['migration', 'm', InputOption::VALUE_NONE, 'Flag to create associated migrations', null],
+            ['prefix', 'p', InputOption::VALUE_NONE, 'Flag to create associated migrations and prefix with module name', null],
         ];
     }
 
@@ -107,13 +108,20 @@ class ModelMakeCommand extends GeneratorCommand
     {
         $module = $this->laravel['modules']->findOrFail($this->getModuleName());
 
-        return (new Stub('/model.stub', [
+        if ($this->option('prefix') === true) {
+            $stub_file = '/model-prefix.stub';
+        } else {
+            $stub_file = '/model.stub';
+        }
+
+        return (new Stub($stub_file, [
             'NAME'              => $this->getModelName(),
             'FILLABLE'          => $this->getFillable(),
             'NAMESPACE'         => $this->getClassNamespace($module),
             'CLASS'             => $this->getClass(),
             'LOWER_NAME'        => $module->getLowerName(),
             'MODULE'            => $this->getModuleName(),
+            'TABLE'             => strtolower($this->argument('module')) . '_' . $this->createMigrationName(),            
             'STUDLY_NAME'       => $module->getStudlyName(),
             'MODULE_NAMESPACE'  => $this->laravel['modules']->config('namespace'),
         ]))->render();

--- a/src/Commands/ModelMakeCommand.php
+++ b/src/Commands/ModelMakeCommand.php
@@ -96,7 +96,11 @@ class ModelMakeCommand extends GeneratorCommand
     private function handleOptionalMigrationOption()
     {
         if ($this->option('migration') === true) {
-            $migrationName = 'create_' . $this->createMigrationName() . '_table';
+            if ($this->option('prefix') === true) {
+                $migrationName = 'create_' . strtolower($this->argument('module')) . '_' . $this->createMigrationName() . '_table';
+            } else {
+                $migrationName = 'create_' . $this->createMigrationName() . '_table';
+            }
             $this->call('module:make-migration', ['name' => $migrationName, 'module' => $this->argument('module')]);
         }
     }

--- a/src/Commands/stubs/model-prefix.stub
+++ b/src/Commands/stubs/model-prefix.stub
@@ -13,5 +13,12 @@ class $CLASS$ extends Model
      */
     protected $fillable = $FILLABLE$;
 
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = "$TABLE$";
+
     // 
 }


### PR DESCRIPTION
## Current
Command
```php
// create a Post model with its migration for the Blog module
php artisan module:make-model -m Post Blog
```
Output
```php
// Post model
<?php

namespace Modules\Post\Entities;

use Illuminate\Database\Eloquent\Model;

class Post extends Model
{
    protected $fillable = [];
}


// migration  2018_05_15_204011_create_posts_table
<?php

use Illuminate\Support\Facades\Schema;
use Illuminate\Database\Schema\Blueprint;
use Illuminate\Database\Migrations\Migration;

class CreatePostsTable extends Migration
{
    /**
     * Run the migrations.
     *
     * @return void
     */
    public function up()
    {
        Schema::create('posts', function (Blueprint $table) {
            $table->increments('id');

            $table->timestamps();
        });
    }

    /**
     * Reverse the migrations.
     *
     * @return void
     */
    public function down()
    {
        Schema::dropIfExists('posts');
    }
}

```

## PR Change
Command
```php
// create a Post model with its migration for the Blog module, but prefix the module's name
php artisan module:make-model Post -pm Post Blog
```
Output
```php
// Post model
<?php

namespace Modules\Blog\Entities;

use Illuminate\Database\Eloquent\Model;

class Post extends Model
{
    /**
     * The attributes that are mass assignable.
     *
     * @var array
     */
    protected $fillable = [];

    /**
     * The table associated with the model.
     *
     * @var string
     */
    protected $table = "blog_posts";

    // 
}


// migration file 2018_05_15_204011_create_blog_posts_table
<?php

use Illuminate\Support\Facades\Schema;
use Illuminate\Database\Schema\Blueprint;
use Illuminate\Database\Migrations\Migration;

class CreateBlogPostsTable extends Migration
{
    /**
     * Run the migrations.
     *
     * @return void
     */
    public function up()
    {
        Schema::create('blog_posts', function (Blueprint $table) {
            $table->increments('id');

            $table->timestamps();
        });
    }

    /**
     * Reverse the migrations.
     *
     * @return void
     */
    public function down()
    {
        Schema::dropIfExists('blog_posts');
    }
}

```