### PR TITLE
Custom cache path for Laravel Vapor deployed app

### DIFF
--- a/src/Laravel/Module.php
+++ b/src/Laravel/Module.php
@@ -15,6 +15,12 @@ class Module extends BaseModule
      */
     public function getCachedServicesPath(): string
     {
+        // This checks if we are running on a Laravel Vapor managed instance
+        // and sets the path to a writable one (services path is not on a writable storage in Vapor).
+        if(!is_null(env('VAPOR_MAINTENANCE_MODE', null))) {
+            return Str::replaceLast('config.php', $this->getSnakeName() . '_module.php', $this->app->getCachedConfigPath());
+        }
+
         return Str::replaceLast('services.php', $this->getSnakeName() . '_module.php', $this->app->getCachedServicesPath());
     }
 


### PR DESCRIPTION
Hi @nWidart !

We had the problem last week that our deployments on Laravel Vapor went down multiple times with the same error message again and again. This caused about 30k messages in Sentry exception logging for us and a few hours of deep diving into the code 😅

**The problem:**
```
Exception: The /var/task/bootstrap/cache directory must be present and writable.
#28 /vendor/laravel/framework/src/Illuminate/Foundation/ProviderRepository.php(190): Illuminate\Foundation\ProviderRepository::writeManifest
#27 /vendor/laravel/framework/src/Illuminate/Foundation/ProviderRepository.php(165): Illuminate\Foundation\ProviderRepository::compileManifest
#26 /vendor/laravel/framework/src/Illuminate/Foundation/ProviderRepository.php(61): Illuminate\Foundation\ProviderRepository::load
#25 /vendor/nwidart/laravel-modules/src/Laravel/Module.php(27): Nwidart\Modules\Laravel\Module::registerProviders
#24 /vendor/nwidart/laravel-modules/src/Module.php(264): Nwidart\Modules\Module::register
#23 /vendor/nwidart/laravel-modules/src/FileRepository.php(321): Nwidart\Modules\FileRepository::register
#22 /vendor/nwidart/laravel-modules/src/Providers/BootstrapServiceProvider.php(23): Nwidart\Modules\Providers\BootstrapServiceProvider::register
#21 /vendor/laravel/framework/src/Illuminate/Foundation/Application.php(627): Illuminate\Foundation\Application::register
#20 /vendor/nwidart/laravel-modules/src/ModulesServiceProvider.php(31): Nwidart\Modules\ModulesServiceProvider::registerModules
#19 /vendor/nwidart/laravel-modules/src/LaravelModulesServiceProvider.php(17): Nwidart\Modules\LaravelModulesServiceProvider::boot
#18 [internal](0): call_user_func_array
#17 /vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(37): Illuminate\Container\BoundMethod::Illuminate\Container\{closure}
#16 /vendor/laravel/framework/src/Illuminate/Container/Util.php(37): Illuminate\Container\Util::unwrapIfClosure
#15 /vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(95): Illuminate\Container\BoundMethod::callBoundMethod
#14 /vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(39): Illuminate\Container\BoundMethod::call
#13 /vendor/laravel/framework/src/Illuminate/Container/Container.php(596): Illuminate\Container\Container::call
#12 /vendor/laravel/framework/src/Illuminate/Foundation/Application.php(867): Illuminate\Foundation\Application::bootProvider
#11 /vendor/laravel/framework/src/Illuminate/Foundation/Application.php(850): Illuminate\Foundation\Application::Illuminate\Foundation\{closure}
#10 [internal](0): array_walk
#9 /vendor/laravel/framework/src/Illuminate/Foundation/Application.php(851): Illuminate\Foundation\Application::boot
#8 /vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/BootProviders.php(17): Illuminate\Foundation\Bootstrap\BootProviders::bootstrap
#7 /vendor/laravel/framework/src/Illuminate/Foundation/Application.php(230): Illuminate\Foundation\Application::bootstrapWith
#6 /vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(310): Illuminate\Foundation\Console\Kernel::bootstrap
#5 /vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(261): Illuminate\Foundation\Console\Kernel::call
#4 /cliRuntime.php(45): {closure}
#3 /vendor/laravel/framework/src/Illuminate/Support/helpers.php(558): with
#2 /cliRuntime.php(46): require
#1 /runtime.php(30): require
#0 /opt/bootstrap.php(6): null
```

A workaround/alternative solution is in this PR. It checks for a Laravel Vapor environment variable and sets the path to a writable directory.

Comment from @themsaid from the Laravel Vapor chat:
> That's a strange use case. This whole directory is framework related and shouldn't be altered by external packages.

Setting a custom path inside the storage folder or creating a new temporary directory for this would maybe be a better solution, but for now this does the job.

Best wishes
Tom