### PR TITLE
fix class name when special characters are used the rule name

### DIFF
--- a/src/Commands/RuleMakeCommand.php
+++ b/src/Commands/RuleMakeCommand.php
@@ -62,7 +62,7 @@ class RuleMakeCommand extends GeneratorCommand
 
         return (new Stub('/rule.stub', [
             'NAMESPACE' => $this->getClassNamespace($module),
-            'CLASS'     => $this->getClass(),
+            'CLASS'     => $this->getFileName(),
         ]))->render();
     }
 


### PR DESCRIPTION
**before:** 
```
php artisan module:make-rule phone-number Test

namespace Modules\Test\Rules;

use Illuminate\Contracts\Validation\Rule;

class phone-number implements Rule
{
```

**after:**
```
php artisan module:make-rule phone-number Test

namespace Modules\Test\Rules;

use Illuminate\Contracts\Validation\Rule;

class PhoneNumber implements Rule
{
```
