### PR TITLE
Update Route Provider stub to not affect the root namespace of the URL generator

### DIFF
--- a/src/Commands/stubs/route-provider.stub
+++ b/src/Commands/stubs/route-provider.stub
@@ -8,11 +8,11 @@ use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvi
 class $CLASS$ extends ServiceProvider
 {
     /**
-     * The root namespace to assume when generating URLs to actions.
+     * The module namespace to assume when generating URLs to actions.
      *
      * @var string
      */
-    protected $namespace = '$MODULE_NAMESPACE$\$MODULE$\Http\Controllers';
+    protected $moduleNamespace = '$MODULE_NAMESPACE$\$MODULE$\Http\Controllers';
 
     /**
      * Called before routes are registered.
@@ -48,7 +48,7 @@ class $CLASS$ extends ServiceProvider
     protected function mapWebRoutes()
     {
         Route::middleware('web')
-            ->namespace($this->namespace)
+            ->namespace($this->moduleNamespace)
             ->group(__DIR__ . '/../Routes/web.php');
     }
 
@@ -63,7 +63,7 @@ class $CLASS$ extends ServiceProvider
     {
         Route::prefix('api')
             ->middleware('api')
-            ->namespace($this->namespace)
+            ->namespace($this->moduleNamespace)
             ->group(__DIR__ . '/../Routes/api.php');
     }
 }

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_module_resources__4.php
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_module_resources__4.php
@@ -8,11 +8,11 @@ use Illuminate\\Foundation\\Support\\Providers\\RouteServiceProvider as ServiceP
 class RouteServiceProvider extends ServiceProvider
 {
     /**
-     * The root namespace to assume when generating URLs to actions.
+     * The module namespace to assume when generating URLs to actions.
      *
      * @var string
      */
-    protected $namespace = \'Modules\\Blog\\Http\\Controllers\';
+    protected $moduleNamespace = \'Modules\\Blog\\Http\\Controllers\';
 
     /**
      * Called before routes are registered.
@@ -48,7 +48,7 @@ class RouteServiceProvider extends ServiceProvider
     protected function mapWebRoutes()
     {
         Route::middleware(\'web\')
-            ->namespace($this->namespace)
+            ->namespace($this->moduleNamespace)
             ->group(__DIR__ . \'/../Routes/web.php\');
     }
 
@@ -63,7 +63,7 @@ class RouteServiceProvider extends ServiceProvider
     {
         Route::prefix(\'api\')
             ->middleware(\'api\')
-            ->namespace($this->namespace)
+            ->namespace($this->moduleNamespace)
             ->group(__DIR__ . \'/../Routes/api.php\');
     }
 }

--- a/tests/Commands/__snapshots__/RouteProviderMakeCommandTest__it_can_change_the_default_namespace__1.php
+++ b/tests/Commands/__snapshots__/RouteProviderMakeCommandTest__it_can_change_the_default_namespace__1.php
@@ -8,11 +8,11 @@ use Illuminate\\Foundation\\Support\\Providers\\RouteServiceProvider as ServiceP
 class RouteServiceProvider extends ServiceProvider
 {
     /**
-     * The root namespace to assume when generating URLs to actions.
+     * The module namespace to assume when generating URLs to actions.
      *
      * @var string
      */
-    protected $namespace = \'Modules\\Blog\\Http\\Controllers\';
+    protected $moduleNamespace = \'Modules\\Blog\\Http\\Controllers\';
 
     /**
      * Called before routes are registered.
@@ -48,7 +48,7 @@ class RouteServiceProvider extends ServiceProvider
     protected function mapWebRoutes()
     {
         Route::middleware(\'web\')
-            ->namespace($this->namespace)
+            ->namespace($this->moduleNamespace)
             ->group(__DIR__ . \'/../Routes/web.php\');
     }
 
@@ -63,7 +63,7 @@ class RouteServiceProvider extends ServiceProvider
     {
         Route::prefix(\'api\')
             ->middleware(\'api\')
-            ->namespace($this->namespace)
+            ->namespace($this->moduleNamespace)
             ->group(__DIR__ . \'/../Routes/api.php\');
     }
 }

--- a/tests/Commands/__snapshots__/RouteProviderMakeCommandTest__it_generated_correct_file_with_content__1.php
+++ b/tests/Commands/__snapshots__/RouteProviderMakeCommandTest__it_generated_correct_file_with_content__1.php
@@ -8,11 +8,11 @@ use Illuminate\\Foundation\\Support\\Providers\\RouteServiceProvider as ServiceP
 class RouteServiceProvider extends ServiceProvider
 {
     /**
-     * The root namespace to assume when generating URLs to actions.
+     * The module namespace to assume when generating URLs to actions.
      *
      * @var string
      */
-    protected $namespace = \'Modules\\Blog\\Http\\Controllers\';
+    protected $moduleNamespace = \'Modules\\Blog\\Http\\Controllers\';
 
     /**
      * Called before routes are registered.
@@ -48,7 +48,7 @@ class RouteServiceProvider extends ServiceProvider
     protected function mapWebRoutes()
     {
         Route::middleware(\'web\')
-            ->namespace($this->namespace)
+            ->namespace($this->moduleNamespace)
             ->group(__DIR__ . \'/../Routes/web.php\');
     }
 
@@ -63,7 +63,7 @@ class RouteServiceProvider extends ServiceProvider
     {
         Route::prefix(\'api\')
             ->middleware(\'api\')
-            ->namespace($this->namespace)
+            ->namespace($this->moduleNamespace)
             ->group(__DIR__ . \'/../Routes/api.php\');
     }
 }


### PR DESCRIPTION
The stubbed RouteProvider extends `Illuminate\Foundation\Support\Providers\RouteServiceProvider` setting the `$namespace` property means that on each `boot()` of a module's RouteServiceProvider we are changing the URL generator's root namespace.  

I believe this should be controlled by the application level RouteServiceProvider only.
See `Illuminate\Foundation\Support\ProvidersRouteServiceProvider::setRootControllerNamespace`