### PR TITLE
Fixed custom stub path issue.

### DIFF
--- a/src/LaravelModulesServiceProvider.php
+++ b/src/LaravelModulesServiceProvider.php
@@ -32,7 +32,8 @@ class LaravelModulesServiceProvider extends ModulesServiceProvider
      */
     public function setupStubPath()
     {
-        Stub::setBasePath(__DIR__ . '/Commands/stubs');
+        $path = $this->app['config']->get('modules.stubs.path') ?? __DIR__ . '/Commands/stubs';
+        Stub::setBasePath($path);
 
         $this->app->booted(function ($app) {
             /** @var RepositoryInterface $moduleRepository */


### PR DESCRIPTION
Current version of laravel-modules doesn't work custom stub path because of LaravelModulesServiceProvider used fixed path on line number 35.
```
Stub::setBasePath(__DIR__ . '/Commands/stubs');
```
Replace above code with this code then it works fine.
```
$path = $this->app['config']->get('modules.stubs.path') ?? __DIR__ . '/Commands/stubs';
        Stub::setBasePath($path);
```