### PR TITLE
Add alternative way to provide the namespace via configuration

### DIFF
--- a/src/Commands/CommandMakeCommand.php
+++ b/src/Commands/CommandMakeCommand.php
@@ -38,9 +38,7 @@ class CommandMakeCommand extends GeneratorCommand
     {
         $module = $this->laravel['modules'];
 
-        return ($namespace = $module->config('paths.generator.command.namespace'))
-            ? $namespace
-            : $module->config('paths.generator.command.path', 'Console');
+        return $module->config('paths.generator.command.namespace') ?: $module->config('paths.generator.command.path', 'Console');
     }
 
     /**

--- a/src/Commands/CommandMakeCommand.php
+++ b/src/Commands/CommandMakeCommand.php
@@ -36,7 +36,11 @@ class CommandMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace() : string
     {
-        return $this->laravel['modules']->config('paths.generator.command.path', 'Console');
+        $module = $this->laravel['modules'];
+
+        return ($namespace = $module->config('paths.generator.command.namespace'))
+            ? $namespace
+            : $module->config('paths.generator.command.path', 'Console');
     }
 
     /**

--- a/src/Commands/ControllerMakeCommand.php
+++ b/src/Commands/ControllerMakeCommand.php
@@ -119,9 +119,7 @@ class ControllerMakeCommand extends GeneratorCommand
     {
         $module = $this->laravel['modules'];
 
-        return ($namespace = $module->config('paths.generator.controller.namespace'))
-            ? $namespace
-            : $module->config('paths.generator.controller.path', 'Http/Controllers');
+        return $module->config('paths.generator.controller.namespace') ?: $module->config('paths.generator.controller.path', 'Http/Controllers');
     }
 
     /**

--- a/src/Commands/ControllerMakeCommand.php
+++ b/src/Commands/ControllerMakeCommand.php
@@ -117,7 +117,11 @@ class ControllerMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace() : string
     {
-        return $this->laravel['modules']->config('paths.generator.controller.path', 'Http/Controllers');
+        $module = $this->laravel['modules'];
+
+        return ($namespace = $module->config('paths.generator.controller.namespace'))
+            ? $namespace
+            : $module->config('paths.generator.controller.path', 'Http/Controllers');
     }
 
     /**

--- a/src/Commands/EventMakeCommand.php
+++ b/src/Commands/EventMakeCommand.php
@@ -59,9 +59,7 @@ class EventMakeCommand extends GeneratorCommand
     {
         $module = $this->laravel['modules'];
 
-        return ($namespace = $module->config('paths.generator.event.namespace'))
-            ? $namespace
-            : $module->config('paths.generator.event.path', 'Events');
+        return $module->config('paths.generator.event.namespace') ?: $module->config('paths.generator.event.path', 'Events');
     }
 
     /**

--- a/src/Commands/EventMakeCommand.php
+++ b/src/Commands/EventMakeCommand.php
@@ -57,7 +57,11 @@ class EventMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace() : string
     {
-        return $this->laravel['modules']->config('paths.generator.event.path', 'Events');
+        $module = $this->laravel['modules'];
+
+        return ($namespace = $module->config('paths.generator.event.namespace'))
+            ? $namespace
+            : $module->config('paths.generator.event.path', 'Events');
     }
 
     /**

--- a/src/Commands/JobMakeCommand.php
+++ b/src/Commands/JobMakeCommand.php
@@ -33,9 +33,7 @@ class JobMakeCommand extends GeneratorCommand
     {
         $module = $this->laravel['modules'];
 
-        return ($namespace = $module->config('paths.generator.jobs.namespace'))
-            ? $namespace
-            : $module->config('paths.generator.jobs.path', 'Jobs');
+        return $module->config('paths.generator.jobs.namespace') ?: $module->config('paths.generator.jobs.path', 'Jobs');
     }
 
     /**

--- a/src/Commands/JobMakeCommand.php
+++ b/src/Commands/JobMakeCommand.php
@@ -31,7 +31,11 @@ class JobMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace() : string
     {
-        return $this->laravel['modules']->config('paths.generator.jobs.path', 'Jobs');
+        $module = $this->laravel['modules'];
+
+        return ($namespace = $module->config('paths.generator.jobs.namespace'))
+            ? $namespace
+            : $module->config('paths.generator.jobs.path', 'Jobs');
     }
 
     /**

--- a/src/Commands/MailMakeCommand.php
+++ b/src/Commands/MailMakeCommand.php
@@ -32,9 +32,7 @@ class MailMakeCommand extends GeneratorCommand
     {
         $module = $this->laravel['modules'];
 
-        return ($namespace = $module->config('paths.generator.emails.namespace'))
-            ? $namespace
-            : $module->config('paths.generator.emails.path', 'Emails');
+        return $module->config('paths.generator.emails.namespace') ?: $module->config('paths.generator.emails.path', 'Emails');
     }
 
     /**

--- a/src/Commands/MailMakeCommand.php
+++ b/src/Commands/MailMakeCommand.php
@@ -30,7 +30,11 @@ class MailMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace() : string
     {
-        return $this->laravel['modules']->config('paths.generator.emails.path', 'Emails');
+        $module = $this->laravel['modules'];
+
+        return ($namespace = $module->config('paths.generator.emails.namespace'))
+            ? $namespace
+            : $module->config('paths.generator.emails.path', 'Emails');
     }
 
     /**

--- a/src/Commands/MiddlewareMakeCommand.php
+++ b/src/Commands/MiddlewareMakeCommand.php
@@ -35,7 +35,11 @@ class MiddlewareMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace() : string
     {
-        return $this->laravel['modules']->config('paths.generator.filter.path', 'Http/Middleware');
+        $module = $this->laravel['modules'];
+
+        return ($namespace = $module->config('paths.generator.filter.namespace'))
+            ? $namespace
+            : $module->config('paths.generator.filter.path', 'Http/Middleware');
     }
 
     /**

--- a/src/Commands/MiddlewareMakeCommand.php
+++ b/src/Commands/MiddlewareMakeCommand.php
@@ -37,9 +37,7 @@ class MiddlewareMakeCommand extends GeneratorCommand
     {
         $module = $this->laravel['modules'];
 
-        return ($namespace = $module->config('paths.generator.filter.namespace'))
-            ? $namespace
-            : $module->config('paths.generator.filter.path', 'Http/Middleware');
+        return $module->config('paths.generator.filter.namespace') ?: $module->config('paths.generator.filter.path', 'Http/Middleware');
     }
 
     /**

--- a/src/Commands/ModelMakeCommand.php
+++ b/src/Commands/ModelMakeCommand.php
@@ -164,8 +164,6 @@ class ModelMakeCommand extends GeneratorCommand
     {
         $module = $this->laravel['modules'];
 
-        return ($namespace = $module->config('paths.generator.model.namespace'))
-            ? $namespace
-            : $module->config('paths.generator.model.path', 'Entities');
+        return $module->config('paths.generator.model.namespace') ?: $module->config('paths.generator.model.path', 'Entities');
     }
 }

--- a/src/Commands/ModelMakeCommand.php
+++ b/src/Commands/ModelMakeCommand.php
@@ -162,6 +162,10 @@ class ModelMakeCommand extends GeneratorCommand
      */
     public function getDefaultNamespace() : string
     {
-        return $this->laravel['modules']->config('paths.generator.model.path', 'Entities');
+        $module = $this->laravel['modules'];
+
+        return ($namespace = $module->config('paths.generator.model.namespace'))
+            ? $namespace
+            : $module->config('paths.generator.model.path', 'Entities');
     }
 }

