### PR TITLE
Livewire added

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -128,6 +128,8 @@ return [
             'resource' => ['path' => 'Transformers', 'generate' => false],
             'component-view' => ['path' => 'Resources/views/components', 'generate' => false],
             'component-class' => ['path' => 'View/Component', 'generate' => false],
+            'livewire-namespace' => ['path' => 'Http\\Livewire', 'generate' => false],
+            'livewire-view' => ['path' => 'Resources/views/livewire', 'generate' => false],
         ],
     ],
 
@@ -159,6 +161,7 @@ return [
         Commands\RouteProviderMakeCommand::class,
         Commands\InstallCommand::class,
         Commands\ListCommand::class,
+        Commands\LivewireCommand::class,
         Commands\ModuleDeleteCommand::class,
         Commands\ModuleMakeCommand::class,
         Commands\FactoryMakeCommand::class,

--- a/src/Commands/LivewireCommand.php
+++ b/src/Commands/LivewireCommand.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Nwidart\Modules\Commands;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Nwidart\Modules\Support\Stub;
+use Nwidart\Modules\Traits\ModuleCommandTrait;
+use Nwidart\Modules\Support\Config\GenerateConfigReader;
+
+class LivewireCommand extends Command
+{
+    use ModuleCommandTrait;
+
+    public $component;
+
+    public $module;
+
+    public $directories;
+
+
+    protected $signature = 'module:make-livewire {module} {name} {--view=} {--force} {--inline}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate Livewire Component.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        if (! class_exists('Livewire')) {
+            $this->line("\n<options=bold,reverse;fg=red> WHOOPS! </> 😳 \n");
+            $this->line("<fg=red;options=bold>Livewire not found!</> \n");
+            $this->line("<fg=green;options=bold>Install The Livewire Package - composer require livewire/livewire</> \n");
+            return 0;
+        }
+
+        $this->component = $this->getComponent();
+
+        if ($this->isReservedClassName($name = $this->component->class->name)) {
+            $this->line("\n<options=bold,reverse;fg=red> WHOOPS! </> 😳 \n");
+            $this->line("<fg=red;options=bold>Class is reserved:</> {$name} \n");
+            return 0;
+        }
+
+        $force = $this->option('force');
+        $inline = $this->option('inline');
+
+        $class = $this->createClass($force, $inline);
+        $view = $this->createView($force, $inline);
+
+        if ($class || $view) {
+            $this->line("\n <options=bold,reverse;fg=green> COMPONENT CREATED </> 🤙\n");
+            $class && $this->line("<options=bold;fg=green>CLASS:</> {$this->component->class->path}");
+
+            if (! $inline) {
+                $view && $this->line("<options=bold;fg=green>VIEW:</>  {$this->component->view->path}");
+            }
+        }
+
+        return 0;
+    }
+
+    protected function getComponent()
+    {
+        $module = $this->laravel['modules']->findOrFail($this->getModuleName());
+        
+        $this->module = $module;
+        
+        $this->directories = preg_split('/[.\/(\\\\)]+/', $this->argument('name'));
+        
+        $classInfo = $this->getClassInfo();
+        
+        $viewInfo = $this->getViewInfo();
+
+        return (object) [
+            'class' => $classInfo,
+            'view' => $viewInfo
+        ];
+    }
+
+    public function getClassInfo()
+    {
+        $modulePath = $this->module->getPath().'/';
+
+        $defaultNamespace = GenerateConfigReader::read('livewire-namespace')->getPath();
+
+        $classDir = $modulePath . strtr($defaultNamespace, ['\\' => '/']);
+
+        $path = collect($this->directories)
+            ->map([\Str::class, 'studly'])
+            ->implode('/');
+
+        $beforeLast = (\Str::contains($path, '/')) ? '/' . \Str::beforeLast($path, '/') : '';
+
+        $namespace = config('modules.namespace') . '\\' . $this->module->getName() . '\\' . $defaultNamespace . strtr($beforeLast, ['/' => '\\']);
+
+        $name = \Str::studly( \Arr::last($this->directories) );
+
+        return (object) [
+            'dir' => $classDir,
+            'path' => $path,
+            'file' => $classDir . '/' . $path . '.php',
+            'namespace' => $namespace,
+            'name' => $name,
+        ];
+    }
+
+    public function getViewInfo()
+    {
+        $modulePath = $this->module->getPath().'/';
+
+        $viewDir = $modulePath . GenerateConfigReader::read('livewire-view')->getPath();
+
+        $path = collect($this->directories)
+            ->map([\Str::class, 'kebab'])
+            ->implode('/');
+
+        if ($this->option('view')) $path = strtr($this->option('view'), ['.' => '/']);
+        
+        $name = strtr($path, ['/' => '.']);
+
+        return (object) [
+            'dir' => $viewDir,
+            'path' => $path,
+            'folder' => \Str::after($viewDir, 'views/'),
+            'file' => $viewDir . '/' . $path . '.blade.php',
+            'name' => $name,
+        ];
+    }
+
+    protected function createClass($force = false, $inline = false)
+    {
+        $classPath = $this->component->class->file;
+
+        if (File::exists($classPath) && ! $force) {
+            $this->line("<options=bold,reverse;fg=red> WHOOPS </> 😳 \n");
+            $this->line("<fg=red;options=bold>Class already exists:</> {$this->component->class->path}");
+            return false;
+        }
+
+        $this->ensureDirectoryExists($classPath);
+
+        File::put($classPath, $this->classContents($inline));
+
+        return $classPath;
+    }
+
+    public function classContents($inline = false)
+    {
+        $stubName = $inline ? '/livewire/livewire.inline.stub' : '/livewire/livewire.stub';
+
+        return (new Stub($stubName, [
+            'NAMESPACE'  => $this->component->class->namespace,
+            'CLASS'      => $this->component->class->name,
+            'LOWER_NAME' => $this->module->getLowerName(),
+            'VIEW_NAME'  => $this->component->view->folder . '.' . $this->component->view->name,
+        ]))->render();
+    }
+
+    protected function createView($force = false, $inline = false)
+    {
+        if ($inline) return false;
+
+        $viewPath = $this->component->view->file;
+
+        if (File::exists($viewPath) && ! $force) {
+            $this->line("<fg=red;options=bold>View already exists:</> {$this->component->view->path}");
+            return false;
+        }
+
+        $this->ensureDirectoryExists($viewPath);
+
+        File::put($viewPath, $this->viewContents());
+
+        return $viewPath;
+    }
+
+    public function viewContents($inline = false)
+    {
+        return (new Stub('/livewire/livewire.view.stub'))->render();
+    }
+
+    protected function ensureDirectoryExists($path)
+    {
+        if (! File::isDirectory(dirname($path))) {
+            File::makeDirectory(dirname($path), 0777, $recursive = true, $force = true);
+        }
+    }
+
+    public function isReservedClassName($name)
+    {
+        return array_search($name, ['Parent', 'Component', 'Interface']) !== false;
+    }
+}

