### PR TITLE
Add return statements in Commands/GeneratorCommand.php

### DIFF
--- a/src/Commands/DisableCommand.php
+++ b/src/Commands/DisableCommand.php
@@ -25,7 +25,7 @@ class DisableCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle() : int
     {
         /**
          * check if user entred an argument
@@ -44,6 +44,8 @@ class DisableCommand extends Command
         } else {
             $this->comment("Module [{$module}] has already disabled.");
         }
+
+        return 0;
     }
 
     /**

--- a/src/Commands/DumpCommand.php
+++ b/src/Commands/DumpCommand.php
@@ -24,7 +24,7 @@ class DumpCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle() : int
     {
         $this->info('Generating optimized autoload modules.');
 
@@ -35,6 +35,8 @@ class DumpCommand extends Command
                 $this->dump($module->getStudlyName());
             }
         }
+
+        return 0;
     }
 
     public function dump($module)

--- a/src/Commands/EnableCommand.php
+++ b/src/Commands/EnableCommand.php
@@ -25,13 +25,14 @@ class EnableCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle() : int
     {
         /**
          * check if user entred an argument
          */
         if ($this->argument('module') === null) {
-            return $this->enableAll();
+            $this->enableAll();
+            return 0;
         }
 
         /** @var Module $module */
@@ -44,6 +45,8 @@ class EnableCommand extends Command
         } else {
             $this->comment("Module [{$module}] has already enabled.");
         }
+
+        return 0;
     }
 
     /**

--- a/src/Commands/GeneratorCommand.php
+++ b/src/Commands/GeneratorCommand.php
@@ -31,6 +31,8 @@ abstract class GeneratorCommand extends Command
 
     /**
      * Execute the console command.
+     *
+     * @return bool
      */
     public function handle()
     {

--- a/src/Commands/GeneratorCommand.php
+++ b/src/Commands/GeneratorCommand.php
@@ -47,8 +47,10 @@ abstract class GeneratorCommand extends Command
             (new FileGenerator($path, $contents))->withFileOverwrite($overwriteFile)->generate();
 
             $this->info("Created : {$path}");
+            return true;
         } catch (FileAlreadyExistException $e) {
             $this->error("File : {$path} already exists.");
+            return false;
         }
     }
 

--- a/src/Commands/GeneratorCommand.php
+++ b/src/Commands/GeneratorCommand.php
@@ -31,10 +31,8 @@ abstract class GeneratorCommand extends Command
 
     /**
      * Execute the console command.
-     *
-     * @return bool
      */
-    public function handle()
+    public function handle() : bool
     {
         $path = str_replace('\\', '/', $this->getDestinationFilePath());
 

--- a/src/Commands/GeneratorCommand.php
+++ b/src/Commands/GeneratorCommand.php
@@ -32,7 +32,7 @@ abstract class GeneratorCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle() : bool
+    public function handle() : int
     {
         $path = str_replace('\\', '/', $this->getDestinationFilePath());
 
@@ -47,11 +47,12 @@ abstract class GeneratorCommand extends Command
             (new FileGenerator($path, $contents))->withFileOverwrite($overwriteFile)->generate();
 
             $this->info("Created : {$path}");
-            return true;
         } catch (FileAlreadyExistException $e) {
             $this->error("File : {$path} already exists.");
-            return false;
+            return E_ERROR;
         }
+
+        return 0;
     }
 
     /**

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -35,12 +35,10 @@ class InstallCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle() : int
     {
         if (is_null($this->argument('name'))) {
-            $this->installFromFile();
-
-            return;
+            return $this->installFromFile();
         }
 
         $this->install(
@@ -49,17 +47,19 @@ class InstallCommand extends Command
             $this->option('type'),
             $this->option('tree')
         );
+
+        return 0;
     }
 
     /**
      * Install modules from modules.json file.
      */
-    protected function installFromFile()
+    protected function installFromFile() : int
     {
         if (!file_exists($path = base_path('modules.json'))) {
             $this->error("File 'modules.json' does not exist in your project root.");
 
-            return;
+            return E_ERROR;
         }
 
         $modules = Json::make($path);
@@ -75,6 +75,8 @@ class InstallCommand extends Command
                 $module->get('type')
             );
         }
+
+        return 0;
     }
 
     /**

--- a/src/Commands/LaravelModulesV6Migrator.php
+++ b/src/Commands/LaravelModulesV6Migrator.php
@@ -13,7 +13,7 @@ class LaravelModulesV6Migrator extends Command
     protected $name = 'module:v6:migrate';
     protected $description = 'Migrate laravel-modules v5 modules statuses to v6.';
 
-    public function handle()
+    public function handle() : int
     {
         $moduleStatuses = [];
         /** @var RepositoryInterface $modules */
@@ -33,5 +33,7 @@ class LaravelModulesV6Migrator extends Command
         }
         $this->info('All modules have been migrated.');
         $this->table(['Module name', 'Status'], $moduleStatuses);
+
+        return 0;
     }
 }

--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -25,9 +25,11 @@ class ListCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle() : int
     {
         $this->table(['Name', 'Status', 'Order', 'Path'], $this->getRows());
+
+        return 0;
     }
 
     /**

--- a/src/Commands/MigrateCommand.php
+++ b/src/Commands/MigrateCommand.php
@@ -34,7 +34,7 @@ class MigrateCommand extends Command
      *
      * @return mixed
      */
-    public function handle()
+    public function handle() : int
     {
         $this->module = $this->laravel['modules'];
 
@@ -43,7 +43,9 @@ class MigrateCommand extends Command
         if ($name) {
             $module = $this->module->findOrFail($name);
 
-            return $this->migrate($module);
+            $this->migrate($module);
+
+            return 0;
         }
 
         foreach ($this->module->getOrdered($this->option('direction')) as $module) {
@@ -51,6 +53,8 @@ class MigrateCommand extends Command
 
             $this->migrate($module);
         }
+
+        return 0;
     }
 
     /**

--- a/src/Commands/MigrateRefreshCommand.php
+++ b/src/Commands/MigrateRefreshCommand.php
@@ -28,7 +28,7 @@ class MigrateRefreshCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle() : int
     {
         $this->call('module:migrate-reset', [
             'module' => $this->getModuleName(),
@@ -47,6 +47,8 @@ class MigrateRefreshCommand extends Command
                 'module' => $this->getModuleName(),
             ]);
         }
+
+        return 0;
     }
 
     /**

--- a/src/Commands/MigrateResetCommand.php
+++ b/src/Commands/MigrateResetCommand.php
@@ -34,7 +34,7 @@ class MigrateResetCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle() : int
     {
         $this->module = $this->laravel['modules'];
 
@@ -43,7 +43,7 @@ class MigrateResetCommand extends Command
         if (!empty($name)) {
             $this->reset($name);
 
-            return;
+            return 0;
         }
 
         foreach ($this->module->getOrdered($this->option('direction')) as $module) {
@@ -51,6 +51,8 @@ class MigrateResetCommand extends Command
 
             $this->reset($module);
         }
+
+        return 0;
     }
 
     /**

--- a/src/Commands/MigrateRollbackCommand.php
+++ b/src/Commands/MigrateRollbackCommand.php
@@ -34,7 +34,7 @@ class MigrateRollbackCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle() : int
     {
         $this->module = $this->laravel['modules'];
 
@@ -43,7 +43,7 @@ class MigrateRollbackCommand extends Command
         if (!empty($name)) {
             $this->rollback($name);
 
-            return;
+            return 0;
         }
 
         foreach ($this->module->getOrdered($this->option('direction')) as $module) {
@@ -51,6 +51,8 @@ class MigrateRollbackCommand extends Command
 
             $this->rollback($module);
         }
+
+        return 0;
     }
 
     /**

--- a/src/Commands/MigrateStatusCommand.php
+++ b/src/Commands/MigrateStatusCommand.php
@@ -34,7 +34,7 @@ class MigrateStatusCommand extends Command
      *
      * @return mixed
      */
-    public function handle()
+    public function handle() : int
     {
         $this->module = $this->laravel['modules'];
 
@@ -43,13 +43,17 @@ class MigrateStatusCommand extends Command
         if ($name) {
             $module = $this->module->findOrFail($name);
 
-            return $this->migrateStatus($module);
+            $this->migrateStatus($module);
+
+            return 0;
         }
 
         foreach ($this->module->getOrdered($this->option('direction')) as $module) {
             $this->line('Running for module: <info>' . $module->getName() . '</info>');
             $this->migrateStatus($module);
         }
+
+        return 0;
     }
 
     /**

--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -151,16 +151,16 @@ class MigrationMakeCommand extends GeneratorCommand
     /**
      * Run the command.
      */
-    public function handle() : bool
+    public function handle() : int
     {
-        if (parent::handle() === false) {
-            return false;
+        if (parent::handle() === E_ERROR) {
+            return E_ERROR;
         }
 
         if (app()->environment() === 'testing') {
-            return true;
+            return 0;
         }
 
-        return true;
+        return 0;
     }
 }