--- a/src/Commands/NotificationMakeCommand.php
+++ b/src/Commands/NotificationMakeCommand.php
@@ -32,9 +32,7 @@ final class NotificationMakeCommand extends GeneratorCommand
     {
         $module = $this->laravel['modules'];
 
-        return ($namespace = $module->config('paths.generator.notifications.namespace'))
-            ? $namespace
-            : $module->config('paths.generator.notifications.path', 'Notifications');
+        return $module->config('paths.generator.notifications.namespace') ?: $module->config('paths.generator.notifications.path', 'Notifications');
     }
 
     /**

--- a/src/Commands/NotificationMakeCommand.php
+++ b/src/Commands/NotificationMakeCommand.php
@@ -30,7 +30,11 @@ final class NotificationMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace() : string
     {
-        return $this->laravel['modules']->config('paths.generator.notifications.path', 'Notifications');
+        $module = $this->laravel['modules'];
+
+        return ($namespace = $module->config('paths.generator.notifications.namespace'))
+            ? $namespace
+            : $module->config('paths.generator.notifications.path', 'Notifications');
     }
 
     /**

--- a/src/Commands/PolicyMakeCommand.php
+++ b/src/Commands/PolicyMakeCommand.php
@@ -37,9 +37,7 @@ class PolicyMakeCommand extends GeneratorCommand
     {
         $module = $this->laravel['modules'];
 
-        return ($namespace = $module->config('paths.generator.policies.namespace'))
-            ? $namespace
-            : $module->config('paths.generator.policies.path', 'Policies');
+        return $module->config('paths.generator.policies.namespace') ?: $module->config('paths.generator.policies.path', 'Policies');
     }
 
     /**

--- a/src/Commands/PolicyMakeCommand.php
+++ b/src/Commands/PolicyMakeCommand.php
@@ -35,7 +35,11 @@ class PolicyMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace() : string
     {
-        return $this->laravel['modules']->config('paths.generator.policies.path', 'Policies');
+        $module = $this->laravel['modules'];
+
+        return ($namespace = $module->config('paths.generator.policies.namespace'))
+            ? $namespace
+            : $module->config('paths.generator.policies.path', 'Policies');
     }
 
     /**

--- a/src/Commands/ProviderMakeCommand.php
+++ b/src/Commands/ProviderMakeCommand.php
@@ -37,7 +37,11 @@ class ProviderMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace() : string
     {
-        return $this->laravel['modules']->config('paths.generator.provider.path', 'Providers');
+        $module = $this->laravel['modules'];
+
+        return ($namespace = $module->config('paths.generator.provider.namespace'))
+            ? $namespace
+            : $module->config('paths.generator.provider.path', 'Providers');
     }
 
     /**

--- a/src/Commands/ProviderMakeCommand.php
+++ b/src/Commands/ProviderMakeCommand.php
@@ -39,9 +39,7 @@ class ProviderMakeCommand extends GeneratorCommand
     {
         $module = $this->laravel['modules'];
 
-        return ($namespace = $module->config('paths.generator.provider.namespace'))
-            ? $namespace
-            : $module->config('paths.generator.provider.path', 'Providers');
+        return $module->config('paths.generator.provider.namespace') ?: $module->config('paths.generator.provider.path', 'Providers');
     }
 
     /**

--- a/src/Commands/RequestMakeCommand.php
+++ b/src/Commands/RequestMakeCommand.php
@@ -37,9 +37,7 @@ class RequestMakeCommand extends GeneratorCommand
     {
         $module = $this->laravel['modules'];
 
-        return ($namespace = $module->config('paths.generator.request.namespace'))
-            ? $namespace
-            : $module->config('paths.generator.request.path', 'Http/Requests');
+        return $module->config('paths.generator.request.namespace') ?: $module->config('paths.generator.request.path', 'Http/Requests');
     }
 
     /**

--- a/src/Commands/RequestMakeCommand.php
+++ b/src/Commands/RequestMakeCommand.php
@@ -35,7 +35,11 @@ class RequestMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace() : string
     {
-        return $this->laravel['modules']->config('paths.generator.request.path', 'Http/Requests');
+        $module = $this->laravel['modules'];
+
+        return ($namespace = $module->config('paths.generator.request.namespace'))
+            ? $namespace
+            : $module->config('paths.generator.request.path', 'Http/Requests');
     }
 
     /**

--- a/src/Commands/ResourceMakeCommand.php
+++ b/src/Commands/ResourceMakeCommand.php
@@ -21,9 +21,7 @@ class ResourceMakeCommand extends GeneratorCommand
     {
         $module = $this->laravel['modules'];
 
-        return ($namespace = $module->config('paths.generator.resource.namespace'))
-            ? $namespace
-            : $module->config('paths.generator.resource.path', 'Transformers');
+        return $module->config('paths.generator.resource.namespace') ?: $module->config('paths.generator.resource.path', 'Transformers');
     }
 
     /**

--- a/src/Commands/ResourceMakeCommand.php
+++ b/src/Commands/ResourceMakeCommand.php
@@ -19,7 +19,11 @@ class ResourceMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace() : string
     {
-        return $this->laravel['modules']->config('paths.generator.resource.path', 'Transformers');
+        $module = $this->laravel['modules'];
+
+        return ($namespace = $module->config('paths.generator.resource.namespace'))
+            ? $namespace
+            : $module->config('paths.generator.resource.path', 'Transformers');
     }
 
     /**

--- a/src/Commands/RouteProviderMakeCommand.php
+++ b/src/Commands/RouteProviderMakeCommand.php
@@ -107,6 +107,10 @@ class RouteProviderMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace() : string
     {
-        return $this->laravel['modules']->config('paths.generator.provider.path', 'Providers');
+        $module = $this->laravel['modules'];
+
+        return ($namespace = $module->config('paths.generator.provider.namespace'))
+            ? $namespace
+            : $module->config('paths.generator.provider.path', 'Providers');
     }
 }

--- a/src/Commands/RouteProviderMakeCommand.php
+++ b/src/Commands/RouteProviderMakeCommand.php
@@ -109,8 +109,6 @@ class RouteProviderMakeCommand extends GeneratorCommand
     {
         $module = $this->laravel['modules'];
 
-        return ($namespace = $module->config('paths.generator.provider.namespace'))
-            ? $namespace
-            : $module->config('paths.generator.provider.path', 'Providers');
+        return $module->config('paths.generator.provider.namespace') ?: $module->config('paths.generator.provider.path', 'Providers');
     }
 }

--- a/src/Commands/RuleMakeCommand.php
+++ b/src/Commands/RuleMakeCommand.php
@@ -35,7 +35,11 @@ class RuleMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace() : string
     {
-        return $this->laravel['modules']->config('paths.generator.rules.path', 'Rules');
+        $module = $this->laravel['modules'];
+
+        return ($namespace = $module->config('paths.generator.rules.namespace'))
+            ? $namespace
+            : $module->config('paths.generator.rules.path', 'Rules');
     }
 
     /**

--- a/src/Commands/RuleMakeCommand.php
+++ b/src/Commands/RuleMakeCommand.php
@@ -37,9 +37,7 @@ class RuleMakeCommand extends GeneratorCommand
     {
         $module = $this->laravel['modules'];
 
-        return ($namespace = $module->config('paths.generator.rules.namespace'))
-            ? $namespace
-            : $module->config('paths.generator.rules.path', 'Rules');
+        return $module->config('paths.generator.rules.namespace') ?: $module->config('paths.generator.rules.path', 'Rules');
     }
 
     /**

--- a/src/Commands/SeedCommand.php
+++ b/src/Commands/SeedCommand.php
@@ -159,10 +159,10 @@ class SeedCommand extends Command
         $name = Str::studly($name);
 
         $namespace = $this->laravel['modules']->config('namespace');
-        $seederPath = GenerateConfigReader::read('seeder');
-        $seederPath = str_replace('/', '\\', $seederPath->getPath());
+        $config = GenerateConfigReader::read('seeder');
+        $seederPath = str_replace('/', '\\', $config->getPath());
 
-        return $namespace . '\\' . $name . '\\' . $seederPath . '\\' . $name . 'DatabaseSeeder';
+        return $namespace . '\\' . $name . '\\' . $config->getNamespace() . '\\' . $name . 'DatabaseSeeder';
     }
 
     /**

--- a/src/Commands/SeedMakeCommand.php
+++ b/src/Commands/SeedMakeCommand.php
@@ -110,8 +110,6 @@ class SeedMakeCommand extends GeneratorCommand
     {
         $module = $this->laravel['modules'];
 
-        return ($namespace = $module->config('paths.generator.seeder.namespace'))
-            ? $namespace
-            : $module->config('paths.generator.seeder.path', 'Database/Seeders');
+        return $module->config('paths.generator.seeder.namespace') ?: $module->config('paths.generator.seeder.path', 'Database/Seeders');
     }
 }

--- a/src/Commands/SeedMakeCommand.php
+++ b/src/Commands/SeedMakeCommand.php
@@ -108,6 +108,10 @@ class SeedMakeCommand extends GeneratorCommand
      */
     public function getDefaultNamespace() : string
     {
-        return $this->laravel['modules']->config('paths.generator.seeder.path', 'Database/Seeders');
+        $module = $this->laravel['modules'];
+
+        return ($namespace = $module->config('paths.generator.seeder.namespace'))
+            ? $namespace
+            : $module->config('paths.generator.seeder.path', 'Database/Seeders');
     }
 }

