### PR TITLE
Bugfix/str 4114 illuminatecontractsfilesystemfi

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -230,7 +230,7 @@ return [
     |
     */
     'cache' => [
-        'enabled' => false,
+        'enabled' => env('MODULES_CACHE_ENABLED', false),
         'key' => 'laravel-modules',
         'lifetime' => 60,
     ],

--- a/config/config.php
+++ b/config/config.php
@@ -71,7 +71,7 @@ return [
         |
         */
 
-        'modules' => base_path('Modules'),
+        'modules' => env('MODULES_PATH', base_path('Modules')),
         /*
         |--------------------------------------------------------------------------
         | Modules assets path

--- a/config/config.php
+++ b/config/config.php
@@ -142,6 +142,7 @@ return [
     |
     */
     'commands' => [
+        Commands\ClearModulesCacheCommand::class,
         Commands\CommandMakeCommand::class,
         Commands\ComponentClassMakeCommand::class,
         Commands\ComponentViewMakeCommand::class,

--- a/src/Commands/ClearModulesCacheCommand.php
+++ b/src/Commands/ClearModulesCacheCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Nwidart\Modules\Commands;
+
+use Illuminate\Console\Command;
+use Nwidart\Modules\Traits\CanClearModulesCache;
+
+class ClearModulesCacheCommand extends Command
+{
+    use CanClearModulesCache;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'module:clear-cache {--force}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Clear the modules cache';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $force = $this->option('force');
+        $this->clearCache($force);
+        $this->info('The modules cache has been cleared.');
+    }
+}

--- a/src/Commands/ClearModulesCacheCommand.php
+++ b/src/Commands/ClearModulesCacheCommand.php
@@ -33,5 +33,6 @@ class ClearModulesCacheCommand extends Command
         $force = $this->option('force');
         $this->clearCache($force);
         $this->info('The modules cache has been cleared.');
+        return 0;
     }
 }

