### PR TITLE
remove duplicate define commands from config

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -185,8 +185,6 @@ return [
         Commands\ResourceMakeCommand::class,
         Commands\TestMakeCommand::class,
         Commands\LaravelModulesV6Migrator::class,
-        Commands\ComponentClassMakeCommand::class,
-        Commands\ComponentViewMakeCommand::class,
     ],
 
     /*


### PR DESCRIPTION
`ComponentClassMakeCommand::class` and `ComponentViewMakeCommand::class` are already defined on line [146](https://github.com/nWidart/laravel-modules/pull/1356/commits/ad55a60c068fc25a8d8c418d2e921823ce411c11#diff-f55db4bc294bbb90108ccfcbdd11881f4707473ad9384b382e2a6b653e118471L146) and [147](https://github.com/nWidart/laravel-modules/pull/1356/commits/ad55a60c068fc25a8d8c418d2e921823ce411c11#diff-f55db4bc294bbb90108ccfcbdd11881f4707473ad9384b382e2a6b653e118471L147) respectively