--- a/src/Commands/TestMakeCommand.php
+++ b/src/Commands/TestMakeCommand.php
@@ -22,14 +22,10 @@ class TestMakeCommand extends GeneratorCommand
         $module = $this->laravel['modules'];
 
         if ($this->option('feature')) {
-            return ($namespace = $module->config('paths.generator.test-feature.namespace'))
-                ? $namespace
-                : $module->config('paths.generator.test-feature.path', 'Tests/Feature');
+            return $module->config('paths.generator.test-feature.namespace') ?: $module->config('paths.generator.test-feature.path', 'Tests/Feature');
         }
 
-        return ($namespace = $module->config('paths.generator.test.namespace'))
-            ? $namespace
-            : $module->config('paths.generator.test.path', 'Tests/Unit');
+        return $module->config('paths.generator.test.namespace') ?: $module->config('paths.generator.test.path', 'Tests/Unit');
     }
 
     /**

--- a/src/Commands/TestMakeCommand.php
+++ b/src/Commands/TestMakeCommand.php
@@ -19,10 +19,17 @@ class TestMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace() : string
     {
+        $module = $this->laravel['modules'];
+
         if ($this->option('feature')) {
-            return $this->laravel['modules']->config('paths.generator.test-feature.path', 'Tests/Feature');
+            return ($namespace = $module->config('paths.generator.test-feature.namespace'))
+                ? $namespace
+                : $module->config('paths.generator.test-feature.path', 'Tests/Feature');
         }
-        return $this->laravel['modules']->config('paths.generator.test.path', 'Tests/Unit');
+
+        return ($namespace = $module->config('paths.generator.test.namespace'))
+            ? $namespace
+            : $module->config('paths.generator.test.path', 'Tests/Unit');
     }
 
     /**

--- a/src/Support/Config/GeneratorPath.php
+++ b/src/Support/Config/GeneratorPath.php
@@ -12,11 +12,13 @@ class GeneratorPath
         if (is_array($config)) {
             $this->path = $config['path'];
             $this->generate = $config['generate'];
+            $this->namespace = $config['namespace'] ?? $config['path'];
 
             return;
         }
         $this->path = $config;
         $this->generate = (bool) $config;
+        $this->namespace = $config;
     }
 
     public function getPath()
@@ -27,5 +29,10 @@ class GeneratorPath
     public function generate() : bool
     {
         return $this->generate;
+    }
+
+    public function getNamespace()
+    {
+        return $this->namespace;
     }
 }

--- a/tests/Commands/CommandMakeCommandTest.php
+++ b/tests/Commands/CommandMakeCommandTest.php
@@ -70,4 +70,16 @@ class CommandMakeCommandTest extends BaseTestCase
 
         $this->assertMatchesSnapshot($file);
     }
+
+    /** @test */
+    public function it_can_change_the_default_namespace_specific()
+    {
+        $this->app['config']->set('modules.paths.generator.command.namespace', 'Commands');
+
+        $this->artisan('module:make-command', ['name' => 'AwesomeCommand', 'module' => 'Blog']);
+
+        $file = $this->finder->get($this->modulePath . '/Console/AwesomeCommand.php');
+
+        $this->assertMatchesSnapshot($file);
+    }
 }

