### PR TITLE
Laravel 8 class based factories support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build
 coverage
 .php_cs.cache
 .phpunit.result.cache
+
+.idea/

--- a/config/config.php
+++ b/config/config.php
@@ -105,7 +105,7 @@ return [
             'command' => ['path' => 'Console', 'generate' => true],
             'migration' => ['path' => 'Database/Migrations', 'generate' => true],
             'seeder' => ['path' => 'Database/Seeders', 'generate' => true],
-            'factory' => ['path' => 'Database/factories', 'generate' => true],
+            'factory' => ['path' => 'Database/Factories', 'generate' => true],
             'model' => ['path' => 'Entities', 'generate' => true],
             'routes' => ['path' => 'Routes', 'generate' => true],
             'controller' => ['path' => 'Http/Controllers', 'generate' => true],

--- a/src/Commands/FactoryMakeCommand.php
+++ b/src/Commands/FactoryMakeCommand.php
@@ -7,6 +7,7 @@ use Nwidart\Modules\Support\Config\GenerateConfigReader;
 use Nwidart\Modules\Support\Stub;
 use Nwidart\Modules\Traits\ModuleCommandTrait;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 class FactoryMakeCommand extends GeneratorCommand
 {
@@ -51,7 +52,14 @@ class FactoryMakeCommand extends GeneratorCommand
      */
     protected function getTemplateContents()
     {
-        return (new Stub('/factory.stub'))->render();
+        $module = $this->laravel['modules']->findOrFail($this->getModuleName());
+
+        return (new Stub('/factory.stub', [
+            'NAMESPACE'         => $this->getClassNamespace($module),
+            'CLASS'             => $this->getClass(),
+            'MODEL_CLASS'        => $this->getModelClass(),
+            'MODEL_NAME'        => $this->getModelName(),
+        ]))->render();
     }
 
     /**
@@ -67,10 +75,106 @@ class FactoryMakeCommand extends GeneratorCommand
     }
 
     /**
+     * Get class name.
+     *
+     * @return string
+     */
+    public function getClass()
+    {
+        $studlyName = Str::studly( $this->argument($this->argumentName));
+
+        if (!str_contains($studlyName, 'Factory'))
+            $studlyName .= 'Factory';
+
+        return $studlyName;
+    }
+
+
+    /**
+     * Get model class name.
+     *
+     * @return string
+     */
+    public function getModelClass()
+    {
+        $model = $this->option('model');
+
+        if (!$model) {
+            $module = $this->laravel['modules']->findOrFail($this->getModuleName());
+            $modules = $this->laravel['modules'];
+
+            $namespace = $this->laravel['modules']->config('namespace');
+
+            $namespace .= '\\' . $module->getStudlyName();
+
+            $namespace .= '\\' .  $modules->config('paths.generator.model.path', 'Entities');
+
+            $namespace .= '\\' .  str_replace('Factory', '', $this->argument($this->argumentName));
+
+            if (class_exists($namespace))
+                $model = $namespace;
+
+        }
+
+        return $model ?: 'Illuminate\\Database\\Eloquent\\Model';
+    }
+
+
+    /**
+     * Get model class name.
+     *
+     * @return string
+     */
+    public function getModelName()
+    {
+        return class_basename($this->getModelClass());
+    }
+
+    /**
      * @return string
      */
     private function getFileName()
     {
-        return Str::studly($this->argument('name')) . '.php';
+        return $this->getClass() . '.php';
+    }
+
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['model', 'm', InputOption::VALUE_OPTIONAL, 'The model to factory.', null],
+        ];
+    }
+
+    public function getDefaultNamespace() : string
+    {
+        $module = $this->laravel['modules'];
+
+        return $module->config('paths.generator.factory.namespace') ?: $module->config('paths.generator.factory.path', 'Database\Factories');
+    }
+
+    /**
+     * Get class namespace.
+     *
+     * @param \Nwidart\Modules\Module $module
+     *
+     * @return string
+     */
+    public function getClassNamespace($module)
+    {
+        $namespace = $this->laravel['modules']->config('namespace');
+
+        $namespace .= '\\' . $module->getStudlyName();
+
+        $namespace .= '\\' . $this->getDefaultNamespace();
+
+        $namespace = str_replace('/', '\\', $namespace);
+
+        return trim($namespace, '\\');
     }
 }

--- a/src/Commands/stubs/factory.stub
+++ b/src/Commands/stubs/factory.stub
@@ -1,11 +1,26 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace $NAMESPACE$;
 
-use Faker\Generator as Faker;
+use $MODEL_CLASS$;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
-$factory->define(Model::class, function (Faker $faker) {
-    return [
-        //
-    ];
-});
+class $CLASS$ extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = $MODEL_NAME$::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [];
+    }
+}

--- a/tests/Commands/FactoryMakeCommandTest.php
+++ b/tests/Commands/FactoryMakeCommandTest.php
@@ -37,7 +37,7 @@ class FactoryMakeCommandTest extends BaseTestCase
     {
         $code = $this->artisan('module:make-factory', ['name' => 'PostFactory', 'module' => 'Blog']);
 
-        $factoryFile = $this->modulePath . '/Database/factories/PostFactory.php';
+        $factoryFile = $this->modulePath . '/Database/Factories/PostFactory.php';
 
         $this->assertTrue(is_file($factoryFile), 'Factory file was not created.');
         $this->assertMatchesSnapshot($this->finder->get($factoryFile));

--- a/tests/Commands/__snapshots__/FactoryMakeCommandTest__it_makes_factory__1.php
+++ b/tests/Commands/__snapshots__/FactoryMakeCommandTest__it_makes_factory__1.php
@@ -1,12 +1,27 @@
 <?php return '<?php
 
-/** @var \\Illuminate\\Database\\Eloquent\\Factory $factory */
+namespace Modules\\Blog\\Database\\factories;
 
-use Faker\\Generator as Faker;
+use Illuminate\\Database\\Eloquent\\Model;
+use Illuminate\\Database\\Eloquent\\Factories\\Factory;
 
-$factory->define(Model::class, function (Faker $faker) {
-    return [
-        //
-    ];
-});
+class PostFactory extends Factory
+{
+    /**
+     * The name of the factory\'s corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Model::class;
+
+    /**
+     * Define the model\'s default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [];
+    }
+}
 ';


### PR DESCRIPTION
Updating make-factory command to the new Laravel factory style.

A new option `--model` can be used to specify the model (optional).Ex: 

`php artisan module:make-factory --model="Modules/Blog/Models/Post" Post Blog`

If no model is defined, the script will try to find a compatible "Post" model in the directory specified on config file. if no model is found then`Illuminate\Database\Eloquent\Model` will be used.

"Factory" suffix is added automatically to the factory name.