### PR TITLE
Update json.stub to fix priority issue

### DIFF
--- a/src/Commands/stubs/json.stub
+++ b/src/Commands/stubs/json.stub
@@ -3,7 +3,7 @@
     "alias": "$LOWER_NAME$",
     "description": "",
     "keywords": [],
-    "order": 0,
+    "priority": 0,
     "providers": [
         "$MODULE_NAMESPACE$\\$STUDLY_NAME$\\$PROVIDER_NAMESPACE$\\$STUDLY_NAME$ServiceProvider"
     ],


### PR DESCRIPTION
Replace the "order" key by "priority". There has an error when trying to get priority value from module.json.

```
$priority = $module->getPriority();
```

This code throw an error "Return value of Nwidart\Modules\Module::getPriority() must be of the type string, null returned". It happened because getPriority method trying to fetch "priority" value from "module.json" but there is no "priority" key for this reason $module->json() return null but getPriority() expects to return string.

If we replace "order" by "priority" then the issue solved.

If someone faces any more issues you can reply to me at maab.career@gmail.com.

Thanks