### PR TITLE
Convert Error to ErrorException on SeedCommand

### DIFF
--- a/src/Commands/SeedCommand.php
+++ b/src/Commands/SeedCommand.php
@@ -46,7 +46,14 @@ class SeedCommand extends Command
                 array_walk($modules, [$this, 'moduleSeed']);
                 $this->info('All modules seeded.');
             }
-        } catch (\Throwable $e) {
+        } catch (\Error $e) {
+            $e = new \ErrorException($e->getMessage(), $e->getCode(), 1,  $e->getFile(), $e->getLine(), $e);
+            $this->reportException($e);
+
+            $this->renderException($this->getOutput(), $e);
+
+            return 1;
+        } catch (\Exception $e) {
             $this->reportException($e);
 
             $this->renderException($this->getOutput(), $e);
@@ -192,10 +199,10 @@ class SeedCommand extends Command
      * Report the exception to the exception handler.
      *
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
-     * @param  \Throwable  $e
+     * @param  \Exception  $e
      * @return void
      */
-    protected function renderException($output, \Throwable $e)
+    protected function renderException($output, \Exception $e)
     {
         $this->laravel[ExceptionHandler::class]->renderForConsole($output, $e);
     }
@@ -203,10 +210,10 @@ class SeedCommand extends Command
     /**
      * Report the exception to the exception handler.
      *
-     * @param  \Throwable  $e
+     * @param  \Exception  $e
      * @return void
      */
-    protected function reportException(\Throwable $e)
+    protected function reportException(\Exception $e)
     {
         $this->laravel[ExceptionHandler::class]->report($e);
     }


### PR DESCRIPTION
Fixes \Throwable mess in Laravel report.

Fixes #574 using part of #598. 

Is the same tecnique used by [\Psysh\ExecutionLoopClosure:95](https://github.com/bobthecow/psysh/blob/master/src/ExecutionLoopClosure.php#L95)

Now instead of this:
![Annotation 2019-04-02 092930](https://user-images.githubusercontent.com/159077/55402479-f097a180-5529-11e9-8193-1c5555f95816.jpg)

We got this:
![Annotation 2019-04-02 092822](https://user-images.githubusercontent.com/159077/55402492-f55c5580-5529-11e9-9087-57cdbb7551ea.jpg)