--- a/src/Commands/LivewireCommand.php
+++ b/src/Commands/LivewireCommand.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\File;
 use Nwidart\Modules\Support\Stub;
 use Nwidart\Modules\Traits\ModuleCommandTrait;
 use Nwidart\Modules\Support\Config\GenerateConfigReader;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
 
 class LivewireCommand extends Command
 {
@@ -19,8 +21,12 @@ class LivewireCommand extends Command
 
     public $directories;
 
-
-    protected $signature = 'module:make-livewire {module} {name} {--view=} {--force} {--inline}';
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'module:make-livewire';
 
     /**
      * The console command description.
@@ -67,6 +73,33 @@ class LivewireCommand extends Command
         }
 
         return 0;
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['module', InputArgument::REQUIRED, 'The name of module will be used.'],
+            ['name', InputArgument::REQUIRED, 'The name of the component.'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['view', null, InputOption::VALUE_OPTIONAL, 'Set custom view path for Component.'],
+            ['force', false, InputOption::VALUE_NONE, 'Force create component if the class already exists.'],
+            ['inline', false, InputOption::VALUE_NONE, 'Create inline component.'],
+        ];
     }
 
     protected function getComponent()

--- a/src/Commands/stubs/livewire/livewire.inline.stub
+++ b/src/Commands/stubs/livewire/livewire.inline.stub
@@ -1,0 +1,17 @@
+<?php
+
+namespace $NAMESPACE$;
+
+use Livewire\Component;
+
+class $CLASS$ extends Component
+{
+    public function render()
+    {
+        return <<<'blade'
+            <div>
+                {{-- inline component --}}
+            </div>
+        blade;
+    }
+}

--- a/src/Commands/stubs/livewire/livewire.stub
+++ b/src/Commands/stubs/livewire/livewire.stub
@@ -1,0 +1,13 @@
+<?php
+
+namespace $NAMESPACE$;
+
+use Livewire\Component;
+
+class $CLASS$ extends Component
+{
+    public function render()
+    {
+        return view('$LOWER_NAME$::$VIEW_NAME$');
+    }
+}

--- a/src/Commands/stubs/livewire/livewire.view.stub
+++ b/src/Commands/stubs/livewire/livewire.view.stub
@@ -1,0 +1,3 @@
+<div>
+    {{-- livewire view --}}
+</div>

--- a/src/Livewire/LivewireServiceProvider.php
+++ b/src/Livewire/LivewireServiceProvider.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Nwidart\Modules\Livewire;
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Filesystem\Filesystem;
+use Nwidart\Modules\Support\Config\GenerateConfigReader;
+
+class LivewireServiceProvider extends ServiceProvider
+{
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->loadComponents();
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return [];
+    }
+
+    protected function loadComponents()
+    {
+        if (! class_exists('Livewire')) return false;
+
+        $modules = \Module::toCollection();
+
+        $defaultNamespace = GenerateConfigReader::read('livewire-namespace')->getPath();
+        
+        $filesystem = new Filesystem();
+
+        $modules->map(function ($module) use ($filesystem, $defaultNamespace) {
+            $modulePath = $module->getPath();
+
+            $path = $modulePath. '/'. strtr($defaultNamespace, ['\\' => '/']);
+
+            $files = collect( $filesystem->isDirectory($path) ? $filesystem->allFiles($path) : [] );
+
+            $files->map(function ($file) use ($module, $path, $defaultNamespace) {
+                $componentPath = \Str::after($file->getPathname(), $path.'/');
+
+                $componentClassPath = strtr( $componentPath , ['/' => '\\', '.php' => '']);
+        
+                $componentName = $this->getComponentName($componentClassPath, $module);
+
+                $componentClassStr = '\\' . config('modules.namespace') . '\\' . $module->getName() . '\\' . $defaultNamespace . '\\' . $componentClassPath;
+
+                $componentClass = get_class(new $componentClassStr);
+
+                $loadComponent = \Livewire::component($componentName, $componentClass);
+            });
+        });
+    }
+
+    protected function getComponentName($componentClassPath, $module = null)
+    {
+        $dirs = explode('\\', $componentClassPath);
+
+        $componentName = collect($dirs)
+            ->map([\Str::class, 'kebab'])
+            ->implode('.');
+
+        $moduleNamePrefix = ($module) ? $module->getLowerName().'::' : null;
+
+       return $moduleNamePrefix . $componentName;
+    }
+}

--- a/src/ModulesServiceProvider.php
+++ b/src/ModulesServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Support\ServiceProvider;
 use Nwidart\Modules\Providers\BootstrapServiceProvider;
 use Nwidart\Modules\Providers\ConsoleServiceProvider;
 use Nwidart\Modules\Providers\ContractsServiceProvider;
+use Nwidart\Modules\Livewire\LivewireServiceProvider;
 
 abstract class ModulesServiceProvider extends ServiceProvider
 {
@@ -29,6 +30,7 @@ abstract class ModulesServiceProvider extends ServiceProvider
     protected function registerModules()
     {
         $this->app->register(BootstrapServiceProvider::class);
+        $this->app->register(LivewireServiceProvider::class);
     }
 
     /**

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -28,6 +28,7 @@ class ConsoleServiceProvider extends ServiceProvider
         Commands\RouteProviderMakeCommand::class,
         Commands\InstallCommand::class,
         Commands\ListCommand::class,
+        Commands\LivewireCommand::class,
         Commands\ModuleDeleteCommand::class,
         Commands\ModuleMakeCommand::class,
         Commands\FactoryMakeCommand::class,


### PR DESCRIPTION
### Making Components:

**Command Signature:**

`php artisan module:make-livewire <Module> <Component> --view= --force --inline`

**Example:**

```
php artisan module:make-livewire Core Pages/AboutPage

php artisan module:make-livewire Core Pages\\AboutPage

php artisan module:make-livewire Core pages.about-page
```

**Force create component if the class already exists:**

`php artisan module:make-livewire Core Pages/AboutPage --force`

**Component Files:**

```
Class: Modules/Core/Http/Livewire/Pages/AboutPage.php
View: Modules/Core/Resources/views/livewire/pages/about-page.blade.php
```

**Inline Component:**

`php artisan module:make-livewire Core Pages/AboutPage --inline`

**Component File:**

`Class: Modules/Core/Http/Livewire/Pages/AboutPage.php`


**Extra Option (--view):**

**You able to set custom view path for Component with (--view) option.**

**Example -**

```
php artisan module:make-livewire Core Pages/AboutPage --view=pages/about

or

php artisan module:make-livewire Core Pages/AboutPage --view=pages.about
```

**Component Files:**

```
Class: Modules/Core/Http/Livewire/Pages/AboutPage.php
View: Modules/Core/Resources/views/livewire/pages/about.blade.php
```


### Rendering Components:

`<livewire:{moudle-lower-name}::component-class-kebab-case />`

**Example -**

`<livewire:core::pages.about-page />`