### PR TITLE
Add missing Route facade

### DIFF
--- a/src/Commands/stubs/routes/api.stub
+++ b/src/Commands/stubs/routes/api.stub
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
 
 /*
 |--------------------------------------------------------------------------

--- a/src/Commands/stubs/routes/web.stub
+++ b/src/Commands/stubs/routes/web.stub
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\Route;
+
 /*
 |--------------------------------------------------------------------------
 | Web Routes


### PR DESCRIPTION
Because of error `Undefined type 'Route'`