--- a/tests/Commands/ControllerMakeCommandTest.php
+++ b/tests/Commands/ControllerMakeCommandTest.php
@@ -108,6 +108,18 @@ class ControllerMakeCommandTest extends BaseTestCase
     }
 
     /** @test */
+    public function it_can_change_the_default_namespace_specific()
+    {
+        $this->app['config']->set('modules.paths.generator.controller.namespace', 'Controllers');
+
+        $this->artisan('module:make-controller', ['controller' => 'MyController', 'module' => 'Blog']);
+
+        $file = $this->finder->get($this->modulePath . '/Http/Controllers/MyController.php');
+
+        $this->assertMatchesSnapshot($file);
+    }
+
+    /** @test */
     public function it_can_generate_a_controller_in_sub_namespace_in_correct_folder()
     {
         $this->artisan('module:make-controller', ['controller' => 'Api\\MyController', 'module' => 'Blog']);

--- a/tests/Commands/EventMakeCommandTest.php
+++ b/tests/Commands/EventMakeCommandTest.php
@@ -61,4 +61,16 @@ class EventMakeCommandTest extends BaseTestCase
 
         $this->assertMatchesSnapshot($file);
     }
+
+    /** @test */
+    public function it_can_change_the_default_namespace_specific()
+    {
+        $this->app['config']->set('modules.paths.generator.event.namespace', 'SuperEvents');
+
+        $this->artisan('module:make-event', ['name' => 'PostWasCreated', 'module' => 'Blog']);
+
+        $file = $this->finder->get($this->modulePath . '/Events/PostWasCreated.php');
+
+        $this->assertMatchesSnapshot($file);
+    }
 }

--- a/tests/Commands/JobMakeCommandTest.php
+++ b/tests/Commands/JobMakeCommandTest.php
@@ -70,4 +70,16 @@ class JobMakeCommandTest extends BaseTestCase
 
         $this->assertMatchesSnapshot($file);
     }
+
+    /** @test */
+    public function it_can_change_the_default_namespace_specific()
+    {
+        $this->app['config']->set('modules.paths.generator.jobs.namespace', 'SuperJobs');
+
+        $this->artisan('module:make-job', ['name' => 'SomeJob', 'module' => 'Blog']);
+
+        $file = $this->finder->get($this->modulePath . '/Jobs/SomeJob.php');
+
+        $this->assertMatchesSnapshot($file);
+    }
 }

--- a/tests/Commands/ListenerMakeCommandTest.php
+++ b/tests/Commands/ListenerMakeCommandTest.php
@@ -109,4 +109,19 @@ class ListenerMakeCommandTest extends BaseTestCase
 
         $this->assertMatchesSnapshot($file);
     }
