### PR TITLE
fix: artisan module:migrate for lumen

### DIFF
--- a/src/Migrations/Migrator.php
+++ b/src/Migrations/Migrator.php
@@ -35,7 +35,7 @@ class Migrator
      * @param Module $module
      * @param Application $application
      */
-    public function __construct(Module $module, Application $application)
+    public function __construct(Module $module, Application|\Laravel\Lumen\Application $application)
     {
         $this->module = $module;
         $this->laravel = $application;


### PR DESCRIPTION
fix error 
Nwidart\Modules\Migrations\Migrator::__construct(): Argument #2 ($application) must be of type Illuminate\Contracts\Foundation\Application, Laravel\Lumen\Application given, called in vendor/nwidart/laravel-modules/src/Commands/MigrateCommand.php on line 67