### PR TITLE
Improve FileRepository performance

### DIFF
--- a/src/FileRepository.php
+++ b/src/FileRepository.php
@@ -147,23 +147,23 @@ abstract class FileRepository implements RepositoryInterface, Countable
             return [];
         }
 
-        $ignoreFiles = function ($fileInfo) {
-            if (in_array($fileInfo->getFilename(), $this->config('scan.exclude', []))) {
-                return false;
-            }
+        if (in_array($filename, $this->config('scan.exclude', []))) {
+            return [];
+        }
 
-            return true;
-        };
-
-        $dir      = new \RecursiveDirectoryIterator($folder, \FilesystemIterator::KEY_AS_PATHNAME|\FilesystemIterator::CURRENT_AS_FILEINFO|\FilesystemIterator::FOLLOW_SYMLINKS);
-        $filtered = new \RecursiveCallbackFilterIterator($dir, $ignoreFiles);
-        $ite      = new \RecursiveIteratorIterator($filtered);
+        // Iterate directories
+        $dirs = new \FilesystemIterator($folder, 
+            \FilesystemIterator::KEY_AS_PATHNAME
+            | \FilesystemIterator::CURRENT_AS_FILEINFO 
+            | \FilesystemIterator::SKIP_DOTS 
+            | \FilesystemIterator::FOLLOW_SYMLINKS
+        );
 
         $fileList = [];
-        foreach ($ite as $file) {
-            /** @var SplFileInfo $file */
-            if ($file->getFilename() === $filename) {
-                $fileList[] = $file->getPathname();
+        foreach ($dirs as $dir) {
+            $Pathname = $dir->getPathname() . '/' . $filename;
+            if (is_file($Pathname)) {
+                $fileList[] = $Pathname;
             }
         }
 


### PR DESCRIPTION
See #1420 for issue.

This PR addresses points 3., 4. and 5. in the reported issue.

> 3. Assuming that both `recursiveSearch`  and `exclude` use specific filenames, we do not check once at the beginning of the function if the file we are searching for is in the exclude list and return immediately - instead we recurse all directories and filter out such files which seems to me to be a waste of time. (If we use `glob` style filters, then it would still need to be done in the `RecursiveCallbackFilterIterator`.)
>
> 4. The callback gets the `scan.exclude` array on every iteration rather than once when the function is called. 
>
> 5. The `recursiveSearch` function is looping through every directory and then every file and getting the filename and comparing it to the wanted filename. It would be much better to iterate through the directories and use an improved `RecursiveCallbackFilterIterator` callback function to check that the filename is correct or indeed only iterate the directories and for each directory check whether the specific file exists.

The significant performance benefits arise from point 5.