### PR TITLE
Make properties of frequently used scaffolding placeholders

### DIFF
--- a/src/Commands/stubs/scaffold/provider.stub
+++ b/src/Commands/stubs/scaffold/provider.stub
@@ -8,6 +8,16 @@ use Illuminate\Database\Eloquent\Factory;
 class $CLASS$ extends ServiceProvider
 {
     /**
+     * @var string $moduleName
+     */
+    protected $moduleName = '$MODULE$';
+
+    /**
+     * @var string $moduleNameLower
+     */
+    protected $moduleNameLower = '$LOWER_NAME$';
+
+    /**
      * Boot the application events.
      *
      * @return void
@@ -18,7 +28,7 @@ class $CLASS$ extends ServiceProvider
         $this->registerConfig();
         $this->registerViews();
         $this->registerFactories();
-        $this->loadMigrationsFrom(module_path('$MODULE$', '$MIGRATIONS_PATH$'));
+        $this->loadMigrationsFrom(module_path($this->moduleName, '$MIGRATIONS_PATH$'));
     }
 
     /**
@@ -39,10 +49,10 @@ class $CLASS$ extends ServiceProvider
     protected function registerConfig()
     {
         $this->publishes([
-            module_path('$MODULE$', '$PATH_CONFIG$/config.php') => config_path('$LOWER_NAME$.php'),
+            module_path($this->moduleName, '$PATH_CONFIG$/config.php') => config_path($this->moduleNameLower . '.php'),
         ], 'config');
         $this->mergeConfigFrom(
-            module_path('$MODULE$', '$PATH_CONFIG$/config.php'), '$LOWER_NAME$'
+            module_path($this->moduleName, '$PATH_CONFIG$/config.php'), $this->moduleNameLower
         );
     }
 
@@ -53,15 +63,15 @@ class $CLASS$ extends ServiceProvider
      */
     public function registerViews()
     {
-        $viewPath = resource_path('views/modules/$LOWER_NAME$');
+        $viewPath = resource_path('views/modules/' . $this->moduleNameLower);
 
-        $sourcePath = module_path('$MODULE$', '$PATH_VIEWS$');
+        $sourcePath = module_path($this->moduleName, '$PATH_VIEWS$');
 
         $this->publishes([
             $sourcePath => $viewPath
-        ], ['views', '$LOWER_NAME$-module-views']);
+        ], ['views', $this->moduleNameLower . '-module-views']);
 
-        $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), '$LOWER_NAME$');
+        $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
     }
 
     /**
@@ -71,12 +81,12 @@ class $CLASS$ extends ServiceProvider
      */
     public function registerTranslations()
     {
-        $langPath = resource_path('lang/modules/$LOWER_NAME$');
+        $langPath = resource_path('lang/modules/' . $this->moduleNameLower);
 
         if (is_dir($langPath)) {
-            $this->loadTranslationsFrom($langPath, '$LOWER_NAME$');
+            $this->loadTranslationsFrom($langPath, $this->moduleNameLower);
         } else {
-            $this->loadTranslationsFrom(module_path('$MODULE$', '$PATH_LANG$'), '$LOWER_NAME$');
+            $this->loadTranslationsFrom(module_path($this->moduleName, '$PATH_LANG$'), $this->moduleNameLower);
         }
     }
 
@@ -88,7 +98,7 @@ class $CLASS$ extends ServiceProvider
     public function registerFactories()
     {
         if (! app()->environment('production') && $this->app->runningInConsole()) {
-            app(Factory::class)->load(module_path('$MODULE$', '$FACTORIES_PATH$'));
+            app(Factory::class)->load(module_path($this->moduleName, '$FACTORIES_PATH$'));
         }
     }
 