--- a/src/FileRepository.php
+++ b/src/FileRepository.php
@@ -309,7 +309,9 @@ abstract class FileRepository implements RepositoryInterface, Countable
      */
     public function getPath() : string
     {
-        return $this->path ?: $this->config('paths.modules', base_path('Modules'));
+        $path = $this->path ?: $this->config('paths.modules', base_path('Modules'));
+        $path = ($path[0] !== '/') ? base_path($path) : $path;
+        return $path;
     }
 
     /**

--- a/src/FileRepository.php
+++ b/src/FileRepository.php
@@ -310,7 +310,7 @@ abstract class FileRepository implements RepositoryInterface, Countable
     public function getPath() : string
     {
         $path = $this->path ?: $this->config('paths.modules', base_path('Modules'));
-        $path = ($path === realpath($path)) ? $path : base_path($path);
+        $path = ($path[0] === '/') ? $path : base_path($path);
         return $path;
     }
 

--- a/src/FileRepository.php
+++ b/src/FileRepository.php
@@ -310,7 +310,7 @@ abstract class FileRepository implements RepositoryInterface, Countable
     public function getPath() : string
     {
         $path = $this->path ?: $this->config('paths.modules', base_path('Modules'));
-        $path = ($path[0] !== '/') ? base_path($path) : $path;
+        $path = ($path === realpath($path)) ? $path : base_path($path);
         return $path;
     }
 

--- a/src/Json.php
+++ b/src/Json.php
@@ -5,7 +5,6 @@ namespace Nwidart\Modules;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\Filesystem;
 use Nwidart\Modules\Exceptions\InvalidJsonException;
-use Nwidart\Modules\Traits\CanClearModulesCache;
 
 class Json
 {
@@ -116,6 +115,7 @@ class Json
             $message = sprintf('File Not Found at: "%s"', $this->getPath());
             throw new FileNotFoundException($message);
         }
+
         return $this->filesystem->get($this->getPath());
     }
 

--- a/src/Json.php
+++ b/src/Json.php
@@ -115,7 +115,8 @@ class Json
     public function getContents()
     {
         if ($this->filesystem->exists($this->getPath()) === false) {
-            throw new FileNotFoundException($this->getPath());
+            $message = sprintf('File Not Found at: "%s"', $this->getPath());
+            throw new FileNotFoundException($message);
         }
         return $this->filesystem->get($this->getPath());
     }

--- a/src/Json.php
+++ b/src/Json.php
@@ -114,10 +114,6 @@ class Json
      */
     public function getContents()
     {
-        if ($this->filesystem->exists($this->getPath()) === true) {
-            return $this->filesystem->get($this->getPath());
-        }
-        $this->clearCache();
         if ($this->filesystem->exists($this->getPath()) === false) {
             throw new FileNotFoundException($this->getPath());
         }

--- a/src/Json.php
+++ b/src/Json.php
@@ -114,14 +114,13 @@ class Json
      */
     public function getContents()
     {
-        if ($this->filesystem->exists($this->getPath())) {
-            return $this->filesystem->get($this->getPath());
+        if ($this->filesystem->exists($this->getPath()) === false) {
+            $this->clearCache();
         }
-        $this->clearCache();
-        if ($this->filesystem->exists($this->getPath())) {
-            return $this->filesystem->get($this->getPath());
+        if ($this->filesystem->exists($this->getPath()) === false) {
+            throw new FileNotFoundException($this->getPath());
         }
-        throw new FileNotFoundException($this->getPath());
+        return $this->filesystem->get($this->getPath());
     }
 
     /**

--- a/src/Json.php
+++ b/src/Json.php
@@ -9,8 +9,6 @@ use Nwidart\Modules\Traits\CanClearModulesCache;
 
 class Json
 {
-    use CanClearModulesCache;
-
     /**
      * The file path.
      *

--- a/src/Json.php
+++ b/src/Json.php
@@ -2,11 +2,15 @@
 
 namespace Nwidart\Modules;
 
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\Filesystem;
 use Nwidart\Modules\Exceptions\InvalidJsonException;
+use Nwidart\Modules\Traits\CanClearModulesCache;
 
 class Json
 {
+    use CanClearModulesCache;
+
     /**
      * The file path.
      *
@@ -106,10 +110,18 @@ class Json
      * Get file content.
      *
      * @return string
+     * @throws FileNotFoundException
      */
     public function getContents()
     {
-        return $this->filesystem->get($this->getPath());
+        if ($this->filesystem->exists($this->getPath())) {
+            return $this->filesystem->get($this->getPath());
+        }
+        $this->clearCache();
+        if ($this->filesystem->exists($this->getPath())) {
+            return $this->filesystem->get($this->getPath());
+        }
+        throw new FileNotFoundException($this->getPath());
     }
 
     /**

--- a/src/Json.php
+++ b/src/Json.php
@@ -114,9 +114,10 @@ class Json
      */
     public function getContents()
     {
-        if ($this->filesystem->exists($this->getPath()) === false) {
-            $this->clearCache();
+        if ($this->filesystem->exists($this->getPath()) === true) {
+            return $this->filesystem->get($this->getPath());
         }
+        $this->clearCache();
         if ($this->filesystem->exists($this->getPath()) === false) {
             throw new FileNotFoundException($this->getPath());
         }

--- a/src/LaravelModulesServiceProvider.php
+++ b/src/LaravelModulesServiceProvider.php
@@ -51,7 +51,7 @@ class LaravelModulesServiceProvider extends ModulesServiceProvider
     {
         $this->app->singleton(Contracts\RepositoryInterface::class, function ($app) {
             $path = $app['config']->get('modules.paths.modules');
-
+            $path = ($path[0] !== '/') ?: base_path($path);
             return new Laravel\LaravelFileRepository($app, $path);
         });
         $this->app->singleton(Contracts\ActivatorInterface::class, function ($app) {

--- a/src/LaravelModulesServiceProvider.php
+++ b/src/LaravelModulesServiceProvider.php
@@ -51,7 +51,7 @@ class LaravelModulesServiceProvider extends ModulesServiceProvider
     {
         $this->app->singleton(Contracts\RepositoryInterface::class, function ($app) {
             $path = $app['config']->get('modules.paths.modules');
-            $path = ($path[0] !== '/') ?: base_path($path);
+            $path = ($path[0] !== '/') ? base_path($path) : $path;
             return new Laravel\LaravelFileRepository($app, $path);
         });
         $this->app->singleton(Contracts\ActivatorInterface::class, function ($app) {

--- a/src/LaravelModulesServiceProvider.php
+++ b/src/LaravelModulesServiceProvider.php
@@ -51,7 +51,7 @@ class LaravelModulesServiceProvider extends ModulesServiceProvider
     {
         $this->app->singleton(Contracts\RepositoryInterface::class, function ($app) {
             $path = $app['config']->get('modules.paths.modules');
-            $path = ($path[0] !== '/') ? base_path($path) : $path;
+            $path = ($path === realpath($path)) ? $path : base_path($path);
             return new Laravel\LaravelFileRepository($app, $path);
         });
         $this->app->singleton(Contracts\ActivatorInterface::class, function ($app) {

--- a/src/LaravelModulesServiceProvider.php
+++ b/src/LaravelModulesServiceProvider.php
@@ -51,7 +51,7 @@ class LaravelModulesServiceProvider extends ModulesServiceProvider
     {
         $this->app->singleton(Contracts\RepositoryInterface::class, function ($app) {
             $path = $app['config']->get('modules.paths.modules');
-            $path = ($path === realpath($path)) ? $path : base_path($path);
+            $path = ($path[0] === '/') ? $path : base_path($path);
             return new Laravel\LaravelFileRepository($app, $path);
         });
         $this->app->singleton(Contracts\ActivatorInterface::class, function ($app) {

--- a/src/Module.php
+++ b/src/Module.php
@@ -15,6 +15,8 @@ abstract class Module
 {
     use Macroable;
 
+    public const MODULE_JSON_FILE = 'module.json';
+
     /**
      * The laravel|lumen application instance.
      *
@@ -220,11 +222,12 @@ abstract class Module
     public function json($file = null) : Json
     {
         if ($file === null) {
-            $file = 'module.json';
+            $file = self::MODULE_JSON_FILE;
         }
 
         return Arr::get($this->moduleJson, $file, function () use ($file) {
-            return $this->moduleJson[$file] = new Json($this->getPath() . '/' . $file, $this->files);
+            $path = $this->getPath() . DIRECTORY_SEPARATOR . $file;
+            return $this->moduleJson[$file] = new Json($path, $this->files);
         });
     }
 

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -13,6 +13,7 @@ class ConsoleServiceProvider extends ServiceProvider
      * @var array
      */
     protected $commands = [
+        Commands\ClearModulesCacheCommand::class,
         Commands\CommandMakeCommand::class,
         Commands\ControllerMakeCommand::class,
         Commands\DisableCommand::class,

--- a/src/Traits/CanClearModulesCache.php
+++ b/src/Traits/CanClearModulesCache.php
@@ -6,10 +6,11 @@ trait CanClearModulesCache
 {
     /**
      * Clear the modules cache if it is enabled
+     * @param bool $force
      */
-    public function clearCache()
+    public function clearCache($force = false)
     {
-        if (config('modules.cache.enabled') === true) {
+        if ($force === true || config('modules.cache.enabled') === true) {
             app('cache')->forget(config('modules.cache.key'));
         }
     }

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -83,6 +83,7 @@ abstract class BaseTestCase extends OrchestraTestCase
         $app['config']->set('modules.composer-output', true);
 
         $app['config']->set('modules.commands', [
+            Commands\ClearModulesCacheCommand::class,
             Commands\CommandMakeCommand::class,
             Commands\ControllerMakeCommand::class,
             Commands\DisableCommand::class,


### PR DESCRIPTION
This offers four methods to solve the issued outlined here:

https://github.com/nWidart/laravel-modules/issues/1054

1. We now have a command that we can run to clear the cache (by force, overriding what's in the config) if we need to.
2. If we don't have a modules.json file, then we're probably in the wrong path, so clearing the cache will fix this. Failing that, we (more) gracefully throw an exception, which can be caught, rather than a fatal error we had previously.
3. You can pass in a MODULES_PATH now as an environment variable and specify that if you need to via a .env file
4. It will now handle both paths that are full paths and relative paths, either will work