### PR TITLE
Configuration to change the default stub file variable style

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -27,6 +27,7 @@ return [
 
     'stubs' => [
         'enabled' => false,
+        'style' => '$VARIABLE_NAME$',
         'path' => base_path() . '/vendor/nwidart/laravel-modules/src/Commands/stubs',
         'files' => [
             'routes/web' => 'Routes/web.php',

--- a/config/config.php
+++ b/config/config.php
@@ -27,7 +27,6 @@ return [
 
     'stubs' => [
         'enabled' => false,
-        'style' => '$VARIABLE_NAME$',
         'path' => base_path('vendor/nwidart/laravel-modules/src/Commands/stubs'),
         'files' => [
             'routes/web' => 'Routes/web.php',

--- a/config/config.php
+++ b/config/config.php
@@ -28,7 +28,7 @@ return [
     'stubs' => [
         'enabled' => false,
         'style' => '$VARIABLE_NAME$',
-        'path' => base_path() . '/vendor/nwidart/laravel-modules/src/Commands/stubs',
+        'path' => base_path('vendor/nwidart/laravel-modules/src/Commands/stubs'),
         'files' => [
             'routes/web' => 'Routes/web.php',
             'routes/api' => 'Routes/api.php',

--- a/src/Support/Stub.php
+++ b/src/Support/Stub.php
@@ -26,6 +26,14 @@ class Stub
     protected $replaces = [];
 
     /**
+     * Defines the style of variables in a file
+     * that will be replaced.
+     *
+     * @var string
+     */
+    protected $style;
+
+    /**
      * The contructor.
      *
      * @param string $path
@@ -35,6 +43,37 @@ class Stub
     {
         $this->path = $path;
         $this->replaces = $replaces;
+    }
+
+    /**
+     * Set variable style.
+     *
+     * @param string $style
+     * @return self
+     */
+    public function setStyle($left, $right = null)
+    {
+        if (!$left) {
+            return $this;
+        }
+
+        if (!$right) {
+            $right = $left;
+        }
+
+        $this->style = trim($left . 'VARIABLE_NAME' . $right);
+
+        return $this;
+    }
+
+    /**
+     * Get variable style.
+     *
+     * @return string
+     */
+    public function getStyle()
+    {
+        return $this->style;
     }
 
     /**
@@ -105,8 +144,9 @@ class Stub
     {
         $contents = file_get_contents($this->getPath());
 
-        foreach ($this->replaces as $search => $replace) {
-            $contents = str_replace('$' . strtoupper($search) . '$', $replace, $contents);
+        foreach ($this->replaces as $search => $to) {
+            $replace = str_replace('VARIABLE_NAME', strtoupper($search), $this->style ?: config('modules.stubs.style'));
+            $contents = str_replace($replace, $to, $contents);
         }
 
         return $contents;

--- a/tests/Activators/__snapshots__/FileActivatorTest__it_creates_valid_json_file_after_disabling__1.php
+++ b/tests/Activators/__snapshots__/FileActivatorTest__it_creates_valid_json_file_after_disabling__1.php
@@ -1,5 +1,3 @@
-<?php
-
-return '{
+<?php return '{
     "Recipe": false
 }';

--- a/tests/Activators/__snapshots__/FileActivatorTest__it_creates_valid_json_file_after_disabling__2.php
+++ b/tests/Activators/__snapshots__/FileActivatorTest__it_creates_valid_json_file_after_disabling__2.php
@@ -1,5 +1,3 @@
-<?php
-
-return '{
+<?php return '{
     "Recipe": false
 }';

--- a/tests/Activators/__snapshots__/FileActivatorTest__it_creates_valid_json_file_after_enabling__1.php
+++ b/tests/Activators/__snapshots__/FileActivatorTest__it_creates_valid_json_file_after_enabling__1.php
@@ -1,5 +1,3 @@
-<?php
-
-return '{
+<?php return '{
     "Recipe": true
 }';

--- a/tests/Activators/__snapshots__/FileActivatorTest__it_creates_valid_json_file_after_enabling__2.php
+++ b/tests/Activators/__snapshots__/FileActivatorTest__it_creates_valid_json_file_after_enabling__2.php
@@ -1,5 +1,3 @@
-<?php
-
-return '{
+<?php return '{
     "Recipe": true
 }';

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -76,6 +76,7 @@ abstract class BaseTestCase extends OrchestraTestCase
                 'resource' => ['path' => 'Transformers', 'generate' => true],
             ],
         ]);
+        $app['config']->set('modules.stubs.style', '$VARIABLE_NAME$');
 
         $app['config']->set('modules.commands', [
             CommandMakeCommand::class,


### PR DESCRIPTION
Ability to change stub file variable style. This provides the ability to change the default style of `$` (dollar sign) to anything. 
Examples include: `{{ VARIABLE }}`, `[[VARIABLE]]`, or anything you can think of, even  `~~|~VARIABLE~|~~`