### PR TITLE
Fix error on anonymous migration class

### DIFF
--- a/src/Migrations/Migrator.php
+++ b/src/Migrations/Migrator.php
@@ -198,9 +198,13 @@ class Migrator
      */
     public function resolve($file)
     {
-        $file = implode('_', array_slice(explode('_', $file), 4));
+        $name = implode('_', array_slice(explode('_', $file), 4));
 
-        $class = Str::studly($file);
+        $class = Str::studly($name);
+
+        if (!class_exists($class) && file_exists($this->getPath() . '/' . $file . '.php') ) {
+            return include $this->getPath() . '/' . $file . '.php';
+        }
 
         return new $class();
     }


### PR DESCRIPTION
Laravel team introduce anonymous migration in Laravel 8.37, which solves migration class name collision issue.

Currently, the `module:migrate` command runs normally with anonymous migration.

But, `migrate-rollback` & `migrate-reset` trigger `Class not found` error.

So, I propose this changes to fix that issue.