### PR TITLE
moved routeServiceProvider Registration to boot method in provider.stub

### DIFF
--- a/src/Commands/stubs/scaffold/provider.stub
+++ b/src/Commands/stubs/scaffold/provider.stub
@@ -29,6 +29,7 @@ class $CLASS$ extends ServiceProvider
         $this->registerViews();
         $this->registerFactories();
         $this->loadMigrationsFrom(module_path($this->moduleName, '$MIGRATIONS_PATH$'));
+        $this->app->register(RouteServiceProvider::class);
     }
 
     /**
@@ -38,7 +39,7 @@ class $CLASS$ extends ServiceProvider
      */
     public function register()
     {
-        $this->app->register(RouteServiceProvider::class);
+
     }
 
     /**


### PR DESCRIPTION
Registering RouteServiceProvider in the boot method gives ability to inject whatever laravel provides.
Currently, RouteServiceProvider is registered before the application boots up and we cant use config() and other functions in the routes.