+
+    /** @test */
+    public function it_can_change_the_default_namespace_specific()
+    {
+        $this->app['config']->set('modules.paths.generator.listener.namespace', 'Events\\Handlers');
+
+        $this->artisan(
+            'module:make-listener',
+            ['name' => 'NotifyUsersOfANewPost', 'module' => 'Blog']
+        );
+
+        $file = $this->finder->get($this->modulePath . '/Listeners/NotifyUsersOfANewPost.php');
+
+        $this->assertMatchesSnapshot($file);
+    }
 }

--- a/tests/Commands/MailMakeCommandTest.php
+++ b/tests/Commands/MailMakeCommandTest.php
@@ -60,4 +60,16 @@ class MailMakeCommandTest extends BaseTestCase
 
         $this->assertMatchesSnapshot($file);
     }
+
+    /** @test */
+    public function it_can_change_the_default_namespace_specific()
+    {
+        $this->app['config']->set('modules.paths.generator.emails.namespace', 'SuperEmails');
+
+        $this->artisan('module:make-mail', ['name' => 'SomeMail', 'module' => 'Blog']);
+
+        $file = $this->finder->get($this->modulePath . '/Emails/SomeMail.php');
+
+        $this->assertMatchesSnapshot($file);
+    }
 }

--- a/tests/Commands/MiddlewareMakeCommandTest.php
+++ b/tests/Commands/MiddlewareMakeCommandTest.php
@@ -60,4 +60,16 @@ class MiddlewareMakeCommandTest extends BaseTestCase
 
         $this->assertMatchesSnapshot($file);
     }
+
+    /** @test */
+    public function it_can_change_the_default_namespace_specific()
+    {
+        $this->app['config']->set('modules.paths.generator.filter.namespace', 'Middleware');
+
+        $this->artisan('module:make-middleware', ['name' => 'SomeMiddleware', 'module' => 'Blog']);
+
+        $file = $this->finder->get($this->modulePath . '/Http/Middleware/SomeMiddleware.php');
+
+        $this->assertMatchesSnapshot($file);
+    }
 }

--- a/tests/Commands/ModelMakeCommandTest.php
+++ b/tests/Commands/ModelMakeCommandTest.php
@@ -117,4 +117,16 @@ class ModelMakeCommandTest extends BaseTestCase
 
         $this->assertMatchesSnapshot($file);
     }
+
+    /** @test */
+    public function it_can_change_the_default_namespace_specific()
+    {
+        $this->app['config']->set('modules.paths.generator.model.namespace', 'Models');
+
+        $this->artisan('module:make-model', ['model' => 'Post', 'module' => 'Blog']);
+
+        $file = $this->finder->get($this->modulePath . '/Entities/Post.php');
+
+        $this->assertMatchesSnapshot($file);
+    }
 }

--- a/tests/Commands/NotificationMakeCommandTest.php
+++ b/tests/Commands/NotificationMakeCommandTest.php
@@ -60,4 +60,16 @@ class NotificationMakeCommandTest extends BaseTestCase
 
         $this->assertMatchesSnapshot($file);
     }
+
+    /** @test */
+    public function it_can_change_the_default_namespace_specific()
+    {
+        $this->app['config']->set('modules.paths.generator.notifications.namespace', 'SuperNotifications');
+
+        $this->artisan('module:make-notification', ['name' => 'WelcomeNotification', 'module' => 'Blog']);
+
+        $file = $this->finder->get($this->modulePath . '/Notifications/WelcomeNotification.php');
+
+        $this->assertMatchesSnapshot($file);
+    }
 }

--- a/tests/Commands/PolicyMakeCommandTest.php
+++ b/tests/Commands/PolicyMakeCommandTest.php
@@ -53,4 +53,16 @@ class PolicyMakeCommandTest extends BaseTestCase
 
         $this->assertMatchesSnapshot($file);
     }
+
+    /** @test */
+    public function it_can_change_the_default_namespace_specific()
+    {
+        $this->app['config']->set('modules.paths.generator.policies.namespace', 'SuperPolicies');
+
+        $this->artisan('module:make-policy', ['name' => 'PostPolicy', 'module' => 'Blog']);
+
+        $file = $this->finder->get($this->modulePath . '/Policies/PostPolicy.php');
+
+        $this->assertMatchesSnapshot($file);
+    }
 }

--- a/tests/Commands/ProviderMakeCommandTest.php
+++ b/tests/Commands/ProviderMakeCommandTest.php
@@ -80,4 +80,16 @@ class ProviderMakeCommandTest extends BaseTestCase
 
         $this->assertMatchesSnapshot($file);
     }
+
+    /** @test */
+    public function it_can_change_the_default_namespace_specific()
+    {
+        $this->app['config']->set('modules.paths.generator.provider.namespace', 'SuperProviders');
+
+        $this->artisan('module:make-provider', ['name' => 'BlogServiceProvider', 'module' => 'Blog', '--master' => true]);
+
+        $file = $this->finder->get($this->modulePath . '/Providers/BlogServiceProvider.php');
+
+        $this->assertMatchesSnapshot($file);
+    }
 }

--- a/tests/Commands/RequestMakeCommandTest.php
+++ b/tests/Commands/RequestMakeCommandTest.php
@@ -60,4 +60,16 @@ class RequestMakeCommandTest extends BaseTestCase
 
         $this->assertMatchesSnapshot($file);
     }
+
+    /** @test */
+    public function it_can_change_the_default_namespace_specific()
+    {
+        $this->app['config']->set('modules.paths.generator.request.namespace', 'SuperRequests');
+
+        $this->artisan('module:make-request', ['name' => 'CreateBlogPostRequest', 'module' => 'Blog']);
+
+        $file = $this->finder->get($this->modulePath . '/Http/Requests/CreateBlogPostRequest.php');
+
+        $this->assertMatchesSnapshot($file);
+    }
 }

