### PR TITLE
PHPUnit10 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "ext-json": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.5",
+    "phpunit/phpunit": "^8.5 || ^9.0",
     "mockery/mockery": "~1.0",
     "orchestra/testbench": "^5.0",
     "friendsofphp/php-cs-fixer": "^2.16",

--- a/tests/Commands/ModuleDeleteCommandTest.php
+++ b/tests/Commands/ModuleDeleteCommandTest.php
@@ -33,7 +33,7 @@ class ModuleDeleteCommandTest extends BaseTestCase
         $this->assertDirectoryExists(base_path('modules/WrongModule'));
 
         $this->artisan('module:delete', ['module' => 'WrongModule']);
-        $this->assertDirectoryNotExists(base_path('modules/WrongModule'));
+        $this->assertDirectoryDoesNotExist(base_path('modules/WrongModule'));
     }
 
     /** @test */

--- a/tests/Commands/ModuleMakeCommandTest.php
+++ b/tests/Commands/ModuleMakeCommandTest.php
@@ -261,8 +261,8 @@ class ModuleMakeCommandTest extends BaseTestCase
 
         $this->assertDirectoryExists($this->modulePath . '/Assets');
         $this->assertDirectoryExists($this->modulePath . '/Emails');
-        $this->assertDirectoryNotExists($this->modulePath . '/Rules');
-        $this->assertDirectoryNotExists($this->modulePath . '/Policies');
+        $this->assertDirectoryDoesNotExist($this->modulePath . '/Rules');
+        $this->assertDirectoryDoesNotExist($this->modulePath . '/Policies');
     }
 
     /** @test */
@@ -273,8 +273,8 @@ class ModuleMakeCommandTest extends BaseTestCase
 
         $this->artisan('module:make', ['name' => ['Blog']]);
 
-        $this->assertDirectoryNotExists($this->modulePath . '/Assets');
-        $this->assertDirectoryNotExists($this->modulePath . '/Emails');
+        $this->assertDirectoryDoesNotExist($this->modulePath . '/Assets');
+        $this->assertDirectoryDoesNotExist($this->modulePath . '/Emails');
     }
 
     /** @test */
@@ -285,8 +285,8 @@ class ModuleMakeCommandTest extends BaseTestCase
 
         $this->artisan('module:make', ['name' => ['Blog']]);
 
-        $this->assertDirectoryNotExists($this->modulePath . '/Assets');
-        $this->assertDirectoryNotExists($this->modulePath . '/Emails');
+        $this->assertDirectoryDoesNotExist($this->modulePath . '/Assets');
+        $this->assertDirectoryDoesNotExist($this->modulePath . '/Emails');
     }
 
     /** @test */
@@ -298,9 +298,9 @@ class ModuleMakeCommandTest extends BaseTestCase
 
         $this->artisan('module:make', ['name' => ['Blog']]);
 
-        $this->assertDirectoryNotExists($this->modulePath . '/Database/Seeders');
-        $this->assertDirectoryNotExists($this->modulePath . '/Providers');
-        $this->assertDirectoryNotExists($this->modulePath . '/Http/Controllers');
+        $this->assertDirectoryDoesNotExist($this->modulePath . '/Database/Seeders');
+        $this->assertDirectoryDoesNotExist($this->modulePath . '/Providers');
+        $this->assertDirectoryDoesNotExist($this->modulePath . '/Http/Controllers');
     }
 
     /** @test */

--- a/tests/LaravelModuleTest.php
+++ b/tests/LaravelModuleTest.php
@@ -204,7 +204,7 @@ class ModuleTest extends BaseTestCase
         $cachedServicesPath = $this->module->getCachedServicesPath();
 
         @unlink($cachedServicesPath);
-        $this->assertFileNotExists($cachedServicesPath);
+        $this->assertFileDoesNotExist($cachedServicesPath);
 
         $this->module->registerProviders();
 


### PR DESCRIPTION
renamed assertDirectoryNotExists and assertFileNotExists to assertDirectoryDoesNotExist and assertFileDoesNotExist as they'll be deprecated on PHPUnit 10