### PR TITLE
Refactor ListenerMakeCommand

### DIFF
--- a/src/Commands/ListenerMakeCommand.php
+++ b/src/Commands/ListenerMakeCommand.php
@@ -63,7 +63,7 @@ class ListenerMakeCommand extends GeneratorCommand
         return (new Stub($this->getStubName(), [
             'NAMESPACE' => $this->getClassNamespace($module),
             'EVENTNAME' => $this->getEventName($module),
-            'SHORTEVENTNAME' => class_basename($this->option('event')),
+            'SHORTEVENTNAME' => $this->getShortEventName(),
             'CLASS' => $this->getClass(),
         ]))->render();
     }
@@ -83,6 +83,11 @@ class ListenerMakeCommand extends GeneratorCommand
         $eventName = $namespace . "\\" . $eventPath->getPath() . "\\" . $this->option('event');
 
         return str_replace('/', '\\', $eventName);
+    }
+
+    protected function getShortEventName()
+    {
+        return class_basename($this->option('event'));
     }
 
     protected function getDestinationFilePath()

--- a/src/Commands/ListenerMakeCommand.php
+++ b/src/Commands/ListenerMakeCommand.php
@@ -63,7 +63,7 @@ class ListenerMakeCommand extends GeneratorCommand
         return (new Stub($this->getStubName(), [
             'NAMESPACE' => $this->getClassNamespace($module),
             'EVENTNAME' => $this->getEventName($module),
-            'SHORTEVENTNAME' => $this->option('event'),
+            'SHORTEVENTNAME' => class_basename($this->option('event')),
             'CLASS' => $this->getClass(),
         ]))->render();
     }

--- a/src/Commands/ListenerMakeCommand.php
+++ b/src/Commands/ListenerMakeCommand.php
@@ -77,9 +77,12 @@ class ListenerMakeCommand extends GeneratorCommand
 
     protected function getEventName(Module $module)
     {
+        $namespace = $this->laravel['modules']->config('namespace') . "\\" . $module->getStudlyName();
         $eventPath = GenerateConfigReader::read('event');
 
-        return $this->getClassNamespace($module) . "\\" . $eventPath->getPath() . "\\" . $this->option('event');
+        $eventName = $namespace . "\\" . $eventPath->getPath() . "\\" . $this->option('event');
+
+        return str_replace('/', '\\', $eventName);
     }
 
     protected function getDestinationFilePath()

--- a/tests/Commands/ListenerMakeCommandTest.php
+++ b/tests/Commands/ListenerMakeCommandTest.php
@@ -60,6 +60,20 @@ class ListenerMakeCommandTest extends BaseTestCase
     }
 
     /** @test */
+    public function it_generated_correct_sync_event_in_a_subdirectory_with_content()
+    {
+        $code = $this->artisan(
+            'module:make-listener',
+            ['name' => 'NotifyUsersOfANewPost', 'module' => 'Blog', '--event' => 'User/WasCreated']
+        );
+
+        $file = $this->finder->get($this->modulePath . '/Listeners/NotifyUsersOfANewPost.php');
+
+        $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
+    }
+
+    /** @test */
     public function it_generated_correct_sync_duck_event_with_content()
     {
         $code = $this->artisan(
@@ -79,6 +93,20 @@ class ListenerMakeCommandTest extends BaseTestCase
         $code = $this->artisan(
             'module:make-listener',
             ['name' => 'NotifyUsersOfANewPost', 'module' => 'Blog', '--event' => 'UserWasCreated', '--queued' => true]
+        );
+
+        $file = $this->finder->get($this->modulePath . '/Listeners/NotifyUsersOfANewPost.php');
+
+        $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
+    }
+
+    /** @test */
+    public function it_generated_correct_queued_event_in_a_subdirectory_with_content()
+    {
+        $code = $this->artisan(
+            'module:make-listener',
+            ['name' => 'NotifyUsersOfANewPost', 'module' => 'Blog', '--event' => 'User/WasCreated', '--queued' => true]
         );
 
         $file = $this->finder->get($this->modulePath . '/Listeners/NotifyUsersOfANewPost.php');

--- a/tests/Commands/__snapshots__/ListenerMakeCommandTest__it_generated_correct_queued_event_in_a_subdirectory_with_content__1.php
+++ b/tests/Commands/__snapshots__/ListenerMakeCommandTest__it_generated_correct_queued_event_in_a_subdirectory_with_content__1.php
@@ -1,0 +1,34 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\Listeners;
+
+use Modules\\Blog\\Events\\User\\WasCreated;
+use Illuminate\\Queue\\InteractsWithQueue;
+use Illuminate\\Contracts\\Queue\\ShouldQueue;
+
+class NotifyUsersOfANewPost implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  WasCreated  $event
+     * @return void
+     */
+    public function handle(WasCreated $event)
+    {
+        //
+    }
+}
+';

--- a/tests/Commands/__snapshots__/ListenerMakeCommandTest__it_generated_correct_queued_event_with_content__1.php
+++ b/tests/Commands/__snapshots__/ListenerMakeCommandTest__it_generated_correct_queued_event_with_content__1.php
@@ -2,7 +2,7 @@
 
 namespace Modules\\Blog\\Listeners;
 
-use Modules\\Blog\\Listeners\\Events\\UserWasCreated;
+use Modules\\Blog\\Events\\UserWasCreated;
 use Illuminate\\Queue\\InteractsWithQueue;
 use Illuminate\\Contracts\\Queue\\ShouldQueue;
 

--- a/tests/Commands/__snapshots__/ListenerMakeCommandTest__it_generated_correct_sync_event_in_a_subdirectory_with_content__1.php
+++ b/tests/Commands/__snapshots__/ListenerMakeCommandTest__it_generated_correct_sync_event_in_a_subdirectory_with_content__1.php
@@ -1,0 +1,32 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\Listeners;
+
+use Modules\\Blog\\Events\\User\\WasCreated;
+use Illuminate\\Queue\\InteractsWithQueue;
+use Illuminate\\Contracts\\Queue\\ShouldQueue;
+
+class NotifyUsersOfANewPost
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param WasCreated $event
+     * @return void
+     */
+    public function handle(WasCreated $event)
+    {
+        //
+    }
+}
+';

--- a/tests/Commands/__snapshots__/ListenerMakeCommandTest__it_generated_correct_sync_event_with_content__1.php
+++ b/tests/Commands/__snapshots__/ListenerMakeCommandTest__it_generated_correct_sync_event_with_content__1.php
@@ -2,7 +2,7 @@
 
 namespace Modules\\Blog\\Listeners;
 
-use Modules\\Blog\\Listeners\\Events\\UserWasCreated;
+use Modules\\Blog\\Events\\UserWasCreated;
 use Illuminate\\Queue\\InteractsWithQueue;
 use Illuminate\\Contracts\\Queue\\ShouldQueue;
 


### PR DESCRIPTION
This PR fixes issue #1017 where the Event class namespace should depend on the Event path set in the config file. Also added support for Event classes placed on sub-directories.