### PR TITLE
Allow class resolution on short name and abstract

### DIFF
--- a/src/LaravelModulesServiceProvider.php
+++ b/src/LaravelModulesServiceProvider.php
@@ -44,11 +44,11 @@ class LaravelModulesServiceProvider extends ModulesServiceProvider
      */
     protected function registerServices()
     {
-        $this->app->singleton(Repository::class, function ($app) {
+        $this->app->singleton(Contracts\RepositoryInterface::class, function ($app) {
             $path = $app['config']->get('modules.paths.modules');
 
             return new \Nwidart\Modules\Laravel\Repository($app, $path);
         });
-        $this->app->alias(Repository::class, 'modules');
+        $this->app->alias(Contracts\RepositoryInterface::class, 'modules');
     }
 }

--- a/src/LaravelModulesServiceProvider.php
+++ b/src/LaravelModulesServiceProvider.php
@@ -44,10 +44,11 @@ class LaravelModulesServiceProvider extends ModulesServiceProvider
      */
     protected function registerServices()
     {
-        $this->app->singleton('modules', function ($app) {
+        $this->app->singleton(Repository::class, function ($app) {
             $path = $app['config']->get('modules.paths.modules');
 
             return new \Nwidart\Modules\Laravel\Repository($app, $path);
         });
+        $this->app->alias(Repository::class, 'modules');
     }
 }

--- a/src/LumenModulesServiceProvider.php
+++ b/src/LumenModulesServiceProvider.php
@@ -42,11 +42,11 @@ class LumenModulesServiceProvider extends ModulesServiceProvider
      */
     protected function registerServices()
     {
-        $this->app->singleton(Repository::class, function ($app) {
+        $this->app->singleton(Contracts\RepositoryInterface::class, function ($app) {
             $path = $app['config']->get('modules.paths.modules');
 
             return new \Nwidart\Modules\Lumen\Repository($app, $path);
         });
-        $this->app->alias(Repository::class, 'modules');
+        $this->app->alias(Contracts\RepositoryInterface::class, 'modules');
     }
 }

--- a/src/LumenModulesServiceProvider.php
+++ b/src/LumenModulesServiceProvider.php
@@ -42,10 +42,11 @@ class LumenModulesServiceProvider extends ModulesServiceProvider
      */
     protected function registerServices()
     {
-        $this->app->singleton('modules', function ($app) {
+        $this->app->singleton(Repository::class, function ($app) {
             $path = $app['config']->get('modules.paths.modules');
 
             return new \Nwidart\Modules\Lumen\Repository($app, $path);
         });
+        $this->app->alias(Repository::class, 'modules');
     }
 }

--- a/src/ModulesServiceProvider.php
+++ b/src/ModulesServiceProvider.php
@@ -63,7 +63,7 @@ abstract class ModulesServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return ['modules'];
+        return [Repository::class, 'modules'];
     }
 
     /**

--- a/src/ModulesServiceProvider.php
+++ b/src/ModulesServiceProvider.php
@@ -63,7 +63,7 @@ abstract class ModulesServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return [Repository::class, 'modules'];
+        return [Contracts\RepositoryInterface::class, 'modules'];
     }
 
     /**

--- a/tests/LaravelModulesServiceProviderTest.php
+++ b/tests/LaravelModulesServiceProviderTest.php
@@ -2,7 +2,7 @@
 
 namespace Nwidart\Modules\Tests;
 
-use Nwidart\Modules\Laravel\Contracts\RepositoryInterface;
+use Nwidart\Modules\Contracts\RepositoryInterface;
 
 class LaravelModulesServiceProviderTest extends BaseTestCase
 {

--- a/tests/LaravelModulesServiceProviderTest.php
+++ b/tests/LaravelModulesServiceProviderTest.php
@@ -2,13 +2,13 @@
 
 namespace Nwidart\Modules\Tests;
 
-use Nwidart\Modules\Laravel\Repository;
+use Nwidart\Modules\Laravel\Contracts\RepositoryInterface;
 
 class LaravelModulesServiceProviderTest extends BaseTestCase
 {
     /** @test */
     public function it_binds_modules_key_to_repository_class()
     {
-        $this->assertInstanceOf(Contracts\RepositoryInterface::class, app('modules'));
+        $this->assertInstanceOf(RepositoryInterface::class, app('modules'));
     }
 }

--- a/tests/LaravelModulesServiceProviderTest.php
+++ b/tests/LaravelModulesServiceProviderTest.php
@@ -9,6 +9,6 @@ class LaravelModulesServiceProviderTest extends BaseTestCase
     /** @test */
     public function it_binds_modules_key_to_repository_class()
     {
-        $this->assertInstanceOf(Repository::class, app('modules'));
+        $this->assertInstanceOf(Contracts\RepositoryInterface::class, app('modules'));
     }
 }


### PR DESCRIPTION
Allows developers to do: `app('modules')->someMethod();` and `app(Repository::class)->someMethod();`

Without this, there would be an exception thrown (for example in a new install of AsgardCMS v3):

```
Illuminate\Contracts\Container\BindingResolutionException thrown with message "Target [Nwidart\Modules\Repository] is not instantiable."
```

I'm also opening a PR to do the same thing for v3 of Laravel Modules.