### PR TITLE
Only Register Factories when Running in Console

### DIFF
--- a/src/Commands/stubs/scaffold/provider.stub
+++ b/src/Commands/stubs/scaffold/provider.stub
@@ -89,7 +89,7 @@ class $CLASS$ extends ServiceProvider
      */
     public function registerFactories()
     {
-        if (! app()->environment('production') && $this->runningInConsole()) {
+        if (! app()->environment('production') && $this->app->runningInConsole()) {
             app(Factory::class)->load(__DIR__ . '/../$FACTORIES_PATH$');
         }
     }
@@ -102,15 +102,5 @@ class $CLASS$ extends ServiceProvider
     public function provides()
     {
         return [];
-    }
-
-    /**
-     * Determine if we are running in the console.
-     *
-     * @return bool
-     */
-    protected function runningInConsole()
-    {
-        return php_sapi_name() == 'cli' || php_sapi_name() == 'phpdbg';
     }
 }

--- a/src/Commands/stubs/scaffold/provider.stub
+++ b/src/Commands/stubs/scaffold/provider.stub
@@ -103,4 +103,14 @@ class $CLASS$ extends ServiceProvider
     {
         return [];
     }
+
+    /**
+     * Determine if we are running in the console.
+     *
+     * @return bool
+     */
+    protected function runningInConsole()
+    {
+        return php_sapi_name() == 'cli' || php_sapi_name() == 'phpdbg';
+    }
 }

--- a/src/Commands/stubs/scaffold/provider.stub
+++ b/src/Commands/stubs/scaffold/provider.stub
@@ -89,7 +89,7 @@ class $CLASS$ extends ServiceProvider
      */
     public function registerFactories()
     {
-        if (! app()->environment('production')) {
+        if (! app()->environment('production') && $this->runningInConsole()) {
             app(Factory::class)->load(__DIR__ . '/../$FACTORIES_PATH$');
         }
     }

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_module_namespace_using_studly_case__1.php
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_module_namespace_using_studly_case__1.php
@@ -89,7 +89,7 @@ class ModuleNameServiceProvider extends ServiceProvider
      */
     public function registerFactories()
     {
-        if (! app()->environment(\'production\')) {
+        if (! app()->environment(\'production\') && $this->app->runningInConsole()) {
             app(Factory::class)->load(__DIR__ . \'/../Database/factories\');
         }
     }

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_module_resources__1.php
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_module_resources__1.php
@@ -89,7 +89,7 @@ class BlogServiceProvider extends ServiceProvider
      */
     public function registerFactories()
     {
-        if (! app()->environment(\'production\')) {
+        if (! app()->environment(\'production\') && $this->app->runningInConsole()) {
             app(Factory::class)->load(__DIR__ . \'/../Database/factories\');
         }
     }

--- a/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_can_change_the_default_namespace__1.php
+++ b/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_can_change_the_default_namespace__1.php
@@ -89,7 +89,7 @@ class BlogServiceProvider extends ServiceProvider
      */
     public function registerFactories()
     {
-        if (! app()->environment(\'production\')) {
+        if (! app()->environment(\'production\') && $this->app->runningInConsole()) {
             app(Factory::class)->load(__DIR__ . \'/../Database/factories\');
         }
     }

--- a/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_can_have_custom_migration_resources_location_paths__1.php
+++ b/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_can_have_custom_migration_resources_location_paths__1.php
@@ -89,7 +89,7 @@ class BlogServiceProvider extends ServiceProvider
      */
     public function registerFactories()
     {
-        if (! app()->environment(\'production\')) {
+        if (! app()->environment(\'production\') && $this->app->runningInConsole()) {
             app(Factory::class)->load(__DIR__ . \'/../Database/factories\');
         }
     }

--- a/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_generates_a_master_service_provider_with_resource_loading__1.php
+++ b/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_generates_a_master_service_provider_with_resource_loading__1.php
@@ -89,7 +89,7 @@ class BlogServiceProvider extends ServiceProvider
      */
     public function registerFactories()
     {
-        if (! app()->environment(\'production\')) {
+        if (! app()->environment(\'production\') && $this->app->runningInConsole()) {
             app(Factory::class)->load(__DIR__ . \'/../Database/factories\');
         }
     }


### PR DESCRIPTION
I think this approach can reduce the application to load the unused file when running in browser.