--- a/tests/Commands/ResourceMakeCommandTest.php
+++ b/tests/Commands/ResourceMakeCommandTest.php
@@ -70,4 +70,16 @@ class ResourceMakeCommandTest extends BaseTestCase
 
         $this->assertMatchesSnapshot($file);
     }
+
+    /** @test */
+    public function it_can_change_the_default_namespace_specific()
+    {
+        $this->app['config']->set('modules.paths.generator.resource.namespace', 'Http\\Resources');
+
+        $this->artisan('module:make-resource', ['name' => 'PostsTransformer', 'module' => 'Blog', '--collection' => true]);
+
+        $file = $this->finder->get($this->modulePath . '/Transformers/PostsTransformer.php');
+
+        $this->assertMatchesSnapshot($file);
+    }
 }

--- a/tests/Commands/RouteProviderMakeCommandTest.php
+++ b/tests/Commands/RouteProviderMakeCommandTest.php
@@ -62,6 +62,18 @@ class RouteProviderMakeCommandTest extends BaseTestCase
     }
 
     /** @test */
+    public function it_can_change_the_default_namespace_specific()
+    {
+        $this->app['config']->set('modules.paths.generator.provider.namespace', 'SuperProviders');
+
+        $this->artisan('module:route-provider', ['module' => 'Blog']);
+
+        $file = $this->finder->get($this->modulePath . '/Providers/RouteServiceProvider.php');
+
+        $this->assertMatchesSnapshot($file);
+    }
+
+    /** @test */
     public function it_can_overwrite_route_file_names()
     {
         $this->app['config']->set('modules.stubs.files.routes/web', 'SuperRoutes/web.php');

--- a/tests/Commands/RuleMakeCommandTest.php
+++ b/tests/Commands/RuleMakeCommandTest.php
@@ -53,4 +53,16 @@ class RuleMakeCommandTest extends BaseTestCase
 
         $this->assertMatchesSnapshot($file);
     }
+
+    /** @test */
+    public function it_can_change_the_default_namespace_specific()
+    {
+        $this->app['config']->set('modules.paths.generator.rules.namespace', 'SuperRules');
+
+        $this->artisan('module:make-rule', ['name' => 'UniqueRule', 'module' => 'Blog']);
+
+        $file = $this->finder->get($this->modulePath . '/Rules/UniqueRule.php');
+
+        $this->assertMatchesSnapshot($file);
+    }
 }

--- a/tests/Commands/TestMakeCommandTest.php
+++ b/tests/Commands/TestMakeCommandTest.php
@@ -74,6 +74,18 @@ class TestMakeCommandTest extends BaseTestCase
     }
 
     /** @test */
+    public function it_can_change_the_default_unit_namespace_specific()
+    {
+        $this->app['config']->set('modules.paths.generator.test.namespace', 'SuperTests\\Unit');
+
+        $this->artisan('module:make-test', ['name' => 'EloquentPostRepositoryTest', 'module' => 'Blog']);
+
+        $file = $this->finder->get($this->modulePath . '/Tests/Unit/EloquentPostRepositoryTest.php');
+
+        $this->assertMatchesSnapshot($file);
+    }
+
+    /** @test */
     public function it_can_change_the_default_feature_namespace()
     {
         $this->app['config']->set('modules.paths.generator.test-feature.path', 'SuperTests/Feature');
@@ -81,6 +93,18 @@ class TestMakeCommandTest extends BaseTestCase
         $this->artisan('module:make-test', ['name' => 'EloquentPostRepositoryTest', 'module' => 'Blog', '--feature' => true]);
 
         $file = $this->finder->get($this->modulePath . '/SuperTests/Feature/EloquentPostRepositoryTest.php');
+
+        $this->assertMatchesSnapshot($file);
+    }
+
+    /** @test */
+    public function it_can_change_the_default_feature_namespace_specific()
+    {
+        $this->app['config']->set('modules.paths.generator.test-feature.namespace', 'SuperTests\\Feature');
+
+        $this->artisan('module:make-test', ['name' => 'EloquentPostRepositoryTest', 'module' => 'Blog', '--feature' => true]);
+
+        $file = $this->finder->get($this->modulePath . '/Tests/Feature/EloquentPostRepositoryTest.php');
 
         $this->assertMatchesSnapshot($file);
     }

--- a/tests/Commands/__snapshots__/CommandMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
+++ b/tests/Commands/__snapshots__/CommandMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
@@ -1,0 +1,69 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\Commands;
+
+use Illuminate\\Console\\Command;
+use Symfony\\Component\\Console\\Input\\InputOption;
+use Symfony\\Component\\Console\\Input\\InputArgument;
+
+class AwesomeCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = \'command:name\';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = \'Command description.\';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        //
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            [\'example\', InputArgument::REQUIRED, \'An example argument.\'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            [\'example\', null, InputOption::VALUE_OPTIONAL, \'An example option.\', null],
+        ];
+    }
+}
+';