@@ -106,8 +116,8 @@ class $CLASS$ extends ServiceProvider
     {
         $paths = [];
         foreach (\Config::get('view.paths') as $path) {
-            if (is_dir($path . '/modules/$LOWER_NAME$')) {
-                $paths[] = $path . '/modules/$LOWER_NAME$';
+            if (is_dir($path . '/modules/' . $this->moduleNameLower)) {
+                $paths[] = $path . '/modules/' . $this->moduleNameLower;
             }
         }
         return $paths;

--- a/tests/Activators/__snapshots__/FileActivatorTest__it_creates_valid_json_file_after_disabling__1.php
+++ b/tests/Activators/__snapshots__/FileActivatorTest__it_creates_valid_json_file_after_disabling__1.php
@@ -1,5 +1,3 @@
-<?php
-
-return '{
+<?php return '{
     "Recipe": false
 }';

--- a/tests/Activators/__snapshots__/FileActivatorTest__it_creates_valid_json_file_after_disabling__2.php
+++ b/tests/Activators/__snapshots__/FileActivatorTest__it_creates_valid_json_file_after_disabling__2.php
@@ -1,5 +1,3 @@
-<?php
-
-return '{
+<?php return '{
     "Recipe": false
 }';

--- a/tests/Activators/__snapshots__/FileActivatorTest__it_creates_valid_json_file_after_enabling__1.php
+++ b/tests/Activators/__snapshots__/FileActivatorTest__it_creates_valid_json_file_after_enabling__1.php
@@ -1,5 +1,3 @@
-<?php
-
-return '{
+<?php return '{
     "Recipe": true
 }';

