### PR TITLE
added Laravel 8 compatible Factory and Model generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build
 coverage
 .php_cs.cache
 .phpunit.result.cache
+
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@ build
 coverage
 .php_cs.cache
 .phpunit.result.cache
-
-.idea

--- a/src/Commands/FactoryMakeCommand.php
+++ b/src/Commands/FactoryMakeCommand.php
@@ -41,7 +41,7 @@ class FactoryMakeCommand extends GeneratorCommand
     protected function getArguments()
     {
         return [
-            ['name', InputArgument::REQUIRED, 'The name of the factory.'],
+            ['name', InputArgument::REQUIRED, 'The name of the model.'],
             ['module', InputArgument::OPTIONAL, 'The name of module will be used.'],
         ];
     }
@@ -51,7 +51,13 @@ class FactoryMakeCommand extends GeneratorCommand
      */
     protected function getTemplateContents()
     {
-        return (new Stub('/factory.stub'))->render();
+        $module = $this->laravel['modules']->findOrFail($this->getModuleName());
+
+        return (new Stub('/factory.stub', [
+            'NAMESPACE' => $this->getClassNamespace($module),
+            'NAME' => $this->getModelName(),
+            'MODEL_NAMESPACE' => $this->getModelNamespace(),
+        ]))->render();
     }
 
     /**
@@ -71,6 +77,36 @@ class FactoryMakeCommand extends GeneratorCommand
      */
     private function getFileName()
     {
-        return Str::studly($this->argument('name')) . '.php';
+        return Str::studly($this->argument('name')) . 'Factory.php';
+    }
+
+    /**
+     * @return mixed|string
+     */
+    private function getModelName()
+    {
+        return Str::studly($this->argument('name'));
+    }
+
+    /**
+     * Get default namespace.
+     *
+     * @return string
+     */
+    public function getDefaultNamespace(): string
+    {
+        $module = $this->laravel['modules'];
+
+        return $module->config('paths.generator.factory.namespace') ?: $module->config('paths.generator.factory.path');
+    }
+
+    /**
+     * Get model namespace.
+     *
+     * @return string
+     */
+    public function getModelNamespace(): string
+    {
+        return $this->laravel['modules']->config('namespace') . '\\' . $this->laravel['modules']->findOrFail($this->getModuleName()) . '\\' . $this->laravel['modules']->config('paths.generator.model.path', 'Entities');
     }
 }

--- a/src/Commands/stubs/factory.stub
+++ b/src/Commands/stubs/factory.stub
@@ -1,11 +1,27 @@
 <?php
+namespace $NAMESPACE$;
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+use Illuminate\Database\Eloquent\Factories\Factory;
 
-use Faker\Generator as Faker;
+class $NAME$Factory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = \$MODEL_NAMESPACE$\$NAME$::class;
 
-$factory->define(Model::class, function (Faker $faker) {
-    return [
-        //
-    ];
-});
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            //
+        ];
+    }
+}
+

--- a/src/Commands/stubs/model.stub
+++ b/src/Commands/stubs/model.stub
@@ -3,8 +3,16 @@
 namespace $NAMESPACE$;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class $CLASS$ extends Model
 {
+    use HasFactory;
+
+    protected static function newFactory()
+    {
+        return \$MODULE_NAMESPACE$\$MODULE$\Database\factories\$NAME$Factory::new();
+    }
+
     protected $fillable = $FILLABLE$;
 }

--- a/src/Commands/stubs/model.stub
+++ b/src/Commands/stubs/model.stub
@@ -9,10 +9,10 @@ class $CLASS$ extends Model
 {
     use HasFactory;
 
+    protected $fillable = $FILLABLE$;
+    
     protected static function newFactory()
     {
         return \$MODULE_NAMESPACE$\$MODULE$\Database\factories\$NAME$Factory::new();
     }
-
-    protected $fillable = $FILLABLE$;
 }

