### PR TITLE
Command "module:make-component" is not defined

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -185,6 +185,8 @@ return [
         Commands\ResourceMakeCommand::class,
         Commands\TestMakeCommand::class,
         Commands\LaravelModulesV6Migrator::class,
+        Commands\ComponentClassMakeCommand::class,
+        Commands\ComponentViewMakeCommand::class,
     ],
 
     /*


### PR DESCRIPTION
The two component creation commands have been forgotten in the modules file. 
#1188 