### PR TITLE
[IMPLEMENT] replace controller namespace in provider stub when you us…

### DIFF
--- a/src/Commands/RouteProviderMakeCommand.php
+++ b/src/Commands/RouteProviderMakeCommand.php
@@ -57,13 +57,14 @@ class RouteProviderMakeCommand extends GeneratorCommand
         $module = $this->laravel['modules']->findOrFail($this->getModuleName());
 
         return (new Stub('/route-provider.stub', [
-            'NAMESPACE'        => $this->getClassNamespace($module),
-            'CLASS'            => $this->getFileName(),
-            'MODULE_NAMESPACE' => $this->laravel['modules']->config('namespace'),
-            'MODULE'           => $this->getModuleName(),
-            'WEB_ROUTES_PATH'  => $this->getWebRoutesPath(),
-            'API_ROUTES_PATH'  => $this->getApiRoutesPath(),
-            'LOWER_NAME'       => $module->getLowerName(),
+            'NAMESPACE'            => $this->getClassNamespace($module),
+            'CLASS'                => $this->getFileName(),
+            'MODULE_NAMESPACE'     => $this->laravel['modules']->config('namespace'),
+            'MODULE'               => $this->getModuleName(),
+            'CONTROLLER_NAMESPACE' => $this->getControllerNameSpace(),
+            'WEB_ROUTES_PATH'      => $this->getWebRoutesPath(),
+            'API_ROUTES_PATH'      => $this->getApiRoutesPath(),
+            'LOWER_NAME'           => $module->getLowerName(),
         ]))->render();
     }
 
@@ -110,5 +111,14 @@ class RouteProviderMakeCommand extends GeneratorCommand
         $module = $this->laravel['modules'];
 
         return $module->config('paths.generator.provider.namespace') ?: $module->config('paths.generator.provider.path', 'Providers');
+    }
+
+    /**
+     * @return string
+     */
+    private function getControllerNameSpace(): string
+    {
+        $module = $this->laravel['modules'];
+        return str_replace('/', '\\', $module->config('paths.generator.controller.namespace') ?: $module->config('paths.generator.controller.path', 'Controller'));
     }
 }

--- a/src/Commands/stubs/route-provider.stub
+++ b/src/Commands/stubs/route-provider.stub
@@ -12,7 +12,7 @@ class $CLASS$ extends ServiceProvider
      *
      * @var string
      */
-    protected $moduleNamespace = '$MODULE_NAMESPACE$\$MODULE$\Http\Controllers';
+    protected $moduleNamespace = '$MODULE_NAMESPACE$\$MODULE$\$CONTROLLER_NAMESPACE$';
 
     /**
      * Called before routes are registered.

--- a/tests/Commands/RouteProviderMakeCommandTest.php
+++ b/tests/Commands/RouteProviderMakeCommandTest.php
@@ -98,4 +98,18 @@ class RouteProviderMakeCommandTest extends BaseTestCase
 
         $this->assertMatchesSnapshot($file);
     }
+
+    /** @test */
+    public function it_can_change_the_custom_controller_namespace(): void
+    {
+        $this->app['config']->set('modules.paths.generator.controller.path', 'app/Http/Controllers');
+        $this->app['config']->set('modules.paths.generator.controller.namespace', 'App\Http\Controllers');
+        $this->app['config']->set('modules.paths.generator.provider.path', 'app/Providers');
+        $this->app['config']->set('modules.paths.generator.provider.namespace', 'Providers');
+        $this->artisan('module:route-provider', ['module' => 'Blog']);
+
+        $file = $this->finder->get($this->modulePath . '/app/Providers/RouteServiceProvider.php');
+
+        $this->assertMatchesSnapshot($file);
+    }
 }

--- a/tests/Commands/__snapshots__/RouteProviderMakeCommandTest__it_can_change_the_custom_controller_namespace__1.php
+++ b/tests/Commands/__snapshots__/RouteProviderMakeCommandTest__it_can_change_the_custom_controller_namespace__1.php
@@ -1,0 +1,70 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\Providers;
+
+use Illuminate\\Support\\Facades\\Route;
+use Illuminate\\Foundation\\Support\\Providers\\RouteServiceProvider as ServiceProvider;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    /**
+     * The module namespace to assume when generating URLs to actions.
+     *
+     * @var string
+     */
+    protected $moduleNamespace = \'Modules\\Blog\\App\\Http\\Controllers\';
+
+    /**
+     * Called before routes are registered.
+     *
+     * Register any model bindings or pattern based filters.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        parent::boot();
+    }
+
+    /**
+     * Define the routes for the application.
+     *
+     * @return void
+     */
+    public function map()
+    {
+        $this->mapApiRoutes();
+
+        $this->mapWebRoutes();
+    }
+
+    /**
+     * Define the "web" routes for the application.
+     *
+     * These routes all receive session state, CSRF protection, etc.
+     *
+     * @return void
+     */
+    protected function mapWebRoutes()
+    {
+        Route::middleware(\'web\')
+            ->namespace($this->moduleNamespace)
+            ->group(module_path(\'Blog\', \'/Routes/web.php\'));
+    }
+
+    /**
+     * Define the "api" routes for the application.
+     *
+     * These routes are typically stateless.
+     *
+     * @return void
+     */
+    protected function mapApiRoutes()
+    {
+        Route::prefix(\'api\')
+            ->middleware(\'api\')
+            ->namespace($this->moduleNamespace)
+            ->group(module_path(\'Blog\', \'/Routes/api.php\'));
+    }
+}
+';


### PR DESCRIPTION
Dear Sir,
I make a PR for the replacement controller namespace in the provider stub.
Example:
I make a blog module with the custom path and namespace of the controller such as ```App/Https/Controller```. 
In order, The module namespace of controller in provider must be
```Modules\Blog\App\Http\Controllers```