### PR TITLE
[feat] add command show model to package

### DIFF
--- a/src/Commands/ModelShowCommand.php
+++ b/src/Commands/ModelShowCommand.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Nwidart\Modules\Commands;
+
+use Illuminate\Foundation\Console\ShowModelCommand;
+
+class ModelShowCommand extends ShowModelCommand
+{
+
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'module:model-show';
+
+    /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     *
+     * @deprecated
+     */
+    protected static $defaultName = 'module:model-show';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Show information about an Eloquent model in modules';
+
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'module:model-show {model : The model to show}
+                {--database= : The database connection to use}
+                {--json : Output the model as JSON}';
+
+
+    /**
+     * Qualify the given model class base name.
+     *
+     * @param string $model
+     * @return string
+     *
+     * @see \Illuminate\Console\GeneratorCommand
+     */
+    protected function qualifyModel(string $model): string
+    {
+        if (str_contains($model, '\\') && class_exists($model)) {
+            return $model;
+        }
+
+        $rootNamespace = config('modules.namespace');
+
+        $modelPath = glob($rootNamespace . DIRECTORY_SEPARATOR .
+            '*' . DIRECTORY_SEPARATOR .
+            config('modules.paths.generator.model.path') . DIRECTORY_SEPARATOR .
+            "$model.php");
+
+        if (!count($modelPath)) {
+            return $model;
+        }
+
+        return str_replace(['/', '.php'], ['\\', ''], $modelPath[0]);
+    }
+
+}

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -41,6 +41,7 @@ class ConsoleServiceProvider extends ServiceProvider
         Commands\MigrateStatusCommand::class,
         Commands\MigrationMakeCommand::class,
         Commands\ModelMakeCommand::class,
+        Commands\ModelShowCommand::class,
         Commands\PublishCommand::class,
         Commands\PublishConfigurationCommand::class,
         Commands\PublishMigrationCommand::class,


### PR DESCRIPTION
This PR introduces a new `module:model-show` command that displays information for a model. It combines information from the database alongside information from Eloquent to give you a complete overview of your model. this command exclusively changed to this package.

more info about this Command : [[9.x] Artisan model:show command #43156](https://github.com/laravel/framework/pull/43156)

only change `qualifyModel` method to find model name in `Entities` Folder.