### PR TITLE
[5.7] disable mocking the console output & fix events

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -264,7 +264,7 @@ abstract class Module extends ServiceProvider
      */
     protected function fireEvent($event)
     {
-        $this->app['events']->fire(sprintf('modules.%s.' . $event, $this->getLowerName()), [$this]);
+        $this->app['events']->dispatch(sprintf('modules.%s.' . $event, $this->getLowerName()), [$this]);
     }
     /**
      * Register the aliases from this module.

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -11,6 +11,7 @@ abstract class BaseTestCase extends OrchestraTestCase
     {
         parent::setUp();
 
+        $this->withoutMockingConsoleOutput();
         // $this->setUpDatabase();
     }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9212274/45841806-940a2d00-bd23-11e8-921b-62d211f4cafb.png)

~There other test failures for the events, I'll check them later.~

I found the problem, while ago they changed the $event->fire to $event->dispatch, they remove it completely in 5.7