### PR TITLE
update module controller scaffold to extend laravel default controller

### DIFF
--- a/src/Commands/stubs/controller-plain.stub
+++ b/src/Commands/stubs/controller-plain.stub
@@ -2,7 +2,8 @@
 
 namespace $CLASS_NAMESPACE$;
 
-use Illuminate\Routing\Controller;
+use Illuminate\Routing\Controller as BaseController;
+use App\Http\Controllers\Controller;
 
 class $CLASS$ extends Controller
 {

--- a/src/Commands/stubs/controller.stub
+++ b/src/Commands/stubs/controller.stub
@@ -4,7 +4,8 @@ namespace $CLASS_NAMESPACE$;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Illuminate\Routing\Controller;
+use Illuminate\Routing\Controller as BaseController;
+use App\Http\Controllers\Controller;
 
 class $CLASS$ extends Controller
 {


### PR DESCRIPTION
Updating the module:make-controller command stub so that the created controller will extend App\Http\Controllers\Controller instead of use Illuminate\Routing\Controller.