### PR TITLE
Fix exception issue by replacing throwable with built-in php exception

### DIFF
--- a/src/Commands/SeedCommand.php
+++ b/src/Commands/SeedCommand.php
@@ -46,7 +46,7 @@ class SeedCommand extends Command
                 array_walk($modules, [$this, 'moduleSeed']);
                 $this->info('All modules seeded.');
             }
-        } catch (\Throwable $e) {
+        } catch (\Exception $e) {
             $this->reportException($e);
 
             $this->renderException($this->getOutput(), $e);
@@ -195,7 +195,7 @@ class SeedCommand extends Command
      * @param  \Throwable  $e
      * @return void
      */
-    protected function renderException($output, \Throwable $e)
+    protected function renderException($output, \Exception $e)
     {
         $this->laravel[ExceptionHandler::class]->renderForConsole($output, $e);
     }


### PR DESCRIPTION
This PR fixes  #574 issue . 
**The problem is that, laravel expects to get php built-in \Exception but that method gives it an instance of \Throwable interface which is wrong in php concept. because even \Exception is instance of \Throwable but the opposite is not possible. so the workaround is to pass an \Exception to it.** 
this really fixed my issues in  src/Commands/SeedCommand.php , i hope this pr fixes yours too. 
i checked previous issues about this problem, feel free to report other problems here , i will gladly fix them too. by the way i ran all of unit tests in the code and everything was fine.