### PR TITLE
Support a Foreign Key Constraints

### DIFF
--- a/src/Support/Migrations/SchemaParser.php
+++ b/src/Support/Migrations/SchemaParser.php
@@ -170,11 +170,19 @@ class SchemaParser implements Arrayable
      */
     protected function addRelationColumn($key, $field, $column)
     {
-        $relatedColumn = Str::snake(class_basename($field)) . '_id';
-
-        $method = 'integer';
-
-        return "->{$method}('{$relatedColumn}')";
+        if($key == 0) {
+            $relatedColumn = snake_case(class_basename($field)) . '_id';
+            return "->integer('{$relatedColumn}')->unsigned();".PHP_EOL."\t\t\t" . "\$table->foreign('{$relatedColumn}')";
+        } elseif ($key == 1) {
+            return "->references('{$field}')";
+        } elseif ($key == 2) {
+            return "->on('{$field}')";
+        } else {
+            if (str_contains($field, '(')) {
+                return '->' . $field;
+            }
+            return '->' . $field . '()';
+        }
     }
 
     /**

--- a/tests/Commands/MigrationMakeCommandTest.php
+++ b/tests/Commands/MigrationMakeCommandTest.php
@@ -100,4 +100,17 @@ class MigrationMakeCommandTest extends BaseTestCase
 
         $this->assertMatchesSnapshot($file);
     }
+    
+    
+    /** @test */
+    public function it_generates_foreign_key_constraints()
+    {
+        $this->artisan('module:make-migration', ['name' => 'create_posts_table', 'module' => 'Blog', '--fields' => 'belongsTo:user:id:users']);
+
+        $migrations = $this->finder->allFiles($this->modulePath . '/Database/Migrations');
+        $fileName = $migrations[0]->getRelativePathname();
+        $file = $this->finder->get($this->modulePath . '/Database/Migrations/' . $fileName);
+
+        $this->assertMatchesSnapshot($file);
+    }
 }

--- a/tests/Commands/__snapshots__/MigrationMakeCommandTest__it_generates_foreign_key_constraints__1.php
+++ b/tests/Commands/__snapshots__/MigrationMakeCommandTest__it_generates_foreign_key_constraints__1.php
@@ -1,0 +1,35 @@
+<?php return '<?php
+
+use Illuminate\\Support\\Facades\\Schema;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Database\\Migrations\\Migration;
+
+class CreatePostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create(\'posts\', function (Blueprint $table) {
+            $table->bigIncrements(\'id\');
+			$table->integer(\'user_id\')->unsigned();
+			$table->foreign(\'user_id\')->references(\'id\')->on(\'users\');
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists(\'posts\');
+    }
+}
+';


### PR DESCRIPTION
Support a Foreign Key Constraints (https://laravel.com/docs/5.8/migrations#foreign-key-constraints), use --fields=belongsTo: foreign: references: on.

Exemple:
Command: ```php artisan module:make-migration create_post_table --fields=belongsTo:user:id:users```

Result:
```
Schema::create('post', function (Blueprint $table) {
        $table->increments('id');

        $table->integer('user_id')->unsigned();
	$table->foreign('user_id')->references('id')->on('users');

        $table->timestamps();
});
```