### PR TITLE
Add optional controller flag to model generator command

### DIFF
--- a/src/Commands/ModelMakeCommand.php
+++ b/src/Commands/ModelMakeCommand.php
@@ -41,6 +41,7 @@ class ModelMakeCommand extends GeneratorCommand
         }
 
         $this->handleOptionalMigrationOption();
+        $this->handleOptionalControllerOption();
 
         return 0;
     }
@@ -90,6 +91,7 @@ class ModelMakeCommand extends GeneratorCommand
         return [
             ['fillable', null, InputOption::VALUE_OPTIONAL, 'The fillable attributes.', null],
             ['migration', 'm', InputOption::VALUE_NONE, 'Flag to create associated migrations', null],
+            ['controller', 'c', InputOption::VALUE_NONE, 'Flag to create associated controllers', null],
         ];
     }
 
@@ -101,6 +103,20 @@ class ModelMakeCommand extends GeneratorCommand
         if ($this->option('migration') === true) {
             $migrationName = 'create_' . $this->createMigrationName() . '_table';
             $this->call('module:make-migration', ['name' => $migrationName, 'module' => $this->argument('module')]);
+        }
+    }
+
+    /**
+     * Create the controller file for the given model if controller flag was used
+     */
+    private function handleOptionalControllerOption()
+    {
+        if ($this->option('controller') === true) {
+            $controllerName = "{$this->getModelName()}Controller";
+
+            $this->call('module:make-controller', array_filter([
+                'controller' => $controllerName
+            ]));
         }
     }
 

--- a/src/Commands/ModelMakeCommand.php
+++ b/src/Commands/ModelMakeCommand.php
@@ -115,7 +115,8 @@ class ModelMakeCommand extends GeneratorCommand
             $controllerName = "{$this->getModelName()}Controller";
 
             $this->call('module:make-controller', array_filter([
-                'controller' => $controllerName
+                'controller' => $controllerName,
+                'module' => $this->argument('module')
             ]));
         }
     }

--- a/tests/Commands/ModelMakeCommandTest.php
+++ b/tests/Commands/ModelMakeCommandTest.php
@@ -91,6 +91,31 @@ class ModelMakeCommandTest extends BaseTestCase
     }
 
     /** @test */
+    public function it_generates_controller_file_with_model()
+    {
+        $code = $this->artisan('module:make-model', ['model' => 'Post', 'module' => 'Blog', '--controller' => true]);
+        $controllers = $this->finder->allFiles($this->modulePath . '/Http/Controllers');
+        $controllerFile = $controllers[1];
+        $controllerContent = $this->finder->get($this->modulePath . '/Http/Controllers/' . $controllerFile->getFilename());
+        $this->assertCount(2, $controllers);
+        $this->assertMatchesSnapshot($controllerContent);
+        $this->assertSame(0, $code);
+    }
+
+    /** @test */
+    public function it_generates_controller_file_with_model_using_shortcut_option()
+    {
+        $code = $this->artisan('module:make-model', ['model' => 'Post', 'module' => 'Blog', '-c' => true]);
+
+        $controllers = $this->finder->allFiles($this->modulePath . '/Http/Controllers');
+        $controllerFile = $controllers[1];
+        $controllerContent = $this->finder->get($this->modulePath . '/Http/Controllers/' . $controllerFile->getFilename());
+        $this->assertCount(2, $controllers);
+        $this->assertMatchesSnapshot($controllerContent);
+        $this->assertSame(0, $code);
+    }
+
+    /** @test */
     public function it_generates_correct_migration_file_name_with_multiple_words_model()
     {
         $code = $this->artisan('module:make-model', ['model' => 'ProductDetail', 'module' => 'Blog', '-m' => true]);

--- a/tests/Commands/ModelMakeCommandTest.php
+++ b/tests/Commands/ModelMakeCommandTest.php
@@ -116,6 +116,26 @@ class ModelMakeCommandTest extends BaseTestCase
     }
 
     /** @test */
