### PR TITLE
Change the fileactivator status file path

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -201,7 +201,7 @@ return [
     'activators' => [
         'file' => [
             'class' => FileActivator::class,
-            'statuses-file' => storage_path('modules_statuses.json'),
+            'statuses-file' => storage_path('app/modules_statuses.json'),
             'cache-key' => 'activator.installed',
             'cache-lifetime' => 604800,
         ],


### PR DESCRIPTION
Change the default path for the statuses file for the FileActivator to the `app` folder in the storage folder. This to keep the application's storage folder clean.

Point of discussion; maybe add modules folder in storage and include files like this in there? The files app folder get git ignored by default.