### PR TITLE
Removing module service provider from composer.json stub

### DIFF
--- a/src/Commands/stubs/composer.stub
+++ b/src/Commands/stubs/composer.stub
@@ -9,9 +9,7 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [
-                "$MODULE_NAMESPACE$\\$STUDLY_NAME$\\$PROVIDER_NAMESPACE$\\$STUDLY_NAME$ServiceProvider"
-            ],
+            "providers": [],
             "aliases": {
 
             }

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_correct_composerjson_file__1.php
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_correct_composerjson_file__1.php
@@ -9,9 +9,7 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [
-                "Modules\\\Blog\\\Providers\\\BlogServiceProvider"
-            ],
+            "providers": [],
             "aliases": {
 
             }

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generes_module_with_new_provider_location__2.php
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generes_module_with_new_provider_location__2.php
@@ -9,9 +9,7 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [
-                "Modules\\\\Blog\\\\Base\\\\Providers\\\\BlogServiceProvider"
-            ],
+            "providers": [],
             "aliases": {
 
             }


### PR DESCRIPTION
Having the service provider in composer.json causes Laravel to auto detect it. This change stops this from happening