### PR TITLE
populate process.env vars to allow Echo usage

### DIFF
--- a/src/Commands/stubs/webpack.stub
+++ b/src/Commands/stubs/webpack.stub
@@ -1,3 +1,6 @@
+const dotenvExpand = require('dotenv-expand');
+dotenvExpand(require('dotenv').config({ path: '../../.env'/*, debug: true*/}));
+
 const mix = require('laravel-mix');
 require('laravel-mix-merge-manifest');
 

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_webpack_file__1.php
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_webpack_file__1.php
@@ -1,4 +1,9 @@
-<?php return 'const mix = require(\'laravel-mix\');
+<?php
+
+return 'const dotenvExpand = require(\'dotenv-expand\');
+dotenvExpand(require(\'dotenv\').config({ path: \'../../.env\'/*, debug: true*/}));
+
+const mix = require(\'laravel-mix\');
 require(\'laravel-mix-merge-manifest\');
 
 mix.setPublicPath(\'../../public\').mergeManifest();
@@ -8,4 +13,5 @@ mix.js(__dirname + \'/Resources/assets/js/app.js\', \'js/blog.js\')
 
 if (mix.inProduction()) {
     mix.version();
-}';
+}
+';


### PR DESCRIPTION
When trying to use Echo in app.js, it miss the `process.env.MIX_*` values, this PR register them and allow to use usual calls like the one commented out in the main Laravel project
```js
 window.Echo = new Echo({
     broadcaster: 'pusher',
     key: process.env.MIX_PUSHER_APP_KEY,
     cluster: process.env.MIX_PUSHER_APP_CLUSTER,
     encrypted: true
 });
```