--- a/tests/Commands/__snapshots__/ControllerMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
+++ b/tests/Commands/__snapshots__/ControllerMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
@@ -1,0 +1,80 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\Controllers;
+
+use Illuminate\\Http\\Request;
+use Illuminate\\Http\\Response;
+use Illuminate\\Routing\\Controller;
+
+class MyController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     * @return Response
+     */
+    public function index()
+    {
+        return view(\'blog::index\');
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     * @return Response
+     */
+    public function create()
+    {
+        return view(\'blog::create\');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     * @param Request $request
+     * @return Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Show the specified resource.
+     * @param int $id
+     * @return Response
+     */
+    public function show($id)
+    {
+        return view(\'blog::show\');
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     * @param int $id
+     * @return Response
+     */
+    public function edit($id)
+    {
+        return view(\'blog::edit\');
+    }
+
+    /**
+     * Update the specified resource in storage.
+     * @param Request $request
+     * @param int $id
+     * @return Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     * @param int $id
+     * @return Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}
+';

--- a/tests/Commands/__snapshots__/EventMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
+++ b/tests/Commands/__snapshots__/EventMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
@@ -1,0 +1,31 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\SuperEvents;
+
+use Illuminate\\Queue\\SerializesModels;
+
+class PostWasCreated
+{
+    use SerializesModels;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the channels the event should be broadcast on.
+     *
+     * @return array
+     */
+    public function broadcastOn()
+    {
+        return [];
+    }
+}
+';

--- a/tests/Commands/__snapshots__/JobMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
+++ b/tests/Commands/__snapshots__/JobMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
@@ -1,0 +1,35 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\SuperJobs;
+
+use Illuminate\\Bus\\Queueable;
+use Illuminate\\Queue\\SerializesModels;
+use Illuminate\\Queue\\InteractsWithQueue;
+use Illuminate\\Contracts\\Queue\\ShouldQueue;
+use Illuminate\\Foundation\\Bus\\Dispatchable;
+
+class SomeJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        //
+    }
+}
+';

--- a/tests/Commands/__snapshots__/ListenerMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
+++ b/tests/Commands/__snapshots__/ListenerMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
@@ -1,0 +1,31 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\Listeners;
+
+use Illuminate\\Queue\\InteractsWithQueue;
+use Illuminate\\Contracts\\Queue\\ShouldQueue;
+
+class NotifyUsersOfANewPost
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  object  $event
+     * @return void
+     */
+    public function handle($event)
+    {
+        //
+    }
+}
+';

--- a/tests/Commands/__snapshots__/MailMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
+++ b/tests/Commands/__snapshots__/MailMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
@@ -1,0 +1,34 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\SuperEmails;
+
+use Illuminate\\Bus\\Queueable;
+use Illuminate\\Mail\\Mailable;
+use Illuminate\\Queue\\SerializesModels;
+use Illuminate\\Contracts\\Queue\\ShouldQueue;
+
+class SomeMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->view(\'view.name\');
+    }
+}
+';

--- a/tests/Commands/__snapshots__/MiddlewareMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
+++ b/tests/Commands/__snapshots__/MiddlewareMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
@@ -1,0 +1,22 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\Middleware;
+
+use Closure;
+use Illuminate\\Http\\Request;
+
+class SomeMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \\Illuminate\\Http\\Request  $request
+     * @param  \\Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        return $next($request);
+    }
+}
+';

--- a/tests/Commands/__snapshots__/ModelMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
+++ b/tests/Commands/__snapshots__/ModelMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
@@ -1,0 +1,11 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\Models;
+
+use Illuminate\\Database\\Eloquent\\Model;
+
+class Post extends Model
+{
+    protected $fillable = [];
+}
+';

--- a/tests/Commands/__snapshots__/NotificationMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
+++ b/tests/Commands/__snapshots__/NotificationMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
@@ -1,0 +1,62 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\SuperNotifications;
+
+use Illuminate\\Bus\\Queueable;
+use Illuminate\\Notifications\\Notification;
+use Illuminate\\Contracts\\Queue\\ShouldQueue;
+use Illuminate\\Notifications\\Messages\\MailMessage;
+
+class WelcomeNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the notification\'s delivery channels.
+     *
+     * @param mixed $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return [\'mail\'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param mixed $notifiable
+     * @return \\Illuminate\\Notifications\\Messages\\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+                    ->line(\'The introduction to the notification.\')
+                    ->action(\'Notification Action\', \'https://laravel.com\')
+                    ->line(\'Thank you for using our application!\');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param mixed $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            //
+        ];
+    }
+}
+';

--- a/tests/Commands/__snapshots__/PolicyMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
+++ b/tests/Commands/__snapshots__/PolicyMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
@@ -1,0 +1,21 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\SuperPolicies;
+
+use Illuminate\\Auth\\Access\\HandlesAuthorization;
+
+class PostPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Create a new policy instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+}
+';