--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -151,12 +151,16 @@ class MigrationMakeCommand extends GeneratorCommand
     /**
      * Run the command.
      */
-    public function handle()
+    public function handle() : bool
     {
-        parent::handle();
+        if (parent::handle() === false) {
+            return false;
+        }
 
         if (app()->environment() === 'testing') {
-            return;
+            return true;
         }
+
+        return true;
     }
 }

--- a/src/Commands/ModelMakeCommand.php
+++ b/src/Commands/ModelMakeCommand.php
@@ -34,11 +34,15 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected $description = 'Create a new model for the specified module.';
 
-    public function handle()
+    public function handle() : bool
     {
-        parent::handle();
+        if (parent::handle() === false) {
+            return false;
+        }
 
         $this->handleOptionalMigrationOption();
+
+        return true;
     }
 
     /**

--- a/src/Commands/ModelMakeCommand.php
+++ b/src/Commands/ModelMakeCommand.php
@@ -34,15 +34,15 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected $description = 'Create a new model for the specified module.';
 
-    public function handle() : bool
+    public function handle() : int
     {
-        if (parent::handle() === false) {
-            return false;
+        if (parent::handle() === E_ERROR) {
+            return E_ERROR;
         }
 
         $this->handleOptionalMigrationOption();
 
-        return true;
+        return 0;
     }
 
     /**

--- a/src/Commands/ModuleDeleteCommand.php
+++ b/src/Commands/ModuleDeleteCommand.php
@@ -10,11 +10,13 @@ class ModuleDeleteCommand extends Command
     protected $name = 'module:delete';
     protected $description = 'Delete a module from the application';
 
-    public function handle()
+    public function handle() : int
     {
         $this->laravel['modules']->delete($this->argument('module'));
 
         $this->info("Module {$this->argument('module')} has been deleted.");
+
+        return 0;
     }
 
     protected function getArguments()

--- a/src/Commands/ModuleMakeCommand.php
+++ b/src/Commands/ModuleMakeCommand.php
@@ -27,7 +27,7 @@ class ModuleMakeCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle() : int
     {
         $names = $this->argument('name');
 
@@ -43,6 +43,8 @@ class ModuleMakeCommand extends Command
                 ->setActive(!$this->option('disabled'))
                 ->generate();
         }
+
+        return 0;
     }
 
     /**

--- a/src/Commands/ModuleMakeCommand.php
+++ b/src/Commands/ModuleMakeCommand.php
@@ -30,9 +30,10 @@ class ModuleMakeCommand extends Command
     public function handle() : int
     {
         $names = $this->argument('name');
+        $success = true;
 
         foreach ($names as $name) {
-            with(new ModuleGenerator($name))
+            $code = with(new ModuleGenerator($name))
                 ->setFilesystem($this->laravel['files'])
                 ->setModule($this->laravel['modules'])
                 ->setConfig($this->laravel['config'])
@@ -42,9 +43,13 @@ class ModuleMakeCommand extends Command
                 ->setPlain($this->option('plain'))
                 ->setActive(!$this->option('disabled'))
                 ->generate();
+
+            if ($code === E_ERROR) {
+                $success = false;
+            }
         }
 
-        return 0;
+        return $success ? 0 : E_ERROR;
     }
 
     /**

--- a/src/Commands/PublishCommand.php
+++ b/src/Commands/PublishCommand.php
@@ -26,15 +26,17 @@ class PublishCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle() : int
     {
         if ($name = $this->argument('module')) {
             $this->publish($name);
 
-            return;
+            return 0;
         }
 
         $this->publishAll();
+
+        return 0;
     }
 
     /**

--- a/src/Commands/PublishConfigurationCommand.php
+++ b/src/Commands/PublishConfigurationCommand.php
@@ -26,17 +26,19 @@ class PublishConfigurationCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle() : int
     {
         if ($module = $this->argument('module')) {
             $this->publishConfiguration($module);
 
-            return;
+            return 0;
         }
 
         foreach ($this->laravel['modules']->allEnabled() as $module) {
             $this->publishConfiguration($module->getName());
         }
+
+        return 0;
     }
 
     /**

--- a/src/Commands/PublishMigrationCommand.php
+++ b/src/Commands/PublishMigrationCommand.php
@@ -26,19 +26,21 @@ class PublishMigrationCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle() : int
     {
         if ($name = $this->argument('module')) {
             $module = $this->laravel['modules']->findOrFail($name);
 
             $this->publish($module);
 
-            return;
+            return 0;
         }
 
         foreach ($this->laravel['modules']->allEnabled() as $module) {
             $this->publish($module);
         }
+
+        return 0;
     }
 
     /**

--- a/src/Commands/PublishTranslationCommand.php
+++ b/src/Commands/PublishTranslationCommand.php
@@ -26,15 +26,17 @@ class PublishTranslationCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle() : int
     {
         if ($name = $this->argument('module')) {
             $this->publish($name);
 
-            return;
+            return 0;
         }
 
         $this->publishAll();
+
+        return 0;
     }
 
     /**

--- a/src/Commands/SeedCommand.php
+++ b/src/Commands/SeedCommand.php
@@ -35,7 +35,7 @@ class SeedCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle() : int
     {
         try {
             if ($name = $this->argument('module')) {
@@ -51,13 +51,15 @@ class SeedCommand extends Command
             $this->reportException($e);
             $this->renderException($this->getOutput(), $e);
 
-            return 1;
+            return E_ERROR;
         } catch (\Exception $e) {
             $this->reportException($e);
             $this->renderException($this->getOutput(), $e);
 
-            return 1;
+            return E_ERROR;
         }
+
+        return 0;
     }
 
     /**

--- a/src/Commands/SetupCommand.php
+++ b/src/Commands/SetupCommand.php
@@ -23,11 +23,11 @@ class SetupCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle() : int
     {
-        $this->generateModulesFolder();
+        $code = $this->generateModulesFolder();
 
-        $this->generateAssetsFolder();
+        return $this->generateAssetsFolder() | $code;
     }
 
     /**
@@ -35,7 +35,7 @@ class SetupCommand extends Command
      */
     public function generateModulesFolder()
     {
-        $this->generateDirectory(
+        return $this->generateDirectory(
             $this->laravel['modules']->config('paths.modules'),
             'Modules directory created successfully',
             'Modules directory already exist'
@@ -47,7 +47,7 @@ class SetupCommand extends Command
      */
     public function generateAssetsFolder()
     {
-        $this->generateDirectory(
+        return $this->generateDirectory(
             $this->laravel['modules']->config('paths.assets'),
             'Assets directory created successfully',
             'Assets directory already exist'
@@ -60,17 +60,20 @@ class SetupCommand extends Command
      * @param $dir
      * @param $success
      * @param $error
+     * @return int
      */
-    protected function generateDirectory($dir, $success, $error)
+    protected function generateDirectory($dir, $success, $error) : int
     {
         if (!$this->laravel['files']->isDirectory($dir)) {
             $this->laravel['files']->makeDirectory($dir, 0755, true, true);
 
             $this->info($success);
 
-            return;
+            return 0;
         }
 
         $this->error($error);
+
+        return E_ERROR;
     }
 }

--- a/src/Commands/UnUseCommand.php
+++ b/src/Commands/UnUseCommand.php
@@ -23,10 +23,12 @@ class UnUseCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle() : int
     {
         $this->laravel['modules']->forgetUsed();
 
         $this->info('Previous module used successfully forgotten.');
+
+        return 0;
     }
 }

--- a/src/Commands/UpdateCommand.php
+++ b/src/Commands/UpdateCommand.php
@@ -27,20 +27,22 @@ class UpdateCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle() : int
     {
         $name = $this->argument('module');
 
         if ($name) {
             $this->updateModule($name);
 
-            return;
+            return 0;
         }
 
         /** @var \Nwidart\Modules\Module $module */
         foreach ($this->laravel['modules']->getOrdered() as $module) {
             $this->updateModule($module->getName());
         }
+
+        return 0;
     }
 
     protected function updateModule($name)

--- a/src/Commands/UseCommand.php
+++ b/src/Commands/UseCommand.php
@@ -25,19 +25,21 @@ class UseCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle() : int
     {
         $module = Str::studly($this->argument('module'));
 
         if (!$this->laravel['modules']->has($module)) {
             $this->error("Module [{$module}] does not exists.");
 
-            return;
+            return E_ERROR;
         }
 
         $this->laravel['modules']->setUsed($module);
 
         $this->info("Module [{$module}] used successfully.");
+
+        return 0;
     }
 
     /**

--- a/src/Generators/ModuleGenerator.php
+++ b/src/Generators/ModuleGenerator.php
@@ -285,7 +285,7 @@ class ModuleGenerator extends Generator
     /**
      * Generate the module.
      */
-    public function generate()
+    public function generate() : int
     {
         $name = $this->getName();
 
@@ -295,7 +295,7 @@ class ModuleGenerator extends Generator
             } else {
                 $this->console->error("Module [{$name}] already exist!");
 
-                return;
+                return E_ERROR;
             }
         }
 
@@ -315,6 +315,8 @@ class ModuleGenerator extends Generator
         $this->activator->setActiveByName($name, $this->isActive);
 
         $this->console->info("Module [{$name}] created successfully.");
+
+        return 0;
     }
 
     /**

--- a/tests/Commands/CommandMakeCommandTest.php
+++ b/tests/Commands/CommandMakeCommandTest.php
@@ -35,25 +35,27 @@ class CommandMakeCommandTest extends BaseTestCase
     /** @test */
     public function it_generates_a_new_console_command_class()
     {
-        $this->artisan('module:make-command', ['name' => 'MyAwesomeCommand', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-command', ['name' => 'MyAwesomeCommand', 'module' => 'Blog']);
 
         $this->assertTrue(is_file($this->modulePath . '/Console/MyAwesomeCommand.php'));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generated_correct_file_with_content()
     {
-        $this->artisan('module:make-command', ['name' => 'MyAwesomeCommand', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-command', ['name' => 'MyAwesomeCommand', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Console/MyAwesomeCommand.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_uses_set_command_name_in_class()
     {
-        $this->artisan(
+        $code = $this->artisan(
             'module:make-command',
             ['name' => 'MyAwesomeCommand', 'module' => 'Blog', '--command' => 'my:awesome']
         );
@@ -61,6 +63,7 @@ class CommandMakeCommandTest extends BaseTestCase
         $file = $this->finder->get($this->modulePath . '/Console/MyAwesomeCommand.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -68,11 +71,12 @@ class CommandMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.command.path', 'Commands');
 
-        $this->artisan('module:make-command', ['name' => 'AwesomeCommand', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-command', ['name' => 'AwesomeCommand', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Commands/AwesomeCommand.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -80,10 +84,11 @@ class CommandMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.command.namespace', 'Commands');
 
-        $this->artisan('module:make-command', ['name' => 'AwesomeCommand', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-command', ['name' => 'AwesomeCommand', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Console/AwesomeCommand.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/ControllerMakeCommandTest.php
+++ b/tests/Commands/ControllerMakeCommandTest.php
@@ -35,43 +35,47 @@ class ControllerMakeCommandTest extends BaseTestCase
     /** @test */
     public function it_generates_a_new_controller_class()
     {
-        $this->artisan('module:make-controller', ['controller' => 'MyController', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-controller', ['controller' => 'MyController', 'module' => 'Blog']);
 
         $this->assertTrue(is_file($this->modulePath . '/Http/Controllers/MyController.php'));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generated_correct_file_with_content()
     {
-        $this->artisan('module:make-controller', ['controller' => 'MyController', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-controller', ['controller' => 'MyController', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Http/Controllers/MyController.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_appends_controller_to_name_if_not_present()
     {
-        $this->artisan('module:make-controller', ['controller' => 'My', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-controller', ['controller' => 'My', 'module' => 'Blog']);
 
         $this->assertTrue(is_file($this->modulePath . '/Http/Controllers/MyController.php'));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_appends_controller_to_class_name_if_not_present()
     {
-        $this->artisan('module:make-controller', ['controller' => 'My', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-controller', ['controller' => 'My', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Http/Controllers/MyController.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_a_plain_controller()
     {
-        $this->artisan('module:make-controller', [
+        $code = $this->artisan('module:make-controller', [
             'controller' => 'MyController',
             'module' => 'Blog',
             '--plain' => true,
@@ -80,12 +84,13 @@ class ControllerMakeCommandTest extends BaseTestCase
         $file = $this->finder->get($this->modulePath . '/Http/Controllers/MyController.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_an_api_controller()
     {
-        $this->artisan('module:make-controller', [
+        $code = $this->artisan('module:make-controller', [
             'controller' => 'MyController',
             'module' => 'Blog',
             '--api' => true,
@@ -94,6 +99,7 @@ class ControllerMakeCommandTest extends BaseTestCase
         $file = $this->finder->get($this->modulePath . '/Http/Controllers/MyController.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -101,11 +107,12 @@ class ControllerMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.controller.path', 'Controllers');
 
-        $this->artisan('module:make-controller', ['controller' => 'MyController', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-controller', ['controller' => 'MyController', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Controllers/MyController.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -113,28 +120,31 @@ class ControllerMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.controller.namespace', 'Controllers');
 
-        $this->artisan('module:make-controller', ['controller' => 'MyController', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-controller', ['controller' => 'MyController', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Http/Controllers/MyController.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_can_generate_a_controller_in_sub_namespace_in_correct_folder()
     {
-        $this->artisan('module:make-controller', ['controller' => 'Api\\MyController', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-controller', ['controller' => 'Api\\MyController', 'module' => 'Blog']);
 
         $this->assertTrue(is_file($this->modulePath . '/Http/Controllers/Api/MyController.php'));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_can_generate_a_controller_in_sub_namespace_with_correct_generated_file()
     {
-        $this->artisan('module:make-controller', ['controller' => 'Api\\MyController', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-controller', ['controller' => 'Api\\MyController', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Http/Controllers/Api/MyController.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/EnableCommandTest.php
+++ b/tests/Commands/EnableCommandTest.php
@@ -29,9 +29,10 @@ class EnableCommandTest extends BaseTestCase
         $blogModule = $this->app[RepositoryInterface::class]->find('Blog');
         $blogModule->disable();
 
-        $this->artisan('module:enable', ['module' => 'Blog']);
+        $code = $this->artisan('module:enable', ['module' => 'Blog']);
 
         $this->assertTrue($blogModule->isEnabled());
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -45,8 +46,9 @@ class EnableCommandTest extends BaseTestCase
         $taxonomyModule = $this->app[RepositoryInterface::class]->find('Taxonomy');
         $taxonomyModule->disable();
 
-        $this->artisan('module:enable');
+        $code = $this->artisan('module:enable');
 
         $this->assertTrue($blogModule->isEnabled() && $taxonomyModule->isEnabled());
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/EventMakeCommandTest.php
+++ b/tests/Commands/EventMakeCommandTest.php
@@ -36,19 +36,21 @@ class EventMakeCommandTest extends BaseTestCase
     /** @test */
     public function it_generates_a_new_event_class()
     {
-        $this->artisan('module:make-event', ['name' => 'PostWasCreated', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-event', ['name' => 'PostWasCreated', 'module' => 'Blog']);
 
         $this->assertTrue(is_file($this->modulePath . '/Events/PostWasCreated.php'));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generated_correct_file_with_content()
     {
-        $this->artisan('module:make-event', ['name' => 'PostWasCreated', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-event', ['name' => 'PostWasCreated', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Events/PostWasCreated.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -56,11 +58,12 @@ class EventMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.event.path', 'SuperEvents');
 
-        $this->artisan('module:make-event', ['name' => 'PostWasCreated', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-event', ['name' => 'PostWasCreated', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/SuperEvents/PostWasCreated.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -68,10 +71,11 @@ class EventMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.event.namespace', 'SuperEvents');
 
-        $this->artisan('module:make-event', ['name' => 'PostWasCreated', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-event', ['name' => 'PostWasCreated', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Events/PostWasCreated.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/FactoryMakeCommandTest.php
+++ b/tests/Commands/FactoryMakeCommandTest.php
@@ -35,11 +35,12 @@ class FactoryMakeCommandTest extends BaseTestCase
     /** @test */
     public function it_makes_factory()
     {
-        $this->artisan('module:make-factory', ['name' => 'PostFactory', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-factory', ['name' => 'PostFactory', 'module' => 'Blog']);
 
         $factoryFile = $this->modulePath . '/Database/factories/PostFactory.php';
 
         $this->assertTrue(is_file($factoryFile), 'Factory file was not created.');
         $this->assertMatchesSnapshot($this->finder->get($factoryFile));
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/JobMakeCommandTest.php
+++ b/tests/Commands/JobMakeCommandTest.php
@@ -35,29 +35,32 @@ class JobMakeCommandTest extends BaseTestCase
     /** @test */
     public function it_generates_the_job_class()
     {
-        $this->artisan('module:make-job', ['name' => 'SomeJob', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-job', ['name' => 'SomeJob', 'module' => 'Blog']);
 
         $this->assertTrue(is_file($this->modulePath . '/Jobs/SomeJob.php'));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generated_correct_file_with_content()
     {
-        $this->artisan('module:make-job', ['name' => 'SomeJob', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-job', ['name' => 'SomeJob', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Jobs/SomeJob.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generated_correct_sync_job_file_with_content()
     {
-        $this->artisan('module:make-job', ['name' => 'SomeJob', 'module' => 'Blog', '--sync' => true]);
+        $code = $this->artisan('module:make-job', ['name' => 'SomeJob', 'module' => 'Blog', '--sync' => true]);
 
         $file = $this->finder->get($this->modulePath . '/Jobs/SomeJob.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -65,11 +68,12 @@ class JobMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.jobs.path', 'SuperJobs');
 
-        $this->artisan('module:make-job', ['name' => 'SomeJob', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-job', ['name' => 'SomeJob', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/SuperJobs/SomeJob.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -77,10 +81,11 @@ class JobMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.jobs.namespace', 'SuperJobs');
 
-        $this->artisan('module:make-job', ['name' => 'SomeJob', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-job', ['name' => 'SomeJob', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Jobs/SomeJob.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/ListCommandTest.php
+++ b/tests/Commands/ListCommandTest.php
@@ -34,9 +34,10 @@ class ListCommandTest extends BaseTestCase
     /** @test */
     public function it_can_list_modules()
     {
-        $this->artisan('module:list');
+        $code = $this->artisan('module:list');
 
         // We just want to make sure nothing throws an exception inside the list command
         $this->assertTrue(true);
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/ListenerMakeCommandTest.php
+++ b/tests/Commands/ListenerMakeCommandTest.php
@@ -36,18 +36,19 @@ class ListenerMakeCommandTest extends BaseTestCase
     /** @test */
     public function it_generates_a_new_event_class()
     {
-        $this->artisan(
+        $code = $this->artisan(
             'module:make-listener',
             ['name' => 'NotifyUsersOfANewPost', 'module' => 'Blog', '--event' => 'UserWasCreated']
         );
 
         $this->assertTrue(is_file($this->modulePath . '/Listeners/NotifyUsersOfANewPost.php'));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generated_correct_sync_event_with_content()
     {
-        $this->artisan(
+        $code = $this->artisan(
             'module:make-listener',
             ['name' => 'NotifyUsersOfANewPost', 'module' => 'Blog', '--event' => 'UserWasCreated']
         );
@@ -55,12 +56,13 @@ class ListenerMakeCommandTest extends BaseTestCase
         $file = $this->finder->get($this->modulePath . '/Listeners/NotifyUsersOfANewPost.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generated_correct_sync_duck_event_with_content()
     {
-        $this->artisan(
+        $code = $this->artisan(
             'module:make-listener',
             ['name' => 'NotifyUsersOfANewPost', 'module' => 'Blog']
         );
@@ -68,12 +70,13 @@ class ListenerMakeCommandTest extends BaseTestCase
         $file = $this->finder->get($this->modulePath . '/Listeners/NotifyUsersOfANewPost.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generated_correct_queued_event_with_content()
     {
-        $this->artisan(
+        $code = $this->artisan(
             'module:make-listener',
             ['name' => 'NotifyUsersOfANewPost', 'module' => 'Blog', '--event' => 'UserWasCreated', '--queued' => true]
         );
@@ -81,12 +84,13 @@ class ListenerMakeCommandTest extends BaseTestCase
         $file = $this->finder->get($this->modulePath . '/Listeners/NotifyUsersOfANewPost.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generated_correct_queued_duck_event_with_content()
     {
-        $this->artisan(
+        $code = $this->artisan(
             'module:make-listener',
             ['name' => 'NotifyUsersOfANewPost', 'module' => 'Blog', '--queued' => true]
         );
@@ -94,6 +98,7 @@ class ListenerMakeCommandTest extends BaseTestCase
         $file = $this->finder->get($this->modulePath . '/Listeners/NotifyUsersOfANewPost.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -101,7 +106,7 @@ class ListenerMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.listener.path', 'Events/Handlers');
 
-        $this->artisan(
+        $code = $this->artisan(
             'module:make-listener',
             ['name' => 'NotifyUsersOfANewPost', 'module' => 'Blog']
         );
@@ -109,6 +114,7 @@ class ListenerMakeCommandTest extends BaseTestCase
         $file = $this->finder->get($this->modulePath . '/Events/Handlers/NotifyUsersOfANewPost.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -116,7 +122,7 @@ class ListenerMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.listener.namespace', 'Events\\Handlers');
 
-        $this->artisan(
+        $code = $this->artisan(
             'module:make-listener',
             ['name' => 'NotifyUsersOfANewPost', 'module' => 'Blog']
         );
@@ -124,5 +130,6 @@ class ListenerMakeCommandTest extends BaseTestCase
         $file = $this->finder->get($this->modulePath . '/Listeners/NotifyUsersOfANewPost.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/MailMakeCommandTest.php
+++ b/tests/Commands/MailMakeCommandTest.php
@@ -35,19 +35,21 @@ class MailMakeCommandTest extends BaseTestCase
     /** @test */
     public function it_generates_the_mail_class()
     {
-        $this->artisan('module:make-mail', ['name' => 'SomeMail', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-mail', ['name' => 'SomeMail', 'module' => 'Blog']);
 
         $this->assertTrue(is_file($this->modulePath . '/Emails/SomeMail.php'));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generated_correct_file_with_content()
     {
-        $this->artisan('module:make-mail', ['name' => 'SomeMail', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-mail', ['name' => 'SomeMail', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Emails/SomeMail.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -55,11 +57,12 @@ class MailMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.emails.path', 'SuperEmails');
 
-        $this->artisan('module:make-mail', ['name' => 'SomeMail', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-mail', ['name' => 'SomeMail', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/SuperEmails/SomeMail.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -67,10 +70,11 @@ class MailMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.emails.namespace', 'SuperEmails');
 
-        $this->artisan('module:make-mail', ['name' => 'SomeMail', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-mail', ['name' => 'SomeMail', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Emails/SomeMail.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/MiddlewareMakeCommandTest.php
+++ b/tests/Commands/MiddlewareMakeCommandTest.php
@@ -35,19 +35,21 @@ class MiddlewareMakeCommandTest extends BaseTestCase
     /** @test */
     public function it_generates_a_new_middleware_class()
     {
-        $this->artisan('module:make-middleware', ['name' => 'SomeMiddleware', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-middleware', ['name' => 'SomeMiddleware', 'module' => 'Blog']);
 
         $this->assertTrue(is_file($this->modulePath . '/Http/Middleware/SomeMiddleware.php'));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generated_correct_file_with_content()
     {
-        $this->artisan('module:make-middleware', ['name' => 'SomeMiddleware', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-middleware', ['name' => 'SomeMiddleware', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Http/Middleware/SomeMiddleware.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -55,11 +57,12 @@ class MiddlewareMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.filter.path', 'Middleware');
 
-        $this->artisan('module:make-middleware', ['name' => 'SomeMiddleware', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-middleware', ['name' => 'SomeMiddleware', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Middleware/SomeMiddleware.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -67,10 +70,11 @@ class MiddlewareMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.filter.namespace', 'Middleware');
 
-        $this->artisan('module:make-middleware', ['name' => 'SomeMiddleware', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-middleware', ['name' => 'SomeMiddleware', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Http/Middleware/SomeMiddleware.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/MigrationMakeCommandTest.php
+++ b/tests/Commands/MigrationMakeCommandTest.php
@@ -35,82 +35,89 @@ class MigrationMakeCommandTest extends BaseTestCase
     /** @test */
     public function it_generates_a_new_migration_class()
     {
-        $this->artisan('module:make-migration', ['name' => 'create_posts_table', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-migration', ['name' => 'create_posts_table', 'module' => 'Blog']);
 
         $files = $this->finder->allFiles($this->modulePath . '/Database/Migrations');
 
         $this->assertCount(1, $files);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_correct_create_migration_file_content()
     {
-        $this->artisan('module:make-migration', ['name' => 'create_posts_table', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-migration', ['name' => 'create_posts_table', 'module' => 'Blog']);
 
         $migrations = $this->finder->allFiles($this->modulePath . '/Database/Migrations');
         $fileName = $migrations[0]->getRelativePathname();
         $file = $this->finder->get($this->modulePath . '/Database/Migrations/' . $fileName);
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_correct_add_migration_file_content()
     {
-        $this->artisan('module:make-migration', ['name' => 'add_something_to_posts_table', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-migration', ['name' => 'add_something_to_posts_table', 'module' => 'Blog']);
 
         $migrations = $this->finder->allFiles($this->modulePath . '/Database/Migrations');
         $fileName = $migrations[0]->getRelativePathname();
         $file = $this->finder->get($this->modulePath . '/Database/Migrations/' . $fileName);
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_correct_delete_migration_file_content()
     {
-        $this->artisan('module:make-migration', ['name' => 'delete_something_from_posts_table', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-migration', ['name' => 'delete_something_from_posts_table', 'module' => 'Blog']);
 
         $migrations = $this->finder->allFiles($this->modulePath . '/Database/Migrations');
         $fileName = $migrations[0]->getRelativePathname();
         $file = $this->finder->get($this->modulePath . '/Database/Migrations/' . $fileName);
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_correct_drop_migration_file_content()
     {
-        $this->artisan('module:make-migration', ['name' => 'drop_posts_table', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-migration', ['name' => 'drop_posts_table', 'module' => 'Blog']);
 
         $migrations = $this->finder->allFiles($this->modulePath . '/Database/Migrations');
         $fileName = $migrations[0]->getRelativePathname();
         $file = $this->finder->get($this->modulePath . '/Database/Migrations/' . $fileName);
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_correct_default_migration_file_content()
     {
-        $this->artisan('module:make-migration', ['name' => 'something_random_name', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-migration', ['name' => 'something_random_name', 'module' => 'Blog']);
 
         $migrations = $this->finder->allFiles($this->modulePath . '/Database/Migrations');
         $fileName = $migrations[0]->getRelativePathname();
         $file = $this->finder->get($this->modulePath . '/Database/Migrations/' . $fileName);
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_foreign_key_constraints()
     {
-        $this->artisan('module:make-migration', ['name' => 'create_posts_table', 'module' => 'Blog', '--fields' => 'belongsTo:user:id:users']);
+        $code = $this->artisan('module:make-migration', ['name' => 'create_posts_table', 'module' => 'Blog', '--fields' => 'belongsTo:user:id:users']);
 
         $migrations = $this->finder->allFiles($this->modulePath . '/Database/Migrations');
         $fileName = $migrations[0]->getRelativePathname();
         $file = $this->finder->get($this->modulePath . '/Database/Migrations/' . $fileName);
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/ModelMakeCommandTest.php
+++ b/tests/Commands/ModelMakeCommandTest.php
@@ -36,59 +36,64 @@ class ModelMakeCommandTest extends BaseTestCase
     /** @test */
     public function it_generates_a_new_model_class()
     {
-        $this->artisan('module:make-model', ['model' => 'Post', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-model', ['model' => 'Post', 'module' => 'Blog']);
 
         $this->assertTrue(is_file($this->modulePath . '/Entities/Post.php'));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generated_correct_file_with_content()
     {
-        $this->artisan('module:make-model', ['model' => 'Post', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-model', ['model' => 'Post', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Entities/Post.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_correct_fillable_fields()
     {
-        $this->artisan('module:make-model', ['model' => 'Post', 'module' => 'Blog', '--fillable' => 'title,slug']);
+        $code = $this->artisan('module:make-model', ['model' => 'Post', 'module' => 'Blog', '--fillable' => 'title,slug']);
 
         $file = $this->finder->get($this->modulePath . '/Entities/Post.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_migration_file_with_model()
     {
-        $this->artisan('module:make-model', ['model' => 'Post', 'module' => 'Blog', '--migration' => true]);
+        $code = $this->artisan('module:make-model', ['model' => 'Post', 'module' => 'Blog', '--migration' => true]);
 
         $migrations = $this->finder->allFiles($this->modulePath . '/Database/Migrations');
         $migrationFile = $migrations[0];
         $migrationContent = $this->finder->get($this->modulePath . '/Database/Migrations/' . $migrationFile->getFilename());
         $this->assertCount(1, $migrations);
         $this->assertMatchesSnapshot($migrationContent);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_migration_file_with_model_using_shortcut_option()
     {
-        $this->artisan('module:make-model', ['model' => 'Post', 'module' => 'Blog', '-m' => true]);
+        $code = $this->artisan('module:make-model', ['model' => 'Post', 'module' => 'Blog', '-m' => true]);
 
         $migrations = $this->finder->allFiles($this->modulePath . '/Database/Migrations');
         $migrationFile = $migrations[0];
         $migrationContent = $this->finder->get($this->modulePath . '/Database/Migrations/' . $migrationFile->getFilename());
         $this->assertCount(1, $migrations);
         $this->assertMatchesSnapshot($migrationContent);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_correct_migration_file_name_with_multiple_words_model()
     {
-        $this->artisan('module:make-model', ['model' => 'ProductDetail', 'module' => 'Blog', '-m' => true]);
+        $code = $this->artisan('module:make-model', ['model' => 'ProductDetail', 'module' => 'Blog', '-m' => true]);
 
         $migrations = $this->finder->allFiles($this->modulePath . '/Database/Migrations');
         $migrationFile = $migrations[0];
@@ -96,15 +101,17 @@ class ModelMakeCommandTest extends BaseTestCase
 
         $this->assertStringContainsString('create_product_details_table', $migrationFile->getFilename());
         $this->assertMatchesSnapshot($migrationContent);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_displays_error_if_model_already_exists()
     {
         $this->artisan('module:make-model', ['model' => 'Post', 'module' => 'Blog']);
-        $this->artisan('module:make-model', ['model' => 'Post', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-model', ['model' => 'Post', 'module' => 'Blog']);
 
         $this->assertStringContainsString('already exists', Artisan::output());
+        $this->assertSame(E_ERROR, $code);
     }
 
     /** @test */
@@ -112,11 +119,12 @@ class ModelMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.model.path', 'Models');
 
-        $this->artisan('module:make-model', ['model' => 'Post', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-model', ['model' => 'Post', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Models/Post.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -124,10 +132,11 @@ class ModelMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.model.namespace', 'Models');
 
-        $this->artisan('module:make-model', ['model' => 'Post', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-model', ['model' => 'Post', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Entities/Post.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/ModuleDeleteCommandTest.php
+++ b/tests/Commands/ModuleDeleteCommandTest.php
@@ -32,8 +32,9 @@ class ModuleDeleteCommandTest extends BaseTestCase
         $this->artisan('module:make', ['name' => ['WrongModule']]);
         $this->assertDirectoryExists(base_path('modules/WrongModule'));
 
-        $this->artisan('module:delete', ['module' => 'WrongModule']);
+        $code = $this->artisan('module:delete', ['module' => 'WrongModule']);
         $this->assertDirectoryNotExists(base_path('modules/WrongModule'));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -42,7 +43,8 @@ class ModuleDeleteCommandTest extends BaseTestCase
         $this->artisan('module:make', ['name' => ['WrongModule']]);
         $this->assertMatchesSnapshot($this->finder->get($this->activator->getStatusesFilePath()));
 
-        $this->artisan('module:delete', ['module' => 'WrongModule']);
+        $code = $this->artisan('module:delete', ['module' => 'WrongModule']);
         $this->assertMatchesSnapshot($this->finder->get($this->activator->getStatusesFilePath()));
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/ModuleMakeCommandTest.php
+++ b/tests/Commands/ModuleMakeCommandTest.php
@@ -61,17 +61,18 @@ class ModuleMakeCommandTest extends BaseTestCase
     /** @test */
     public function it_generates_module_folders()
     {
-        $this->artisan('module:make', ['name' => ['Blog']]);
+        $code = $this->artisan('module:make', ['name' => ['Blog']]);
 
         foreach (config('modules.paths.generator') as $directory) {
             $this->assertDirectoryExists($this->modulePath . '/' . $directory['path']);
         }
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_module_files()
     {
-        $this->artisan('module:make', ['name' => ['Blog']]);
+        $code = $this->artisan('module:make', ['name' => ['Blog']]);
 
         foreach (config('modules.stubs.files') as $file) {
             $path = base_path('modules/Blog') . '/' . $file;
@@ -80,44 +81,48 @@ class ModuleMakeCommandTest extends BaseTestCase
         $path = base_path('modules/Blog') . '/module.json';
         $this->assertTrue($this->finder->exists($path), '[module.json] does not exists');
         $this->assertMatchesSnapshot($this->finder->get($path));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_web_route_file()
     {
         $files = $this->app['modules']->config('stubs.files');
-        $this->artisan('module:make', ['name' => ['Blog']]);
+        $code = $this->artisan('module:make', ['name' => ['Blog']]);
 
         $path = $this->modulePath . '/' . $files['routes/web'];
 
         $this->assertMatchesSnapshot($this->finder->get($path));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_api_route_file()
     {
         $files = $this->app['modules']->config('stubs.files');
-        $this->artisan('module:make', ['name' => ['Blog']]);
+        $code = $this->artisan('module:make', ['name' => ['Blog']]);
 
         $path = $this->modulePath . '/' . $files['routes/api'];
 
         $this->assertMatchesSnapshot($this->finder->get($path));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_webpack_file()
     {
-        $this->artisan('module:make', ['name' => ['Blog']]);
+        $code = $this->artisan('module:make', ['name' => ['Blog']]);
 
         $path = $this->modulePath . '/' . $this->app['modules']->config('stubs.files.webpack');
 
         $this->assertMatchesSnapshot($this->finder->get($path));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_module_resources()
     {
-        $this->artisan('module:make', ['name' => ['Blog']]);
+        $code = $this->artisan('module:make', ['name' => ['Blog']]);
 
         $path = base_path('modules/Blog') . '/Providers/BlogServiceProvider.php';
         $this->assertTrue($this->finder->exists($path));
@@ -134,40 +139,45 @@ class ModuleMakeCommandTest extends BaseTestCase
         $path = base_path('modules/Blog') . '/Providers/RouteServiceProvider.php';
         $this->assertTrue($this->finder->exists($path));
         $this->assertMatchesSnapshot($this->finder->get($path));
+
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_correct_composerjson_file()
     {
-        $this->artisan('module:make', ['name' => ['Blog']]);
+        $code = $this->artisan('module:make', ['name' => ['Blog']]);
 
         $file = $this->finder->get($this->modulePath . '/composer.json');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_module_folder_using_studly_case()
     {
-        $this->artisan('module:make', ['name' => ['ModuleName']]);
+        $code = $this->artisan('module:make', ['name' => ['ModuleName']]);
 
         $this->assertTrue($this->finder->exists(base_path('modules/ModuleName')));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_module_namespace_using_studly_case()
     {
-        $this->artisan('module:make', ['name' => ['ModuleName']]);
+        $code = $this->artisan('module:make', ['name' => ['ModuleName']]);
 
         $file = $this->finder->get(base_path('modules/ModuleName') . '/Providers/ModuleNameServiceProvider.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_a_plain_module_with_no_resources()
     {
-        $this->artisan('module:make', ['name' => ['ModuleName'], '--plain' => true]);
+        $code = $this->artisan('module:make', ['name' => ['ModuleName'], '--plain' => true]);
 
         $path = base_path('modules/ModuleName') . '/Providers/ModuleNameServiceProvider.php';
         $this->assertFalse($this->finder->exists($path));
@@ -177,12 +187,14 @@ class ModuleMakeCommandTest extends BaseTestCase
 
         $path = base_path('modules/ModuleName') . '/Database/Seeders/ModuleNameDatabaseSeeder.php';
         $this->assertFalse($this->finder->exists($path));
+
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_a_plain_module_with_no_files()
     {
-        $this->artisan('module:make', ['name' => ['ModuleName'], '--plain' => true]);
+        $code = $this->artisan('module:make', ['name' => ['ModuleName'], '--plain' => true]);
 
         foreach (config('modules.stubs.files') as $file) {
             $path = base_path('modules/ModuleName') . '/' . $file;
@@ -190,35 +202,38 @@ class ModuleMakeCommandTest extends BaseTestCase
         }
         $path = base_path('modules/ModuleName') . '/module.json';
         $this->assertTrue($this->finder->exists($path), '[module.json] does not exists');
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_plain_module_with_no_service_provider_in_modulejson_file()
     {
-        $this->artisan('module:make', ['name' => ['ModuleName'], '--plain' => true]);
+        $code = $this->artisan('module:make', ['name' => ['ModuleName'], '--plain' => true]);
 
         $path = base_path('modules/ModuleName') . '/module.json';
         $content = json_decode($this->finder->get($path));
 
         $this->assertCount(0, $content->providers);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_outputs_error_when_module_exists()
     {
         $this->artisan('module:make', ['name' => ['Blog']]);
-        $this->artisan('module:make', ['name' => ['Blog']]);
+        $code = $this->artisan('module:make', ['name' => ['Blog']]);
 
         $expected = 'Module [Blog] already exist!
 ';
         $this->assertEquals($expected, Artisan::output());
+        $this->assertSame(E_ERROR, $code);
     }
 
     /** @test */
     public function it_still_generates_module_if_it_exists_using_force_flag()
     {
         $this->artisan('module:make', ['name' => ['Blog']]);
-        $this->artisan('module:make', ['name' => ['Blog'], '--force' => true]);
+        $code = $this->artisan('module:make', ['name' => ['Blog'], '--force' => true]);
 
         $output = Artisan::output();
 
@@ -226,6 +241,7 @@ class ModuleMakeCommandTest extends BaseTestCase
 ';
         $this->assertNotEquals($notExpected, $output);
         $this->assertTrue(Str::contains($output, 'Module [Blog] created successfully.'));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -257,12 +273,13 @@ class ModuleMakeCommandTest extends BaseTestCase
             'resource' => false,
         ]);
 
-        $this->artisan('module:make', ['name' => ['Blog']]);
+        $code = $this->artisan('module:make', ['name' => ['Blog']]);
 
         $this->assertDirectoryExists($this->modulePath . '/Assets');
         $this->assertDirectoryExists($this->modulePath . '/Emails');
         $this->assertDirectoryNotExists($this->modulePath . '/Rules');
         $this->assertDirectoryNotExists($this->modulePath . '/Policies');
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -271,10 +288,11 @@ class ModuleMakeCommandTest extends BaseTestCase
         $this->app['config']->set('modules.paths.generator.assets', false);
         $this->app['config']->set('modules.paths.generator.emails', false);
 
-        $this->artisan('module:make', ['name' => ['Blog']]);
+        $code = $this->artisan('module:make', ['name' => ['Blog']]);
 
         $this->assertDirectoryNotExists($this->modulePath . '/Assets');
         $this->assertDirectoryNotExists($this->modulePath . '/Emails');
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -283,10 +301,11 @@ class ModuleMakeCommandTest extends BaseTestCase
         $this->app['config']->set('modules.paths.generator.assets', ['path' => 'Assets', 'generate' => false]);
         $this->app['config']->set('modules.paths.generator.emails', ['path' => 'Emails', 'generate' => false]);
 
-        $this->artisan('module:make', ['name' => ['Blog']]);
+        $code = $this->artisan('module:make', ['name' => ['Blog']]);
 
         $this->assertDirectoryNotExists($this->modulePath . '/Assets');
         $this->assertDirectoryNotExists($this->modulePath . '/Emails');
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -296,27 +315,30 @@ class ModuleMakeCommandTest extends BaseTestCase
         $this->app['config']->set('modules.paths.generator.provider', ['path' => 'Providers', 'generate' => false]);
         $this->app['config']->set('modules.paths.generator.controller', ['path' => 'Http/Controllers', 'generate' => false]);
 
-        $this->artisan('module:make', ['name' => ['Blog']]);
+        $code = $this->artisan('module:make', ['name' => ['Blog']]);
 
         $this->assertDirectoryNotExists($this->modulePath . '/Database/Seeders');
         $this->assertDirectoryNotExists($this->modulePath . '/Providers');
         $this->assertDirectoryNotExists($this->modulePath . '/Http/Controllers');
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_enabled_module()
     {
-        $this->artisan('module:make', ['name' => ['Blog']]);
+        $code = $this->artisan('module:make', ['name' => ['Blog']]);
 
         $this->assertTrue($this->repository->isEnabled('Blog'));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_disabled_module_with_disabled_flag()
     {
-        $this->artisan('module:make', ['name' => ['Blog'], '--disabled' => true]);
+        $code = $this->artisan('module:make', ['name' => ['Blog'], '--disabled' => true]);
 
         $this->assertTrue($this->repository->isDisabled('Blog'));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -324,12 +346,13 @@ class ModuleMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.provider', ['path' => 'Base/Providers', 'generate' => true]);
 
-        $this->artisan('module:make', ['name' => ['Blog']]);
+        $code = $this->artisan('module:make', ['name' => ['Blog']]);
 
         $this->assertDirectoryExists($this->modulePath . '/Base/Providers');
         $file = $this->finder->get($this->modulePath . '/module.json');
         $this->assertMatchesSnapshot($file);
         $file = $this->finder->get($this->modulePath . '/composer.json');
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/NotificationMakeCommandTest.php
+++ b/tests/Commands/NotificationMakeCommandTest.php
@@ -35,19 +35,21 @@ class NotificationMakeCommandTest extends BaseTestCase
     /** @test */
     public function it_generates_the_mail_class()
     {
-        $this->artisan('module:make-notification', ['name' => 'WelcomeNotification', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-notification', ['name' => 'WelcomeNotification', 'module' => 'Blog']);
 
         $this->assertTrue(is_file($this->modulePath . '/Notifications/WelcomeNotification.php'));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generated_correct_file_with_content()
     {
-        $this->artisan('module:make-notification', ['name' => 'WelcomeNotification', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-notification', ['name' => 'WelcomeNotification', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Notifications/WelcomeNotification.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -55,11 +57,12 @@ class NotificationMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.notifications.path', 'SuperNotifications');
 
-        $this->artisan('module:make-notification', ['name' => 'WelcomeNotification', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-notification', ['name' => 'WelcomeNotification', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/SuperNotifications/WelcomeNotification.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -67,10 +70,11 @@ class NotificationMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.notifications.namespace', 'SuperNotifications');
 
-        $this->artisan('module:make-notification', ['name' => 'WelcomeNotification', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-notification', ['name' => 'WelcomeNotification', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Notifications/WelcomeNotification.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/PolicyMakeCommandTest.php
+++ b/tests/Commands/PolicyMakeCommandTest.php
@@ -35,12 +35,13 @@ class PolicyMakeCommandTest extends BaseTestCase
     /** @test */
     public function it_makes_policy()
     {
-        $this->artisan('module:make-policy', ['name' => 'PostPolicy', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-policy', ['name' => 'PostPolicy', 'module' => 'Blog']);
 
         $policyFile = $this->modulePath . '/Policies/PostPolicy.php';
 
         $this->assertTrue(is_file($policyFile), 'Policy file was not created.');
         $this->assertMatchesSnapshot($this->finder->get($policyFile));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -48,11 +49,12 @@ class PolicyMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.policies.path', 'SuperPolicies');
 
-        $this->artisan('module:make-policy', ['name' => 'PostPolicy', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-policy', ['name' => 'PostPolicy', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/SuperPolicies/PostPolicy.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -60,10 +62,11 @@ class PolicyMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.policies.namespace', 'SuperPolicies');
 
-        $this->artisan('module:make-policy', ['name' => 'PostPolicy', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-policy', ['name' => 'PostPolicy', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Policies/PostPolicy.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/ProviderMakeCommandTest.php
+++ b/tests/Commands/ProviderMakeCommandTest.php
@@ -35,39 +35,43 @@ class ProviderMakeCommandTest extends BaseTestCase
     /** @test */
     public function it_generates_a_service_provider()
     {
-        $this->artisan('module:make-provider', ['name' => 'MyBlogServiceProvider', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-provider', ['name' => 'MyBlogServiceProvider', 'module' => 'Blog']);
 
         $this->assertTrue(is_file($this->modulePath . '/Providers/MyBlogServiceProvider.php'));
+        $this->assertSame(0, $code);
     }
     /** @test */
     public function it_generated_correct_file_with_content()
     {
-        $this->artisan('module:make-provider', ['name' => 'MyBlogServiceProvider', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-provider', ['name' => 'MyBlogServiceProvider', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Providers/MyBlogServiceProvider.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generates_a_master_service_provider_with_resource_loading()
     {
-        $this->artisan('module:make-provider', ['name' => 'BlogServiceProvider', 'module' => 'Blog', '--master' => true]);
+        $code = $this->artisan('module:make-provider', ['name' => 'BlogServiceProvider', 'module' => 'Blog', '--master' => true]);
 
         $file = $this->finder->get($this->modulePath . '/Providers/BlogServiceProvider.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_can_have_custom_migration_resources_location_paths()
     {
         $this->app['config']->set('modules.paths.generator.migration', 'migrations');
-        $this->artisan('module:make-provider', ['name' => 'BlogServiceProvider', 'module' => 'Blog', '--master' => true]);
+        $code = $this->artisan('module:make-provider', ['name' => 'BlogServiceProvider', 'module' => 'Blog', '--master' => true]);
 
         $file = $this->finder->get($this->modulePath . '/Providers/BlogServiceProvider.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -75,11 +79,12 @@ class ProviderMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.provider.path', 'SuperProviders');
 
-        $this->artisan('module:make-provider', ['name' => 'BlogServiceProvider', 'module' => 'Blog', '--master' => true]);
+        $code = $this->artisan('module:make-provider', ['name' => 'BlogServiceProvider', 'module' => 'Blog', '--master' => true]);
 
         $file = $this->finder->get($this->modulePath . '/SuperProviders/BlogServiceProvider.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -87,10 +92,11 @@ class ProviderMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.provider.namespace', 'SuperProviders');
 
-        $this->artisan('module:make-provider', ['name' => 'BlogServiceProvider', 'module' => 'Blog', '--master' => true]);
+        $code = $this->artisan('module:make-provider', ['name' => 'BlogServiceProvider', 'module' => 'Blog', '--master' => true]);
 
         $file = $this->finder->get($this->modulePath . '/Providers/BlogServiceProvider.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/PublishCommandTest.php
+++ b/tests/Commands/PublishCommandTest.php
@@ -34,8 +34,9 @@ class PublishCommandTest extends BaseTestCase
     /** @test */
     public function it_published_module_assets()
     {
-        $this->artisan('module:publish', ['module' => 'Blog']);
+        $code = $this->artisan('module:publish', ['module' => 'Blog']);
 
         $this->assertTrue(is_file(public_path('modules/blog/script.js')));
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/PublishMigrationCommandTest.php
+++ b/tests/Commands/PublishMigrationCommandTest.php
@@ -35,10 +35,11 @@ class PublishMigrationCommandTest extends BaseTestCase
     /** @test */
     public function it_publishes_module_migrations()
     {
-        $this->artisan('module:publish-migration', ['module' => 'Blog']);
+        $code = $this->artisan('module:publish-migration', ['module' => 'Blog']);
 
         $files = $this->finder->allFiles(base_path('database/migrations'));
 
         $this->assertCount(1, $files);
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/PublishTranslationCommandTest.php
+++ b/tests/Commands/PublishTranslationCommandTest.php
@@ -33,8 +33,9 @@ class PublishTranslationCommandTest extends BaseTestCase
     /** @test */
     public function it_published_module_translations()
     {
-        $this->artisan('module:publish-translation', ['module' => 'Blog']);
+        $code = $this->artisan('module:publish-translation', ['module' => 'Blog']);
 
         $this->assertDirectoryExists(base_path('resources/lang/blog'));
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/RequestMakeCommandTest.php
+++ b/tests/Commands/RequestMakeCommandTest.php
@@ -35,19 +35,21 @@ class RequestMakeCommandTest extends BaseTestCase
     /** @test */
     public function it_generates_a_new_form_request_class()
     {
-        $this->artisan('module:make-request', ['name' => 'CreateBlogPostRequest', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-request', ['name' => 'CreateBlogPostRequest', 'module' => 'Blog']);
 
         $this->assertTrue(is_file($this->modulePath . '/Http/Requests/CreateBlogPostRequest.php'));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generated_correct_file_with_content()
     {
-        $this->artisan('module:make-request', ['name' => 'CreateBlogPostRequest', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-request', ['name' => 'CreateBlogPostRequest', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Http/Requests/CreateBlogPostRequest.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -55,11 +57,12 @@ class RequestMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.request.path', 'SuperRequests');
 
-        $this->artisan('module:make-request', ['name' => 'CreateBlogPostRequest', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-request', ['name' => 'CreateBlogPostRequest', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/SuperRequests/CreateBlogPostRequest.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -67,10 +70,11 @@ class RequestMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.request.namespace', 'SuperRequests');
 
-        $this->artisan('module:make-request', ['name' => 'CreateBlogPostRequest', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-request', ['name' => 'CreateBlogPostRequest', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Http/Requests/CreateBlogPostRequest.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/ResourceMakeCommandTest.php
+++ b/tests/Commands/ResourceMakeCommandTest.php
@@ -35,29 +35,32 @@ class ResourceMakeCommandTest extends BaseTestCase
     /** @test */
     public function it_generates_a_new_resource_class()
     {
-        $this->artisan('module:make-resource', ['name' => 'PostsTransformer', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-resource', ['name' => 'PostsTransformer', 'module' => 'Blog']);
 
         $this->assertTrue(is_file($this->modulePath . '/Transformers/PostsTransformer.php'));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generated_correct_file_with_content()
     {
-        $this->artisan('module:make-resource', ['name' => 'PostsTransformer', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-resource', ['name' => 'PostsTransformer', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Transformers/PostsTransformer.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_can_generate_a_collection_resource_class()
     {
-        $this->artisan('module:make-resource', ['name' => 'PostsTransformer', 'module' => 'Blog', '--collection' => true]);
+        $code = $this->artisan('module:make-resource', ['name' => 'PostsTransformer', 'module' => 'Blog', '--collection' => true]);
 
         $file = $this->finder->get($this->modulePath . '/Transformers/PostsTransformer.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -65,11 +68,12 @@ class ResourceMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.resource.path', 'Http/Resources');
 
-        $this->artisan('module:make-resource', ['name' => 'PostsTransformer', 'module' => 'Blog', '--collection' => true]);
+        $code = $this->artisan('module:make-resource', ['name' => 'PostsTransformer', 'module' => 'Blog', '--collection' => true]);
 
         $file = $this->finder->get($this->modulePath . '/Http/Resources/PostsTransformer.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -77,10 +81,11 @@ class ResourceMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.resource.namespace', 'Http\\Resources');
 
-        $this->artisan('module:make-resource', ['name' => 'PostsTransformer', 'module' => 'Blog', '--collection' => true]);
+        $code = $this->artisan('module:make-resource', ['name' => 'PostsTransformer', 'module' => 'Blog', '--collection' => true]);
 
         $file = $this->finder->get($this->modulePath . '/Transformers/PostsTransformer.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/RouteProviderMakeCommandTest.php
+++ b/tests/Commands/RouteProviderMakeCommandTest.php
@@ -35,19 +35,21 @@ class RouteProviderMakeCommandTest extends BaseTestCase
     /** @test */
     public function it_generates_a_new_service_provider_class()
     {
-        $this->artisan('module:route-provider', ['module' => 'Blog']);
+        $code = $this->artisan('module:route-provider', ['module' => 'Blog']);
 
         $this->assertTrue(is_file($this->modulePath . '/Providers/RouteServiceProvider.php'));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generated_correct_file_with_content()
     {
-        $this->artisan('module:route-provider', ['module' => 'Blog']);
+        $code = $this->artisan('module:route-provider', ['module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Providers/RouteServiceProvider.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -55,11 +57,12 @@ class RouteProviderMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.provider.path', 'SuperProviders');
 
-        $this->artisan('module:route-provider', ['module' => 'Blog']);
+        $code = $this->artisan('module:route-provider', ['module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/SuperProviders/RouteServiceProvider.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -67,11 +70,12 @@ class RouteProviderMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.provider.namespace', 'SuperProviders');
 
-        $this->artisan('module:route-provider', ['module' => 'Blog']);
+        $code = $this->artisan('module:route-provider', ['module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Providers/RouteServiceProvider.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -80,11 +84,12 @@ class RouteProviderMakeCommandTest extends BaseTestCase
         $this->app['config']->set('modules.stubs.files.routes/web', 'SuperRoutes/web.php');
         $this->app['config']->set('modules.stubs.files.routes/api', 'SuperRoutes/api.php');
 
-        $this->artisan('module:route-provider', ['module' => 'Blog', '--force' => true]);
+        $code = $this->artisan('module:route-provider', ['module' => 'Blog', '--force' => true]);
 
         $file = $this->finder->get($this->modulePath . '/Providers/RouteServiceProvider.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -93,10 +98,11 @@ class RouteProviderMakeCommandTest extends BaseTestCase
         $this->artisan('module:route-provider', ['module' => 'Blog']);
         $this->app['config']->set('modules.stubs.files.routes/web', 'SuperRoutes/web.php');
 
-        $this->artisan('module:route-provider', ['module' => 'Blog', '--force' => true]);
+        $code = $this->artisan('module:route-provider', ['module' => 'Blog', '--force' => true]);
         $file = $this->finder->get($this->modulePath . '/Providers/RouteServiceProvider.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -105,9 +111,10 @@ class RouteProviderMakeCommandTest extends BaseTestCase
         $this->app['config']->set('modules.paths.generator.controller.path', 'Base/Http/Controllers');
         $this->app['config']->set('modules.paths.generator.provider.path', 'Base/Providers');
 
-        $this->artisan('module:route-provider', ['module' => 'Blog']);
+        $code = $this->artisan('module:route-provider', ['module' => 'Blog']);
         $file = $this->finder->get($this->modulePath . '/Base/Providers/RouteServiceProvider.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/RouteProviderMakeCommandTest.php
+++ b/tests/Commands/RouteProviderMakeCommandTest.php
@@ -35,18 +35,22 @@ class RouteProviderMakeCommandTest extends BaseTestCase
     /** @test */
     public function it_generates_a_new_service_provider_class()
     {
+        $path = $this->modulePath . '/Providers/RouteServiceProvider.php';
+        $this->finder->delete($path);
         $code = $this->artisan('module:route-provider', ['module' => 'Blog']);
 
-        $this->assertTrue(is_file($this->modulePath . '/Providers/RouteServiceProvider.php'));
+        $this->assertTrue(is_file($path));
         $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generated_correct_file_with_content()
     {
+        $path = $this->modulePath . '/Providers/RouteServiceProvider.php';
+        $this->finder->delete($path);
         $code = $this->artisan('module:route-provider', ['module' => 'Blog']);
 
-        $file = $this->finder->get($this->modulePath . '/Providers/RouteServiceProvider.php');
+        $file = $this->finder->get($path);
 
         $this->assertMatchesSnapshot($file);
         $this->assertSame(0, $code);
@@ -70,9 +74,11 @@ class RouteProviderMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.provider.namespace', 'SuperProviders');
 
+        $path = $this->modulePath . '/Providers/RouteServiceProvider.php';
+        $this->finder->delete($path);
         $code = $this->artisan('module:route-provider', ['module' => 'Blog']);
 
-        $file = $this->finder->get($this->modulePath . '/Providers/RouteServiceProvider.php');
+        $file = $this->finder->get($path);
 
         $this->assertMatchesSnapshot($file);
         $this->assertSame(0, $code);

--- a/tests/Commands/RuleMakeCommandTest.php
+++ b/tests/Commands/RuleMakeCommandTest.php
@@ -35,12 +35,13 @@ class RuleMakeCommandTest extends BaseTestCase
     /** @test */
     public function it_makes_rule()
     {
-        $this->artisan('module:make-rule', ['name' => 'UniqueRule', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-rule', ['name' => 'UniqueRule', 'module' => 'Blog']);
 
         $ruleFile = $this->modulePath . '/Rules/UniqueRule.php';
 
         $this->assertTrue(is_file($ruleFile), 'Rule file was not created.');
         $this->assertMatchesSnapshot($this->finder->get($ruleFile));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -48,11 +49,12 @@ class RuleMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.rules.path', 'SuperRules');
 
-        $this->artisan('module:make-rule', ['name' => 'UniqueRule', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-rule', ['name' => 'UniqueRule', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/SuperRules/UniqueRule.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -60,10 +62,11 @@ class RuleMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.rules.namespace', 'SuperRules');
 
-        $this->artisan('module:make-rule', ['name' => 'UniqueRule', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-rule', ['name' => 'UniqueRule', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Rules/UniqueRule.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/TestMakeCommandTest.php
+++ b/tests/Commands/TestMakeCommandTest.php
@@ -44,30 +44,33 @@ class TestMakeCommandTest extends BaseTestCase
     public function it_generates_a_new_test_class()
     {
         $this->artisan('module:make-test', ['name' => 'EloquentPostRepositoryTest', 'module' => 'Blog']);
-        $this->artisan('module:make-test', ['name' => 'EloquentPostRepositoryTest', 'module' => 'Blog', '--feature' => true]);
+        $code = $this->artisan('module:make-test', ['name' => 'EloquentPostRepositoryTest', 'module' => 'Blog', '--feature' => true]);
 
         $this->assertTrue(is_file($this->modulePath . '/Tests/Unit/EloquentPostRepositoryTest.php'));
         $this->assertTrue(is_file($this->modulePath . '/Tests/Feature/EloquentPostRepositoryTest.php'));
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generated_correct_unit_file_with_content()
     {
-        $this->artisan('module:make-test', ['name' => 'EloquentPostRepositoryTest', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-test', ['name' => 'EloquentPostRepositoryTest', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Tests/Unit/EloquentPostRepositoryTest.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
     public function it_generated_correct_feature_file_with_content()
     {
-        $this->artisan('module:make-test', ['name' => 'EloquentPostRepositoryTest', 'module' => 'Blog', '--feature' => true]);
+        $code = $this->artisan('module:make-test', ['name' => 'EloquentPostRepositoryTest', 'module' => 'Blog', '--feature' => true]);
 
         $file = $this->finder->get($this->modulePath . '/Tests/Feature/EloquentPostRepositoryTest.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -75,11 +78,12 @@ class TestMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.test.path', 'SuperTests/Unit');
 
-        $this->artisan('module:make-test', ['name' => 'EloquentPostRepositoryTest', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-test', ['name' => 'EloquentPostRepositoryTest', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/SuperTests/Unit/EloquentPostRepositoryTest.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -87,11 +91,12 @@ class TestMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.test.namespace', 'SuperTests\\Unit');
 
-        $this->artisan('module:make-test', ['name' => 'EloquentPostRepositoryTest', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-test', ['name' => 'EloquentPostRepositoryTest', 'module' => 'Blog']);
 
         $file = $this->finder->get($this->modulePath . '/Tests/Unit/EloquentPostRepositoryTest.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -99,11 +104,12 @@ class TestMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.test-feature.path', 'SuperTests/Feature');
 
-        $this->artisan('module:make-test', ['name' => 'EloquentPostRepositoryTest', 'module' => 'Blog', '--feature' => true]);
+        $code = $this->artisan('module:make-test', ['name' => 'EloquentPostRepositoryTest', 'module' => 'Blog', '--feature' => true]);
 
         $file = $this->finder->get($this->modulePath . '/SuperTests/Feature/EloquentPostRepositoryTest.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 
     /** @test */
@@ -111,10 +117,11 @@ class TestMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.test-feature.namespace', 'SuperTests\\Feature');
 
-        $this->artisan('module:make-test', ['name' => 'EloquentPostRepositoryTest', 'module' => 'Blog', '--feature' => true]);
+        $code = $this->artisan('module:make-test', ['name' => 'EloquentPostRepositoryTest', 'module' => 'Blog', '--feature' => true]);
 
         $file = $this->finder->get($this->modulePath . '/Tests/Feature/EloquentPostRepositoryTest.php');
 
         $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
     }
 }

--- a/tests/Commands/__snapshots__/RouteProviderMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
+++ b/tests/Commands/__snapshots__/RouteProviderMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
@@ -1,6 +1,6 @@
 <?php return '<?php
 
-namespace Modules\\Blog\\Providers;
+namespace Modules\\Blog\\SuperProviders;
 
 use Illuminate\\Support\\Facades\\Route;
 use Illuminate\\Foundation\\Support\\Providers\\RouteServiceProvider as ServiceProvider;


### PR DESCRIPTION
These return statements are useful when a subclass of the GeneratorCommand class wants to execute the ```handle()``` of its parent class but wants to know if the file creation was successful or not.