### PR TITLE
Update SchemaParser.php

### DIFF
--- a/src/Support/Migrations/SchemaParser.php
+++ b/src/Support/Migrations/SchemaParser.php
@@ -170,11 +170,19 @@ class SchemaParser implements Arrayable
      */
     protected function addRelationColumn($key, $field, $column)
     {
-        $relatedColumn = Str::snake(class_basename($field)) . '_id';
-
-        $method = 'integer';
-
-        return "->{$method}('{$relatedColumn}')";
+        if($key == 0) {
+            $relatedColumn = snake_case(class_basename($field)) . '_id';
+            return "->integer('{$relatedColumn}')->unsigned();".PHP_EOL."\t\t\t" . "\$table->foreign('{$relatedColumn}')";
+        } elseif ($key == 1) {
+            return "->references('{$field}')";
+        } elseif ($key == 2) {
+            return "->on('{$field}')";
+        } else {
+            if (str_contains($field, '(')) {
+                return '->' . $field;
+            }
+            return '->' . $field . '()';
+        }
     }
 
     /**


### PR DESCRIPTION
Support a Foreign Key Constraints ([https://laravel.com/docs/5.8/migrations#foreign-key-constraints](https://laravel.com/docs/5.8/migrations#foreign-key-constraints)), use --fields=belongsTo: foreign: references: on.

Exemple: 
Command: `php artisan module:make-migration create_test_table --fields=belongsTo:user:id:users`
Result:
```
Schema::create('test', function (Blueprint $table) {
        $table->increments('id');

        $table->integer('user_id')->unsigned();
	$table->foreign('user_id')->references('id')->on('users');

        $table->timestamps();
});
```