### PR TITLE
Fix codestyle of path helpers and extend the module_path helper

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,11 +1,11 @@
 <?php
 
 if (! function_exists('module_path')) {
-    function module_path($name)
+    function module_path($name, $path = '')
     {
         $module = app('modules')->find($name);
 
-        return $module->getPath();
+        return $module->getPath().($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -18,7 +18,7 @@ if (! function_exists('config_path')) {
      */
     function config_path($path = '')
     {
-        return app()->basePath() . '/config' . ($path ? '/' . $path : $path);
+        return app()->basePath().'/config'.($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 }
 
@@ -31,6 +31,6 @@ if (! function_exists('public_path')) {
      */
     function public_path($path = '')
     {
-        return app()->make('path.public') . ($path ? DIRECTORY_SEPARATOR . ltrim($path, DIRECTORY_SEPARATOR) : $path);
+        return app()->make('path.public').($path ? DIRECTORY_SEPARATOR.ltrim($path, DIRECTORY_SEPARATOR) : $path);
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -5,7 +5,7 @@ if (! function_exists('module_path')) {
     {
         $module = app('modules')->find($name);
 
-        return $module->getPath().($path ? DIRECTORY_SEPARATOR.$path : $path);
+        return $module->getPath() . ($path ? DIRECTORY_SEPARATOR . $path : $path);
     }
 }
 
@@ -18,7 +18,7 @@ if (! function_exists('config_path')) {
      */
     function config_path($path = '')
     {
-        return app()->basePath().'/config'.($path ? DIRECTORY_SEPARATOR.$path : $path);
+        return app()->basePath() . '/config' . ($path ? DIRECTORY_SEPARATOR . $path : $path);
     }
 }
 
@@ -31,6 +31,6 @@ if (! function_exists('public_path')) {
      */
     function public_path($path = '')
     {
-        return app()->make('path.public').($path ? DIRECTORY_SEPARATOR.ltrim($path, DIRECTORY_SEPARATOR) : $path);
+        return app()->make('path.public') . ($path ? DIRECTORY_SEPARATOR . ltrim($path, DIRECTORY_SEPARATOR) : $path);
     }
 }

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -34,4 +34,10 @@ class HelpersTest extends BaseTestCase
     {
         $this->assertTrue(Str::contains(module_path('Blog'), 'modules/Blog'));
     }
+
+    /** @test */
+    public function it_can_bind_a_relative_path_to_module_path()
+    {
+        $this->assertTrue(Str::contains(module_path('Blog', 'config/config.php'), 'modules/Blog/config/config.php'));
+    }
 }


### PR DESCRIPTION
Extends the module_path helper with an optional $path parameter to be able to parse a relative path together with the module path. I.E.:

```
$myModuleConfig = module_path('MyModule', 'config/config.php');
```

And fix the codestyle of the other path helpers.