### PR TITLE
Add event name prefix by config

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -277,7 +277,11 @@ abstract class Module
      */
     protected function fireEvent($event): void
     {
-        $this->app['events']->dispatch(sprintf('modules.%s.' . $event, $this->getLowerName()), [$this]);
+        $this->app['events']->dispatch(sprintf(
+            '%s%s.' . $event,
+            config('modules.events.prefix', 'modules.'),
+            $this->getLowerName()
+        ), [$this]);
     }
     /**
      * Register the aliases from this module.


### PR DESCRIPTION
When generating automatic events for modules, a hardcoded prefix is substituted for the name "modules.". This request adds the custom prefix feature