+    public function it_generates_controller_and_migration_when_both_flags_are_present()
+    {
+        $code = $this->artisan('module:make-model', ['model' => 'Post', 'module' => 'Blog', '-c' => true, '-m' => true]);
+
+        $controllers = $this->finder->allFiles($this->modulePath . '/Http/Controllers');
+        $controllerFile = $controllers[1];
+        $controllerContent = $this->finder->get($this->modulePath . '/Http/Controllers/' . $controllerFile->getFilename());
+        $this->assertCount(2, $controllers);
+        $this->assertMatchesSnapshot($controllerContent);
+
+        $migrations = $this->finder->allFiles($this->modulePath . '/Database/Migrations');
+        $migrationFile = $migrations[0];
+        $migrationContent = $this->finder->get($this->modulePath . '/Database/Migrations/' . $migrationFile->getFilename());
+        $this->assertCount(1, $migrations);
+        $this->assertMatchesSnapshot($migrationContent);
+
+        $this->assertSame(0, $code);
+    }
+
+    /** @test */
     public function it_generates_correct_migration_file_name_with_multiple_words_model()
     {
         $code = $this->artisan('module:make-model', ['model' => 'ProductDetail', 'module' => 'Blog', '-m' => true]);

--- a/tests/Commands/__snapshots__/ModelMakeCommandTest__it_generates_controller_and_migration_when_both_flags_are_present__1.php
+++ b/tests/Commands/__snapshots__/ModelMakeCommandTest__it_generates_controller_and_migration_when_both_flags_are_present__1.php
@@ -1,0 +1,80 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\Http\\Controllers;
+
+use Illuminate\Contracts\Support\Renderable;
+use Illuminate\\Http\\Request;
+use Illuminate\\Routing\\Controller;
+
+class PostController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     * @return Renderable
+     */
+    public function index()
+    {
+        return view(\'blog::index\');
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     * @return Renderable
+     */
+    public function create()
+    {
+        return view(\'blog::create\');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     * @param Request $request
+     * @return Renderable
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Show the specified resource.
+     * @param int $id
+     * @return Renderable
+     */
+    public function show($id)
+    {
+        return view(\'blog::show\');
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     * @param int $id
+     * @return Renderable
+     */
+    public function edit($id)
+    {
+        return view(\'blog::edit\');
+    }
+
+    /**
+     * Update the specified resource in storage.
+     * @param Request $request
+     * @param int $id
+     * @return Renderable
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     * @param int $id
+     * @return Renderable
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}
+';

--- a/tests/Commands/__snapshots__/ModelMakeCommandTest__it_generates_controller_and_migration_when_both_flags_are_present__2.php
+++ b/tests/Commands/__snapshots__/ModelMakeCommandTest__it_generates_controller_and_migration_when_both_flags_are_present__2.php
@@ -1,0 +1,33 @@
+<?php return '<?php
+
+use Illuminate\\Support\\Facades\\Schema;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Database\\Migrations\\Migration;
+
+class CreatePostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create(\'posts\', function (Blueprint $table) {
+            $table->id();
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists(\'posts\');
+    }
+}
+';

--- a/tests/Commands/__snapshots__/ModelMakeCommandTest__it_generates_controller_file_with_model__1.php
+++ b/tests/Commands/__snapshots__/ModelMakeCommandTest__it_generates_controller_file_with_model__1.php
@@ -1,0 +1,80 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\Http\\Controllers;
+
+use Illuminate\Contracts\Support\Renderable;
+use Illuminate\\Http\\Request;
+use Illuminate\\Routing\\Controller;
+
+class PostController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     * @return Renderable
+     */
+    public function index()
+    {
+        return view(\'blog::index\');
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     * @return Renderable
+     */
+    public function create()
+    {
+        return view(\'blog::create\');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     * @param Request $request
+     * @return Renderable
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Show the specified resource.
+     * @param int $id
+     * @return Renderable
+     */
+    public function show($id)
+    {
+        return view(\'blog::show\');
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     * @param int $id
+     * @return Renderable
+     */
+    public function edit($id)
+    {
+        return view(\'blog::edit\');
+    }
+
+    /**
+     * Update the specified resource in storage.
+     * @param Request $request
+     * @param int $id
+     * @return Renderable
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     * @param int $id
+     * @return Renderable
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}
+';

--- a/tests/Commands/__snapshots__/ModelMakeCommandTest__it_generates_controller_file_with_model_using_shortcut_option__1.php
+++ b/tests/Commands/__snapshots__/ModelMakeCommandTest__it_generates_controller_file_with_model_using_shortcut_option__1.php
@@ -1,0 +1,80 @@
+<?php return '<?php
+
+namespace Modules\\Blog\\Http\\Controllers;
+
+use Illuminate\Contracts\Support\Renderable;
+use Illuminate\\Http\\Request;
+use Illuminate\\Routing\\Controller;
+
+class PostController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     * @return Renderable
+     */
+    public function index()
+    {
+        return view(\'blog::index\');
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     * @return Renderable
+     */
+    public function create()
+    {
+        return view(\'blog::create\');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     * @param Request $request
+     * @return Renderable
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Show the specified resource.
+     * @param int $id
+     * @return Renderable
+     */
+    public function show($id)
+    {
+        return view(\'blog::show\');
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     * @param int $id
+     * @return Renderable
+     */
+    public function edit($id)
+    {
+        return view(\'blog::edit\');
+    }
+
+    /**
+     * Update the specified resource in storage.
+     * @param Request $request
+     * @param int $id
+     * @return Renderable
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     * @param int $id
+     * @return Renderable
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}
+';


### PR DESCRIPTION
Use controller flag to create and assign controller to a model
```
php artisan module:make-model User -c
```
result
```
Created : .../Modules/ModuleName/Entities/User.php
Created : .../Modules/ModuleName/Http/Controllers/UserController.php
```
or

```
php artisan module:make-model User -mc
```

result
```
Created : .../Modules/ModuleName/Entities/User.php
Created : .../Modules/ModuleName/Database/Migrations/2021_07_28_140048_create_users_table.php
Created : .../Modules/ModuleName/Http/Controllers/UserController.php
```

Note: There was also a [related pull request](https://github.com/nWidart/laravel-modules/pull/1254) and i closed it because of mistakes i made.