--- a/tests/Commands/FactoryMakeCommandTest.php
+++ b/tests/Commands/FactoryMakeCommandTest.php
@@ -35,7 +35,7 @@ class FactoryMakeCommandTest extends BaseTestCase
     /** @test */
     public function it_makes_factory()
     {
-        $code = $this->artisan('module:make-factory', ['name' => 'PostFactory', 'module' => 'Blog']);
+        $code = $this->artisan('module:make-factory', ['name' => 'Post', 'module' => 'Blog']);
 
         $factoryFile = $this->modulePath . '/Database/factories/PostFactory.php';
 

--- a/tests/Commands/__snapshots__/FactoryMakeCommandTest__it_makes_factory__1.php
+++ b/tests/Commands/__snapshots__/FactoryMakeCommandTest__it_makes_factory__1.php
@@ -1,12 +1,28 @@
 <?php return '<?php
+namespace Modules\\Blog\\Database\\factories;
 
-/** @var \\Illuminate\\Database\\Eloquent\\Factory $factory */
+use Illuminate\\Database\\Eloquent\\Factories\\Factory;
 
-use Faker\\Generator as Faker;
+class PostFactory extends Factory
+{
+    /**
+     * The name of the factory\'s corresponding model.
+     *
+     * @var string
+     */
+    protected $model = \\Modules\\Blog\\Entities\\Post::class;
 
-$factory->define(Model::class, function (Faker $faker) {
-    return [
-        //
-    ];
-});
+    /**
+     * Define the model\'s default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            //
+        ];
+    }
+}
+
 ';

--- a/tests/Commands/__snapshots__/ModelMakeCommandTest__it_can_change_the_default_namespace__1.php
+++ b/tests/Commands/__snapshots__/ModelMakeCommandTest__it_can_change_the_default_namespace__1.php
@@ -9,11 +9,11 @@ class Post extends Model
 {
     use HasFactory;
 
+    protected $fillable = [];
+    
     protected static function newFactory()
     {
         return \\Modules\\Blog\\Database\\factories\\PostFactory::new();
     }
-
-    protected $fillable = [];
 }
 ';

--- a/tests/Commands/__snapshots__/ModelMakeCommandTest__it_can_change_the_default_namespace__1.php
+++ b/tests/Commands/__snapshots__/ModelMakeCommandTest__it_can_change_the_default_namespace__1.php
@@ -3,9 +3,17 @@
 namespace Modules\\Blog\\Models;
 
 use Illuminate\\Database\\Eloquent\\Model;
+use Illuminate\\Database\\Eloquent\\Factories\\HasFactory;
 
 class Post extends Model
 {
+    use HasFactory;
+
+    protected static function newFactory()
+    {
+        return \\Modules\\Blog\\Database\\factories\\PostFactory::new();
+    }
+
     protected $fillable = [];
 }
 ';

--- a/tests/Commands/__snapshots__/ModelMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
+++ b/tests/Commands/__snapshots__/ModelMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
@@ -9,11 +9,11 @@ class Post extends Model
 {
     use HasFactory;
 
+    protected $fillable = [];
+    
     protected static function newFactory()
     {
         return \\Modules\\Blog\\Database\\factories\\PostFactory::new();
     }
-
-    protected $fillable = [];
 }
 ';

--- a/tests/Commands/__snapshots__/ModelMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
+++ b/tests/Commands/__snapshots__/ModelMakeCommandTest__it_can_change_the_default_namespace_specific__1.php
@@ -3,9 +3,17 @@
 namespace Modules\\Blog\\Models;
 
 use Illuminate\\Database\\Eloquent\\Model;
+use Illuminate\\Database\\Eloquent\\Factories\\HasFactory;
 
 class Post extends Model
 {
+    use HasFactory;
+
+    protected static function newFactory()
+    {
+        return \\Modules\\Blog\\Database\\factories\\PostFactory::new();
+    }
+
     protected $fillable = [];
 }
 ';

--- a/tests/Commands/__snapshots__/ModelMakeCommandTest__it_generated_correct_file_with_content__1.php
+++ b/tests/Commands/__snapshots__/ModelMakeCommandTest__it_generated_correct_file_with_content__1.php
@@ -3,9 +3,17 @@
 namespace Modules\\Blog\\Entities;
 
 use Illuminate\\Database\\Eloquent\\Model;
+use Illuminate\\Database\\Eloquent\\Factories\\HasFactory;
 
 class Post extends Model
 {
+    use HasFactory;
+
+    protected static function newFactory()
+    {
+        return \\Modules\\Blog\\Database\\factories\\PostFactory::new();
+    }
+
     protected $fillable = [];
 }
 ';

--- a/tests/Commands/__snapshots__/ModelMakeCommandTest__it_generated_correct_file_with_content__1.php
+++ b/tests/Commands/__snapshots__/ModelMakeCommandTest__it_generated_correct_file_with_content__1.php
@@ -9,11 +9,11 @@ class Post extends Model
 {
     use HasFactory;
 
+    protected $fillable = [];
+    
     protected static function newFactory()
     {
         return \\Modules\\Blog\\Database\\factories\\PostFactory::new();
     }
-
-    protected $fillable = [];
 }
 ';

--- a/tests/Commands/__snapshots__/ModelMakeCommandTest__it_generates_correct_fillable_fields__1.php
+++ b/tests/Commands/__snapshots__/ModelMakeCommandTest__it_generates_correct_fillable_fields__1.php
@@ -3,9 +3,17 @@
 namespace Modules\\Blog\\Entities;
 
 use Illuminate\\Database\\Eloquent\\Model;
+use Illuminate\\Database\\Eloquent\\Factories\\HasFactory;
 
 class Post extends Model
 {
+    use HasFactory;
+
+    protected static function newFactory()
+    {
+        return \\Modules\\Blog\\Database\\factories\\PostFactory::new();
+    }
+
     protected $fillable = ["title","slug"];
 }
 ';

--- a/tests/Commands/__snapshots__/ModelMakeCommandTest__it_generates_correct_fillable_fields__1.php
+++ b/tests/Commands/__snapshots__/ModelMakeCommandTest__it_generates_correct_fillable_fields__1.php
@@ -9,11 +9,11 @@ class Post extends Model
 {
     use HasFactory;
 
+    protected $fillable = ["title","slug"];
+    
     protected static function newFactory()
     {
         return \\Modules\\Blog\\Database\\factories\\PostFactory::new();
     }
-
-    protected $fillable = ["title","slug"];
 }
 ';


### PR DESCRIPTION
changed the `module:make-factory` argument description from `ModelFactory` to `Model` that way the command generates a factory with a model name rather that a factory name as argument