### PR TITLE
configurable stubs path fix

### DIFF
--- a/src/Support/Stub.php
+++ b/src/Support/Stub.php
@@ -71,9 +71,9 @@ class Stub
      */
     public function getPath()
     {
-        $path = static::getBasePath() . $this->path;
+        $path = config('modules.stubs.path') . $this->path;
 
-        return file_exists($path) ? $path : __DIR__ . '/../Commands/stubs' . $this->path;
+        return file_exists($path) ? $path : static::getBasePath() . $this->path;
     }
 
     /**


### PR DESCRIPTION
**config.modules.stubs.path** was not used in `vendor/nwidart/laravel-modules/src/Support/Stub.php`.