### PR TITLE
Add routes_with_namespace to config file

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -272,4 +272,6 @@ return [
     ],
 
     'activator' => 'file',
+
+    'routes_with_namespace' => false,
 ];

--- a/src/Commands/RouteProviderMakeCommand.php
+++ b/src/Commands/RouteProviderMakeCommand.php
@@ -65,6 +65,7 @@ class RouteProviderMakeCommand extends GeneratorCommand
             'WEB_ROUTES_PATH'      => $this->getWebRoutesPath(),
             'API_ROUTES_PATH'      => $this->getApiRoutesPath(),
             'LOWER_NAME'           => $module->getLowerName(),
+            'COMMENT_NAMESPACE'    => $module->getCommentNamespace(),
         ]))->render();
     }
 
@@ -121,5 +122,17 @@ class RouteProviderMakeCommand extends GeneratorCommand
         $module = $this->laravel['modules'];
 
         return str_replace('/', '\\', $module->config('paths.generator.controller.namespace') ?: $module->config('paths.generator.controller.path', 'Controller'));
+    }
+
+    /**
+     * @return string
+     */
+    private function getCommentNamespace(): string
+    {
+        if ($this->laravel['modules']->config('routes_with_namespace') === true) {
+            return '';
+        }
+
+        return '// ';
     }
 }

--- a/src/Commands/stubs/route-provider.stub
+++ b/src/Commands/stubs/route-provider.stub
@@ -10,9 +10,9 @@ class $CLASS$ extends ServiceProvider
     /**
      * The module namespace to assume when generating URLs to actions.
      *
-     * @var string
+     * @var string|null
      */
-    protected $moduleNamespace = '$MODULE_NAMESPACE$\$MODULE$\$CONTROLLER_NAMESPACE$';
+    $COMMENT_NAMESPACE$protected $moduleNamespace = '$MODULE_NAMESPACE$\$MODULE$\$CONTROLLER_NAMESPACE$';
 
     /**
      * Called before routes are registered.


### PR DESCRIPTION
PHP callable syntax was added to Laravel 8. Now namespace property in the RouteServiceProvider is nullable by default. When We create a new module, our new RouteServiceProvider file has namespace property with path. This config allows you to create a new module with the namespace property set as null. 