--- a/tests/Activators/__snapshots__/FileActivatorTest__it_creates_valid_json_file_after_enabling__2.php
+++ b/tests/Activators/__snapshots__/FileActivatorTest__it_creates_valid_json_file_after_enabling__2.php
@@ -1,5 +1,3 @@
-<?php
-
-return '{
+<?php return '{
     "Recipe": true
 }';

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_module_namespace_using_studly_case__1.php
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_module_namespace_using_studly_case__1.php
@@ -8,6 +8,16 @@ use Illuminate\\Database\\Eloquent\\Factory;
 class ModuleNameServiceProvider extends ServiceProvider
 {
     /**
+     * @var string $moduleName
+     */
+    protected $moduleName = \'ModuleName\';
+
+    /**
+     * @var string $moduleNameLower
+     */
+    protected $moduleNameLower = \'modulename\';
+
+    /**
      * Boot the application events.
      *
      * @return void
@@ -18,7 +28,7 @@ class ModuleNameServiceProvider extends ServiceProvider
         $this->registerConfig();
         $this->registerViews();
         $this->registerFactories();
-        $this->loadMigrationsFrom(module_path(\'ModuleName\', \'Database/Migrations\'));
+        $this->loadMigrationsFrom(module_path($this->moduleName, \'Database/Migrations\'));
     }
 
     /**
@@ -39,10 +49,10 @@ class ModuleNameServiceProvider extends ServiceProvider
     protected function registerConfig()
     {
         $this->publishes([
-            module_path(\'ModuleName\', \'Config/config.php\') => config_path(\'modulename.php\'),
+            module_path($this->moduleName, \'Config/config.php\') => config_path($this->moduleNameLower . \'.php\'),
         ], \'config\');
         $this->mergeConfigFrom(
-            module_path(\'ModuleName\', \'Config/config.php\'), \'modulename\'
+            module_path($this->moduleName, \'Config/config.php\'), $this->moduleNameLower
         );
     }
 
@@ -53,15 +63,15 @@ class ModuleNameServiceProvider extends ServiceProvider
      */
     public function registerViews()
     {
-        $viewPath = resource_path(\'views/modules/modulename\');
+        $viewPath = resource_path(\'views/modules/\' . $this->moduleNameLower);
 
-        $sourcePath = module_path(\'ModuleName\', \'Resources/views\');
+        $sourcePath = module_path($this->moduleName, \'Resources/views\');
 
         $this->publishes([
             $sourcePath => $viewPath
-        ], [\'views\', \'modulename-module-views\']);
+        ], [\'views\', $this->moduleNameLower . \'-module-views\']);
 
-        $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), \'modulename\');
+        $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
     }
 
     /**
@@ -71,12 +81,12 @@ class ModuleNameServiceProvider extends ServiceProvider
      */
     public function registerTranslations()
     {
-        $langPath = resource_path(\'lang/modules/modulename\');
+        $langPath = resource_path(\'lang/modules/\' . $this->moduleNameLower);
 
         if (is_dir($langPath)) {
-            $this->loadTranslationsFrom($langPath, \'modulename\');
+            $this->loadTranslationsFrom($langPath, $this->moduleNameLower);
         } else {
-            $this->loadTranslationsFrom(module_path(\'ModuleName\', \'Resources/lang\'), \'modulename\');
+            $this->loadTranslationsFrom(module_path($this->moduleName, \'Resources/lang\'), $this->moduleNameLower);
         }
     }
 
@@ -88,7 +98,7 @@ class ModuleNameServiceProvider extends ServiceProvider
     public function registerFactories()
     {
         if (! app()->environment(\'production\') && $this->app->runningInConsole()) {
-            app(Factory::class)->load(module_path(\'ModuleName\', \'Database/factories\'));
+            app(Factory::class)->load(module_path($this->moduleName, \'Database/factories\'));
         }
     }
 
@@ -106,8 +116,8 @@ class ModuleNameServiceProvider extends ServiceProvider
     {
         $paths = [];
         foreach (\\Config::get(\'view.paths\') as $path) {
-            if (is_dir($path . \'/modules/modulename\')) {
-                $paths[] = $path . \'/modules/modulename\';
+            if (is_dir($path . \'/modules/\' . $this->moduleNameLower)) {
+                $paths[] = $path . \'/modules/\' . $this->moduleNameLower;
             }
         }
         return $paths;

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_module_resources__1.php
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_module_resources__1.php
@@ -8,6 +8,16 @@ use Illuminate\\Database\\Eloquent\\Factory;
 class BlogServiceProvider extends ServiceProvider
 {
     /**
+     * @var string $moduleName
+     */
+    protected $moduleName = \'Blog\';
+
+    /**
+     * @var string $moduleNameLower
+     */
+    protected $moduleNameLower = \'blog\';
+
+    /**
      * Boot the application events.
      *
      * @return void
@@ -18,7 +28,7 @@ class BlogServiceProvider extends ServiceProvider
         $this->registerConfig();
         $this->registerViews();
         $this->registerFactories();
-        $this->loadMigrationsFrom(module_path(\'Blog\', \'Database/Migrations\'));
+        $this->loadMigrationsFrom(module_path($this->moduleName, \'Database/Migrations\'));
     }
 
     /**
@@ -39,10 +49,10 @@ class BlogServiceProvider extends ServiceProvider
     protected function registerConfig()
     {
         $this->publishes([
-            module_path(\'Blog\', \'Config/config.php\') => config_path(\'blog.php\'),
+            module_path($this->moduleName, \'Config/config.php\') => config_path($this->moduleNameLower . \'.php\'),
         ], \'config\');
         $this->mergeConfigFrom(
-            module_path(\'Blog\', \'Config/config.php\'), \'blog\'
+            module_path($this->moduleName, \'Config/config.php\'), $this->moduleNameLower
         );
     }
 
@@ -53,15 +63,15 @@ class BlogServiceProvider extends ServiceProvider
      */
     public function registerViews()
     {
-        $viewPath = resource_path(\'views/modules/blog\');
+        $viewPath = resource_path(\'views/modules/\' . $this->moduleNameLower);
 
-        $sourcePath = module_path(\'Blog\', \'Resources/views\');
+        $sourcePath = module_path($this->moduleName, \'Resources/views\');
 
         $this->publishes([
             $sourcePath => $viewPath
-        ], [\'views\', \'blog-module-views\']);
+        ], [\'views\', $this->moduleNameLower . \'-module-views\']);
 
-        $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), \'blog\');
+        $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
     }
 
     /**
@@ -71,12 +81,12 @@ class BlogServiceProvider extends ServiceProvider
      */
     public function registerTranslations()
     {
-        $langPath = resource_path(\'lang/modules/blog\');
+        $langPath = resource_path(\'lang/modules/\' . $this->moduleNameLower);
 
         if (is_dir($langPath)) {
-            $this->loadTranslationsFrom($langPath, \'blog\');
+            $this->loadTranslationsFrom($langPath, $this->moduleNameLower);
         } else {
-            $this->loadTranslationsFrom(module_path(\'Blog\', \'Resources/lang\'), \'blog\');
+            $this->loadTranslationsFrom(module_path($this->moduleName, \'Resources/lang\'), $this->moduleNameLower);
         }
     }
 
@@ -88,7 +98,7 @@ class BlogServiceProvider extends ServiceProvider
     public function registerFactories()
     {
         if (! app()->environment(\'production\') && $this->app->runningInConsole()) {
-            app(Factory::class)->load(module_path(\'Blog\', \'Database/factories\'));
+            app(Factory::class)->load(module_path($this->moduleName, \'Database/factories\'));
         }
     }
 
@@ -106,8 +116,8 @@ class BlogServiceProvider extends ServiceProvider
     {
         $paths = [];
         foreach (\\Config::get(\'view.paths\') as $path) {
-            if (is_dir($path . \'/modules/blog\')) {
-                $paths[] = $path . \'/modules/blog\';
+            if (is_dir($path . \'/modules/\' . $this->moduleNameLower)) {
+                $paths[] = $path . \'/modules/\' . $this->moduleNameLower;
             }
         }
         return $paths;

--- a/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_can_change_the_default_namespace__1.php
+++ b/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_can_change_the_default_namespace__1.php
@@ -8,6 +8,16 @@ use Illuminate\\Database\\Eloquent\\Factory;
 class BlogServiceProvider extends ServiceProvider
 {
     /**
+     * @var string $moduleName
+     */
+    protected $moduleName = \'Blog\';
+
+    /**
+     * @var string $moduleNameLower
+     */
+    protected $moduleNameLower = \'blog\';
+
+    /**
      * Boot the application events.
      *
      * @return void
@@ -18,7 +28,7 @@ class BlogServiceProvider extends ServiceProvider
         $this->registerConfig();
         $this->registerViews();
         $this->registerFactories();
-        $this->loadMigrationsFrom(module_path(\'Blog\', \'Database/Migrations\'));
+        $this->loadMigrationsFrom(module_path($this->moduleName, \'Database/Migrations\'));
     }
 
     /**
@@ -39,10 +49,10 @@ class BlogServiceProvider extends ServiceProvider
     protected function registerConfig()
     {
         $this->publishes([
-            module_path(\'Blog\', \'Config/config.php\') => config_path(\'blog.php\'),
+            module_path($this->moduleName, \'Config/config.php\') => config_path($this->moduleNameLower . \'.php\'),
         ], \'config\');
         $this->mergeConfigFrom(
-            module_path(\'Blog\', \'Config/config.php\'), \'blog\'
+            module_path($this->moduleName, \'Config/config.php\'), $this->moduleNameLower
         );
     }
 
@@ -53,15 +63,15 @@ class BlogServiceProvider extends ServiceProvider
      */
     public function registerViews()
     {
-        $viewPath = resource_path(\'views/modules/blog\');
+        $viewPath = resource_path(\'views/modules/\' . $this->moduleNameLower);
 
-        $sourcePath = module_path(\'Blog\', \'Resources/views\');
+        $sourcePath = module_path($this->moduleName, \'Resources/views\');
 
         $this->publishes([
             $sourcePath => $viewPath
-        ], [\'views\', \'blog-module-views\']);
+        ], [\'views\', $this->moduleNameLower . \'-module-views\']);
 
-        $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), \'blog\');
+        $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
     }
 
     /**
@@ -71,12 +81,12 @@ class BlogServiceProvider extends ServiceProvider
      */
     public function registerTranslations()
     {
-        $langPath = resource_path(\'lang/modules/blog\');
+        $langPath = resource_path(\'lang/modules/\' . $this->moduleNameLower);
 
         if (is_dir($langPath)) {
-            $this->loadTranslationsFrom($langPath, \'blog\');
+            $this->loadTranslationsFrom($langPath, $this->moduleNameLower);
         } else {
-            $this->loadTranslationsFrom(module_path(\'Blog\', \'Resources/lang\'), \'blog\');
+            $this->loadTranslationsFrom(module_path($this->moduleName, \'Resources/lang\'), $this->moduleNameLower);
         }
     }
 
@@ -88,7 +98,7 @@ class BlogServiceProvider extends ServiceProvider
     public function registerFactories()
     {
         if (! app()->environment(\'production\') && $this->app->runningInConsole()) {
-            app(Factory::class)->load(module_path(\'Blog\', \'Database/factories\'));
+            app(Factory::class)->load(module_path($this->moduleName, \'Database/factories\'));
         }
     }
 
@@ -106,8 +116,8 @@ class BlogServiceProvider extends ServiceProvider
     {
         $paths = [];
         foreach (\\Config::get(\'view.paths\') as $path) {
-            if (is_dir($path . \'/modules/blog\')) {
-                $paths[] = $path . \'/modules/blog\';
+            if (is_dir($path . \'/modules/\' . $this->moduleNameLower)) {
+                $paths[] = $path . \'/modules/\' . $this->moduleNameLower;
             }
         }
         return $paths;

--- a/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
+++ b/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
@@ -8,6 +8,16 @@ use Illuminate\\Database\\Eloquent\\Factory;
 class BlogServiceProvider extends ServiceProvider
 {
     /**
+     * @var string $moduleName
+     */
+    protected $moduleName = \'Blog\';
+
+    /**
+     * @var string $moduleNameLower
+     */
+    protected $moduleNameLower = \'blog\';
+
+    /**
      * Boot the application events.
      *
      * @return void
@@ -18,7 +28,7 @@ class BlogServiceProvider extends ServiceProvider
         $this->registerConfig();
         $this->registerViews();
         $this->registerFactories();
-        $this->loadMigrationsFrom(module_path(\'Blog\', \'Database/Migrations\'));
+        $this->loadMigrationsFrom(module_path($this->moduleName, \'Database/Migrations\'));
     }
 
     /**
@@ -39,10 +49,10 @@ class BlogServiceProvider extends ServiceProvider
     protected function registerConfig()
     {
         $this->publishes([
-            module_path(\'Blog\', \'Config/config.php\') => config_path(\'blog.php\'),
+            module_path($this->moduleName, \'Config/config.php\') => config_path($this->moduleNameLower . \'.php\'),
         ], \'config\');
         $this->mergeConfigFrom(
-            module_path(\'Blog\', \'Config/config.php\'), \'blog\'
+            module_path($this->moduleName, \'Config/config.php\'), $this->moduleNameLower
         );
     }
 
@@ -53,15 +63,15 @@ class BlogServiceProvider extends ServiceProvider
      */
     public function registerViews()
     {
-        $viewPath = resource_path(\'views/modules/blog\');
+        $viewPath = resource_path(\'views/modules/\' . $this->moduleNameLower);
 
-        $sourcePath = module_path(\'Blog\', \'Resources/views\');
+        $sourcePath = module_path($this->moduleName, \'Resources/views\');
 
         $this->publishes([
             $sourcePath => $viewPath
-        ], [\'views\', \'blog-module-views\']);
+        ], [\'views\', $this->moduleNameLower . \'-module-views\']);
 
-        $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), \'blog\');
+        $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
     }
 
     /**
@@ -71,12 +81,12 @@ class BlogServiceProvider extends ServiceProvider
      */
     public function registerTranslations()
     {
-        $langPath = resource_path(\'lang/modules/blog\');
+        $langPath = resource_path(\'lang/modules/\' . $this->moduleNameLower);
 
         if (is_dir($langPath)) {
-            $this->loadTranslationsFrom($langPath, \'blog\');
+            $this->loadTranslationsFrom($langPath, $this->moduleNameLower);
         } else {
-            $this->loadTranslationsFrom(module_path(\'Blog\', \'Resources/lang\'), \'blog\');
+            $this->loadTranslationsFrom(module_path($this->moduleName, \'Resources/lang\'), $this->moduleNameLower);
         }
     }
 
@@ -88,7 +98,7 @@ class BlogServiceProvider extends ServiceProvider
     public function registerFactories()
     {
         if (! app()->environment(\'production\') && $this->app->runningInConsole()) {
-            app(Factory::class)->load(module_path(\'Blog\', \'Database/factories\'));
+            app(Factory::class)->load(module_path($this->moduleName, \'Database/factories\'));
         }
     }
 
@@ -106,8 +116,8 @@ class BlogServiceProvider extends ServiceProvider
     {
         $paths = [];
         foreach (\\Config::get(\'view.paths\') as $path) {
-            if (is_dir($path . \'/modules/blog\')) {
-                $paths[] = $path . \'/modules/blog\';
+            if (is_dir($path . \'/modules/\' . $this->moduleNameLower)) {
+                $paths[] = $path . \'/modules/\' . $this->moduleNameLower;
             }
         }
         return $paths;

--- a/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_can_have_custom_migration_resources_location_paths__1.php
+++ b/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_can_have_custom_migration_resources_location_paths__1.php
@@ -8,6 +8,16 @@ use Illuminate\\Database\\Eloquent\\Factory;
 class BlogServiceProvider extends ServiceProvider
 {
     /**
+     * @var string $moduleName
+     */
+    protected $moduleName = \'Blog\';
+
+    /**
+     * @var string $moduleNameLower
+     */
+    protected $moduleNameLower = \'blog\';
+
+    /**
      * Boot the application events.
      *
      * @return void
@@ -18,7 +28,7 @@ class BlogServiceProvider extends ServiceProvider
         $this->registerConfig();
         $this->registerViews();
         $this->registerFactories();
-        $this->loadMigrationsFrom(module_path(\'Blog\', \'migrations\'));
+        $this->loadMigrationsFrom(module_path($this->moduleName, \'migrations\'));
     }
 
     /**
@@ -39,10 +49,10 @@ class BlogServiceProvider extends ServiceProvider
     protected function registerConfig()
     {
         $this->publishes([
-            module_path(\'Blog\', \'Config/config.php\') => config_path(\'blog.php\'),
+            module_path($this->moduleName, \'Config/config.php\') => config_path($this->moduleNameLower . \'.php\'),
         ], \'config\');
         $this->mergeConfigFrom(
-            module_path(\'Blog\', \'Config/config.php\'), \'blog\'
+            module_path($this->moduleName, \'Config/config.php\'), $this->moduleNameLower
         );
     }
 
@@ -53,15 +63,15 @@ class BlogServiceProvider extends ServiceProvider
      */
     public function registerViews()
     {
-        $viewPath = resource_path(\'views/modules/blog\');
+        $viewPath = resource_path(\'views/modules/\' . $this->moduleNameLower);
 
-        $sourcePath = module_path(\'Blog\', \'Resources/views\');
+        $sourcePath = module_path($this->moduleName, \'Resources/views\');
 
         $this->publishes([
             $sourcePath => $viewPath
-        ], [\'views\', \'blog-module-views\']);
+        ], [\'views\', $this->moduleNameLower . \'-module-views\']);
 
-        $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), \'blog\');
+        $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
     }
 
     /**
@@ -71,12 +81,12 @@ class BlogServiceProvider extends ServiceProvider
      */
     public function registerTranslations()
     {
-        $langPath = resource_path(\'lang/modules/blog\');
+        $langPath = resource_path(\'lang/modules/\' . $this->moduleNameLower);
 
         if (is_dir($langPath)) {
-            $this->loadTranslationsFrom($langPath, \'blog\');
+            $this->loadTranslationsFrom($langPath, $this->moduleNameLower);
         } else {
-            $this->loadTranslationsFrom(module_path(\'Blog\', \'Resources/lang\'), \'blog\');
+            $this->loadTranslationsFrom(module_path($this->moduleName, \'Resources/lang\'), $this->moduleNameLower);
         }
     }
 
@@ -88,7 +98,7 @@ class BlogServiceProvider extends ServiceProvider
     public function registerFactories()
     {
         if (! app()->environment(\'production\') && $this->app->runningInConsole()) {
-            app(Factory::class)->load(module_path(\'Blog\', \'Database/factories\'));
+            app(Factory::class)->load(module_path($this->moduleName, \'Database/factories\'));
         }
     }
 
@@ -106,8 +116,8 @@ class BlogServiceProvider extends ServiceProvider
     {
         $paths = [];
         foreach (\\Config::get(\'view.paths\') as $path) {
-            if (is_dir($path . \'/modules/blog\')) {
-                $paths[] = $path . \'/modules/blog\';
+            if (is_dir($path . \'/modules/\' . $this->moduleNameLower)) {
+                $paths[] = $path . \'/modules/\' . $this->moduleNameLower;
             }
         }
         return $paths;

--- a/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_generates_a_master_service_provider_with_resource_loading__1.php
+++ b/tests/Commands/__snapshots__/ProviderMakeCommandTest__it_generates_a_master_service_provider_with_resource_loading__1.php
@@ -8,6 +8,16 @@ use Illuminate\\Database\\Eloquent\\Factory;
 class BlogServiceProvider extends ServiceProvider
 {
     /**
+     * @var string $moduleName
+     */
+    protected $moduleName = \'Blog\';
+
+    /**
+     * @var string $moduleNameLower
+     */
+    protected $moduleNameLower = \'blog\';
+
+    /**
      * Boot the application events.
      *
      * @return void
@@ -18,7 +28,7 @@ class BlogServiceProvider extends ServiceProvider
         $this->registerConfig();
         $this->registerViews();
         $this->registerFactories();
-        $this->loadMigrationsFrom(module_path(\'Blog\', \'Database/Migrations\'));
+        $this->loadMigrationsFrom(module_path($this->moduleName, \'Database/Migrations\'));
     }
 
     /**
@@ -39,10 +49,10 @@ class BlogServiceProvider extends ServiceProvider
     protected function registerConfig()
     {
         $this->publishes([
-            module_path(\'Blog\', \'Config/config.php\') => config_path(\'blog.php\'),
+            module_path($this->moduleName, \'Config/config.php\') => config_path($this->moduleNameLower . \'.php\'),
         ], \'config\');
         $this->mergeConfigFrom(
-            module_path(\'Blog\', \'Config/config.php\'), \'blog\'
+            module_path($this->moduleName, \'Config/config.php\'), $this->moduleNameLower
         );
     }
 
@@ -53,15 +63,15 @@ class BlogServiceProvider extends ServiceProvider
      */
     public function registerViews()
     {
-        $viewPath = resource_path(\'views/modules/blog\');
+        $viewPath = resource_path(\'views/modules/\' . $this->moduleNameLower);
 
-        $sourcePath = module_path(\'Blog\', \'Resources/views\');
+        $sourcePath = module_path($this->moduleName, \'Resources/views\');
 
         $this->publishes([
             $sourcePath => $viewPath
-        ], [\'views\', \'blog-module-views\']);
+        ], [\'views\', $this->moduleNameLower . \'-module-views\']);
 
-        $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), \'blog\');
+        $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
     }
 
     /**
@@ -71,12 +81,12 @@ class BlogServiceProvider extends ServiceProvider
      */
     public function registerTranslations()
     {
-        $langPath = resource_path(\'lang/modules/blog\');
+        $langPath = resource_path(\'lang/modules/\' . $this->moduleNameLower);
 
         if (is_dir($langPath)) {
-            $this->loadTranslationsFrom($langPath, \'blog\');
+            $this->loadTranslationsFrom($langPath, $this->moduleNameLower);
         } else {
-            $this->loadTranslationsFrom(module_path(\'Blog\', \'Resources/lang\'), \'blog\');
+            $this->loadTranslationsFrom(module_path($this->moduleName, \'Resources/lang\'), $this->moduleNameLower);
         }
     }
 
@@ -88,7 +98,7 @@ class BlogServiceProvider extends ServiceProvider
     public function registerFactories()
     {
         if (! app()->environment(\'production\') && $this->app->runningInConsole()) {
-            app(Factory::class)->load(module_path(\'Blog\', \'Database/factories\'));
+            app(Factory::class)->load(module_path($this->moduleName, \'Database/factories\'));
         }
     }
 
@@ -106,8 +116,8 @@ class BlogServiceProvider extends ServiceProvider
     {
         $paths = [];
         foreach (\\Config::get(\'view.paths\') as $path) {
-            if (is_dir($path . \'/modules/blog\')) {
-                $paths[] = $path . \'/modules/blog\';
+            if (is_dir($path . \'/modules/\' . $this->moduleNameLower)) {
+                $paths[] = $path . \'/modules/\' . $this->moduleNameLower;
             }
         }
         return $paths;


### PR DESCRIPTION
The previous stub copied a lot of `'$MODULE$'` and `'$LOWER_NAME$'` into the scaffold, which imho introduces bugs more easily when you have to rename a module after creating a new one. This setup is a little bit cleaner.

I didn't bother to change the other placeholders as properties, since those weren't copied as frequently.


#### Test case
Run `php artisan module:make TestModule` and check the outputs of the generated `TestModuleServiceProvider.php`.