### PR TITLE
Laravel 8 - Factories Workaround

### DIFF
--- a/src/Commands/stubs/scaffold/provider.stub
+++ b/src/Commands/stubs/scaffold/provider.stub
@@ -98,7 +98,7 @@ class $CLASS$ extends ServiceProvider
     public function registerFactories()
     {
         if (! app()->environment('production') && $this->app->runningInConsole()) {
-            app(Factory::class)->load(module_path($this->moduleName, '$FACTORIES_PATH$'));
+            $this->loadFactoriesFrom(module_path($this->moduleName, '$FACTORIES_PATH$'));
         }
     }
 


### PR DESCRIPTION
I found a way to make the module factories work by making change in ServiceProvider class within the module

Changed `app(Factory::class)->load(module_path($this->moduleName, '$FACTORIES_PATH$'));` to `$this->loadFactoriesFrom(module_path($this->moduleName, '$FACTORIES_PATH$'));`

I traced back to the project and this stub file is where I found this code. I've made change to the same file in this pull request. 

Hope it helps and works! 

Cheers