--- a/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
+++ b/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
@@ -1,0 +1,107 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\SuperProviders;
+
+use Illuminate\\Support\\ServiceProvider;
+use Illuminate\\Database\\Eloquent\\Factory;
+
+class BlogServiceProvider extends ServiceProvider
+{
+    /**
+     * Boot the application events.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->registerTranslations();
+        $this->registerConfig();
+        $this->registerViews();
+        $this->registerFactories();
+        $this->loadMigrationsFrom(__DIR__ . \'/../Database/Migrations\');
+    }
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->register(RouteServiceProvider::class);
+    }
+
+    /**
+     * Register config.
+     *
+     * @return void
+     */
+    protected function registerConfig()
+    {
+        $this->publishes([
+            __DIR__.\'/../Config/config.php\' => config_path(\'blog.php\'),
+        ], \'config\');
+        $this->mergeConfigFrom(
+            __DIR__.\'/../Config/config.php\', \'blog\'
+        );
+    }
+
+    /**
+     * Register views.
+     *
+     * @return void
+     */
+    public function registerViews()
+    {
+        $viewPath = resource_path(\'views/modules/blog\');
+
+        $sourcePath = __DIR__.\'/../Resources/views\';
+
+        $this->publishes([
+            $sourcePath => $viewPath
+        ],\'views\');
+
+        $this->loadViewsFrom(array_merge(array_map(function ($path) {
+            return $path . \'/modules/blog\';
+        }, \\Config::get(\'view.paths\')), [$sourcePath]), \'blog\');
+    }
+
+    /**
+     * Register translations.
+     *
+     * @return void
+     */
+    public function registerTranslations()
+    {
+        $langPath = resource_path(\'lang/modules/blog\');
+
+        if (is_dir($langPath)) {
+            $this->loadTranslationsFrom($langPath, \'blog\');
+        } else {
+            $this->loadTranslationsFrom(__DIR__ .\'/../Resources/lang\', \'blog\');
+        }
+    }
+
+    /**
+     * Register an additional directory of factories.
+     *
+     * @return void
+     */
+    public function registerFactories()
+    {
+        if (! app()->environment(\'production\') && $this->app->runningInConsole()) {
+            app(Factory::class)->load(__DIR__ . \'/../Database/factories\');
+        }
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return [];
+    }
+}
+';

--- a/tests/Commands/__snapshots__/RequestMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
+++ b/tests/Commands/__snapshots__/RequestMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
@@ -1,0 +1,31 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\SuperRequests;
+
+use Illuminate\\Foundation\\Http\\FormRequest;
+
+class CreateBlogPostRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+}
+';

--- a/tests/Commands/__snapshots__/ResourceMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
+++ b/tests/Commands/__snapshots__/ResourceMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
@@ -1,0 +1,20 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\Http\\Resources;
+
+use Illuminate\\Http\\Resources\\Json\\ResourceCollection;
+
+class PostsTransformer extends ResourceCollection
+{
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  \\Illuminate\\Http\\Request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return parent::toArray($request);
+    }
+}
+';

--- a/tests/Commands/__snapshots__/RouteProviderMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
+++ b/tests/Commands/__snapshots__/RouteProviderMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
@@ -1,0 +1,70 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\Providers;
+
+use Illuminate\\Support\\Facades\\Route;
+use Illuminate\\Foundation\\Support\\Providers\\RouteServiceProvider as ServiceProvider;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    /**
+     * The module namespace to assume when generating URLs to actions.
+     *
+     * @var string
+     */
+    protected $moduleNamespace = \'Modules\\Blog\\Http\\Controllers\';
+
+    /**
+     * Called before routes are registered.
+     *
+     * Register any model bindings or pattern based filters.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        parent::boot();
+    }
+
+    /**
+     * Define the routes for the application.
+     *
+     * @return void
+     */
+    public function map()
+    {
+        $this->mapApiRoutes();
+
+        $this->mapWebRoutes();
+    }
+
+    /**
+     * Define the "web" routes for the application.
+     *
+     * These routes all receive session state, CSRF protection, etc.
+     *
+     * @return void
+     */
+    protected function mapWebRoutes()
+    {
+        Route::middleware(\'web\')
+            ->namespace($this->moduleNamespace)
+            ->group(__DIR__ . \'/../Routes/web.php\');
+    }
+
+    /**
+     * Define the "api" routes for the application.
+     *
+     * These routes are typically stateless.
+     *
+     * @return void
+     */
+    protected function mapApiRoutes()
+    {
+        Route::prefix(\'api\')
+            ->middleware(\'api\')
+            ->namespace($this->moduleNamespace)
+            ->group(__DIR__ . \'/../Routes/api.php\');
+    }
+}
+';

--- a/tests/Commands/__snapshots__/RuleMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
+++ b/tests/Commands/__snapshots__/RuleMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
@@ -1,0 +1,41 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\SuperRules;
+
+use Illuminate\\Contracts\\Validation\\Rule;
+
+class UniqueRule implements Rule
+{
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        //
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return \'The validation error message.\';
+    }
+}
+';

--- a/tests/Commands/__snapshots__/TestMakeCommandTest__it_can_change_the_default_feature_namespace_specific__1.php
+++ b/tests/Commands/__snapshots__/TestMakeCommandTest__it_can_change_the_default_feature_namespace_specific__1.php
@@ -1,0 +1,23 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\SuperTests\\Feature;
+
+use Tests\\TestCase;
+use Illuminate\\Foundation\\Testing\\WithFaker;
+use Illuminate\\Foundation\\Testing\\RefreshDatabase;
+
+class EloquentPostRepositoryTest extends TestCase
+{
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+    public function testExample()
+    {
+        $response = $this->get(\'/\');
+
+        $response->assertStatus(200);
+    }
+}
+';

--- a/tests/Commands/__snapshots__/TestMakeCommandTest__it_can_change_the_default_unit_namespace_specific__1.php
+++ b/tests/Commands/__snapshots__/TestMakeCommandTest__it_can_change_the_default_unit_namespace_specific__1.php
@@ -1,0 +1,21 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\SuperTests\\Unit;
+
+use Tests\\TestCase;
+use Illuminate\\Foundation\\Testing\\WithFaker;
+use Illuminate\\Foundation\\Testing\\RefreshDatabase;
+
+class EloquentPostRepositoryTest extends TestCase
+{
+    /**
+     * A basic unit test example.
+     *
+     * @return void
+     */
+    public function testExample()
+    {
+        $this->assertTrue(true);
+    }
+}
+';


### PR DESCRIPTION
We could add a third option inside **paths.generator.{alias}** to have `namespace`

When adding parent folder, as part of the `path`, the current behaviour uses the `path` as well as the namespace, there is no way for us to easily provide the namespace, or else we are REQUIRED to extends the commands and modify the laravel module's ConsoleServiceProvider and the booted Provider.

What I could suggest is to add a 3rd parameter as `optional`, so there is no breaking change @nWidart 

```
[
    'path' => 'src/Providers',
    'generate' => true,
    'namespace' => 'Providers',
]
```

---

Example modules that I have and their structure

![image](https://user-images.githubusercontent.com/4581415/60700690-5e89a580-9f2b-11e9-88a8-416c6b44cdf2.png)