### PR TITLE
Laravel 8 Factories Workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.2
   - 7.3
   - 7.4
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "require": {
-    "php": ">=7.2.5",
+    "php": ">=7.3",
     "ext-json": "*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "mockery/mockery": "~1.0",
     "orchestra/testbench": "^5.0",
     "friendsofphp/php-cs-fixer": "^2.16",
-    "laravel/framework": "^7.0",
+    "laravel/framework": "^8.0",
     "spatie/phpunit-snapshot-assertions": "^2.1.0",
     "phpstan/phpstan": "^0.12.14"
   },

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "require-dev": {
     "phpunit/phpunit": "^8.5",
     "mockery/mockery": "~1.0",
-    "orchestra/testbench": "^5.0",
+    "orchestra/testbench": "^6.0",
     "friendsofphp/php-cs-fixer": "^2.16",
     "laravel/framework": "^8.0",
     "spatie/phpunit-snapshot-assertions": "^2.1.0",

--- a/src/Commands/stubs/scaffold/provider.stub
+++ b/src/Commands/stubs/scaffold/provider.stub
@@ -98,7 +98,7 @@ class $CLASS$ extends ServiceProvider
     public function registerFactories()
     {
         if (! app()->environment('production') && $this->app->runningInConsole()) {
-            app(Factory::class)->load(module_path($this->moduleName, '$FACTORIES_PATH$'));
+            $this->loadFactoriesFrom(module_path($this->moduleName, '$FACTORIES_PATH$'));
         }
     }
 


### PR DESCRIPTION
I found a way to make the module factories work by making change in ServiceProvider class within the module

Changed `app(Factory::class)->load(module_path($this->moduleName, '$FACTORIES_PATH$'));` to `$this->loadFactoriesFrom(module_path($this->moduleName, '$FACTORIES_PATH$'));`

I traced back to the project and this stub file is where I found this code. I've made change to the same file in this pull request. 

Hope it helps and works! 

Cheers