### PR TITLE
Fix missing commands

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -143,6 +143,8 @@ return [
     */
     'commands' => [
         Commands\CommandMakeCommand::class,
+        Commands\ComponentClassMakeCommand::class,
+        Commands\ComponentViewMakeCommand::class,
         Commands\ControllerMakeCommand::class,
         Commands\DisableCommand::class,
         Commands\DumpCommand::class,


### PR DESCRIPTION
This PR fixes the issue with these commands not getting registered:
`module:make-component <name> <module>` 
`module:make-component-view <name> <module>` 