### PR TITLE
[feat] update command style to new version of artisan

### DIFF
--- a/src/Commands/DisableCommand.php
+++ b/src/Commands/DisableCommand.php
@@ -40,9 +40,9 @@ class DisableCommand extends Command
         if ($module->isEnabled()) {
             $module->disable();
 
-            $this->info("Module [{$module}] disabled successful.");
+            $this->components->info("Module [{$module}] disabled successful.");
         } else {
-            $this->comment("Module [{$module}] has already disabled.");
+            $this->components->warn("Module [{$module}] has already disabled.");
         }
 
         return 0;
@@ -62,9 +62,9 @@ class DisableCommand extends Command
             if ($module->isEnabled()) {
                 $module->disable();
 
-                $this->info("Module [{$module}] disabled successful.");
+                $this->components->info("Module [{$module}] disabled successful.");
             } else {
-                $this->comment("Module [{$module}] has already disabled.");
+                $this->components->warn("Module [{$module}] has already disabled.");
             }
         }
     }

--- a/src/Commands/GeneratorCommand.php
+++ b/src/Commands/GeneratorCommand.php
@@ -35,23 +35,25 @@ abstract class GeneratorCommand extends Command
     public function handle(): int
     {
         $path = str_replace('\\', '/', $this->getDestinationFilePath());
+        $this->components->task("Generating file {$path}",function () use ($path) {
 
-        if (!$this->laravel['files']->isDirectory($dir = dirname($path))) {
-            $this->laravel['files']->makeDirectory($dir, 0777, true);
-        }
+            if (!$this->laravel['files']->isDirectory($dir = dirname($path))) {
+                $this->laravel['files']->makeDirectory($dir, 0777, true);
+            }
 
-        $contents = $this->getTemplateContents();
+            $contents = $this->getTemplateContents();
 
-        try {
-            $overwriteFile = $this->hasOption('force') ? $this->option('force') : false;
-            (new FileGenerator($path, $contents))->withFileOverwrite($overwriteFile)->generate();
+            try {
+                    $overwriteFile = $this->hasOption('force') ? $this->option('force') : false;
+                    (new FileGenerator($path, $contents))->withFileOverwrite($overwriteFile)->generate();
 
-            $this->info("Created : {$path}");
-        } catch (FileAlreadyExistException $e) {
-            $this->error("File : {$path} already exists.");
+            } catch (FileAlreadyExistException $e) {
+                $this->components->error("File : {$path} already exists.");
 
-            return E_ERROR;
-        }
+                return E_ERROR;
+            }
+
+        });
 
         return 0;
     }

--- a/src/Commands/GeneratorCommand.php
+++ b/src/Commands/GeneratorCommand.php
@@ -35,7 +35,6 @@ abstract class GeneratorCommand extends Command
     public function handle(): int
     {
         $path = str_replace('\\', '/', $this->getDestinationFilePath());
-        $this->components->task("Generating file {$path}",function () use ($path) {
 
             if (!$this->laravel['files']->isDirectory($dir = dirname($path))) {
                 $this->laravel['files']->makeDirectory($dir, 0777, true);
@@ -44,16 +43,16 @@ abstract class GeneratorCommand extends Command
             $contents = $this->getTemplateContents();
 
             try {
+                $this->components->task("Generating file {$path}",function () use ($path,$contents) {
                     $overwriteFile = $this->hasOption('force') ? $this->option('force') : false;
                     (new FileGenerator($path, $contents))->withFileOverwrite($overwriteFile)->generate();
+                });
 
             } catch (FileAlreadyExistException $e) {
                 $this->components->error("File : {$path} already exists.");
 
                 return E_ERROR;
             }
-
-        });
 
         return 0;
     }

--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -27,7 +27,11 @@ class ListCommand extends Command
      */
     public function handle(): int
     {
-        $this->table(['Name', 'Status', 'Priority', 'Path'], $this->getRows());
+        $this->components->twoColumnDetail('<fg=gray>Status / Name</>', '<fg=gray>Path / priority</>');
+        collect($this->getRows())->each(function ($row) {
+
+            $this->components->twoColumnDetail("[{$row[1]}] {$row[0]}", "{$row[3]} [{$row[2]}]");
+        });
 
         return 0;
     }
@@ -45,7 +49,7 @@ class ListCommand extends Command
         foreach ($this->getModules() as $module) {
             $rows[] = [
                 $module->getName(),
-                $module->isEnabled() ? 'Enabled' : 'Disabled',
+                $module->isEnabled() ? '<fg=green>Enabled</>' : '<fg=red>Disabled</>',
                 $module->get('priority'),
                 $module->getPath(),
             ];

--- a/src/Commands/MiddlewareMakeCommand.php
+++ b/src/Commands/MiddlewareMakeCommand.php
@@ -85,4 +85,17 @@ class MiddlewareMakeCommand extends GeneratorCommand
     {
         return Str::studly($this->argument('name'));
     }
+
+    /**
+     * Run the command.
+     */
+    public function handle(): int
+    {
+
+        $this->components->info('Creating middleware...');
+
+        parent::handle();
+
+        return 0;
+    }
 }

--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -153,6 +153,9 @@ class MigrationMakeCommand extends GeneratorCommand
      */
     public function handle(): int
     {
+
+        $this->components->info('Creating migration...');
+
         if (parent::handle() === E_ERROR) {
             return E_ERROR;
         }

--- a/src/Commands/ModuleDeleteCommand.php
+++ b/src/Commands/ModuleDeleteCommand.php
@@ -14,7 +14,7 @@ class ModuleDeleteCommand extends Command
     {
         $this->laravel['modules']->delete($this->argument('module'));
 
-        $this->info("Module {$this->argument('module')} has been deleted.");
+        $this->components->info("Module {$this->argument('module')} has been deleted.");
 
         return 0;
     }

--- a/src/Commands/ModuleMakeCommand.php
+++ b/src/Commands/ModuleMakeCommand.php
@@ -39,6 +39,7 @@ class ModuleMakeCommand extends Command
                 ->setConfig($this->laravel['config'])
                 ->setActivator($this->laravel[ActivatorInterface::class])
                 ->setConsole($this)
+                ->setComponent($this->components)
                 ->setForce($this->option('force'))
                 ->setType($this->getModuleType())
                 ->setActive(!$this->option('disabled'))

--- a/src/Generators/ModuleGenerator.php
+++ b/src/Generators/ModuleGenerator.php
@@ -314,17 +314,16 @@ class ModuleGenerator extends Generator
     {
         $name = $this->getName();
 
-        $this->component->info("Creating module: [$name]");
-
         if ($this->module->has($name)) {
             if ($this->force) {
                 $this->module->delete($name);
             } else {
-                $this->component->error("Module [{$name}] already exist!");
+                $this->component->error("Module [{$name}] already exists!");
 
                 return E_ERROR;
             }
         }
+        $this->component->info("Creating module: [$name]");
 
         $this->generateFolders();
 

--- a/src/Generators/ModuleGenerator.php
+++ b/src/Generators/ModuleGenerator.php
@@ -42,6 +42,14 @@ class ModuleGenerator extends Generator
     protected $console;
 
     /**
+     * The laravel component Factory instance.
+     *
+     * @var \Illuminate\Console\View\Components\Factory
+     */
+    protected $component;
+
+
+    /**
      * The activator instance
      *
      * @var ActivatorInterface
@@ -225,6 +233,23 @@ class ModuleGenerator extends Generator
     }
 
     /**
+     * @return \Illuminate\Console\View\Components\Factory
+     */
+    public function getComponent(): \Illuminate\Console\View\Components\Factory
+    {
+        return $this->component;
+    }
+
+    /**
+     * @param \Illuminate\Console\View\Components\Factory $component
+     */
+    public function setComponent(\Illuminate\Console\View\Components\Factory $component): self
+    {
+        $this->component = $component;
+        return $this;
+    }
+
+    /**
      * Get the module instance.
      *
      * @return \Nwidart\Modules\Module
@@ -289,11 +314,13 @@ class ModuleGenerator extends Generator
     {
         $name = $this->getName();
 
+        $this->component->info("Creating module: [$name]");
+
         if ($this->module->has($name)) {
             if ($this->force) {
                 $this->module->delete($name);
             } else {
-                $this->console->error("Module [{$name}] already exist!");
+                $this->component->error("Module [{$name}] already exist!");
 
                 return E_ERROR;
             }
@@ -314,7 +341,9 @@ class ModuleGenerator extends Generator
 
         $this->activator->setActiveByName($name, $this->isActive);
 
-        $this->console->info("Module [{$name}] created successfully.");
+        $this->console->newLine(1);
+
+        $this->component->info("Module [{$name}] created successfully.");
 
         return 0;
     }
@@ -358,13 +387,13 @@ class ModuleGenerator extends Generator
         foreach ($this->getFiles() as $stub => $file) {
             $path = $this->module->getModulePath($this->getName()) . $file;
 
-            if (!$this->filesystem->isDirectory($dir = dirname($path))) {
-                $this->filesystem->makeDirectory($dir, 0775, true);
-            }
+            $this->component->task("Generating file {$path}",function () use ($stub, $path) {
+                if (!$this->filesystem->isDirectory($dir = dirname($path))) {
+                    $this->filesystem->makeDirectory($dir, 0775, true);
+                }
 
-            $this->filesystem->put($path, $this->getStubContents($stub));
-
-            $this->console->info("Created : {$path}");
+                $this->filesystem->put($path, $this->getStubContents($stub));
+            });
         }
     }
 
@@ -467,13 +496,13 @@ class ModuleGenerator extends Generator
     {
         $path = $this->module->getModulePath($this->getName()) . 'module.json';
 
-        if (!$this->filesystem->isDirectory($dir = dirname($path))) {
-            $this->filesystem->makeDirectory($dir, 0775, true);
-        }
+        $this->component->task("Generating file $path",function () use ($path) {
+            if (!$this->filesystem->isDirectory($dir = dirname($path))) {
+                $this->filesystem->makeDirectory($dir, 0775, true);
+            }
 
-        $this->filesystem->put($path, $this->getStubContents('json'));
-
-        $this->console->info("Created : {$path}");
+            $this->filesystem->put($path, $this->getStubContents('json'));
+        });
     }
 
     /**

--- a/tests/Commands/ModuleMakeCommandTest.php
+++ b/tests/Commands/ModuleMakeCommandTest.php
@@ -223,9 +223,11 @@ class ModuleMakeCommandTest extends BaseTestCase
         $this->artisan('module:make', ['name' => ['Blog']]);
         $code = $this->artisan('module:make', ['name' => ['Blog']]);
 
-        $expected = 'Module [Blog] already exist!
-';
-        $this->assertEquals($expected, Artisan::output());
+        $output = Artisan::output();
+        $expected = 'ERROR  Module [Blog] already exists!';
+
+        $this->assertTrue(Str::contains($output, $expected));
+
         $this->assertSame(E_ERROR, $code);
     }
 


### PR DESCRIPTION
in this PR update commands to  new look for Artisan.
base of this PR is: [[9.x] Introducing a fresh new look for Artisan #43065](https://github.com/laravel/framework/pull/43065)

updated command list is : 
- `module:disable`
- `module:delete`
- `module:list`
- `module:make-middleware`
- `module:make-migration`
- `module:make`

Other commands will be updated soon...
<img width="1032" alt="Screen Shot 1401-05-09 at 01 01 43" src="https://user-images.githubusercontent.com/26966142/181995746-94599c6f-7357-46b4-9d6f-16f343bb1236.png">
<img width="1036" alt="Screen Shot 1401-05-09 at 00 59 37" src="https://user-images.githubusercontent.com/26966142/181995803-d6138987-68f2-4bdd-aaee-9a1160263e55.png">
<img width="1032" alt="Screen Shot 1401-05-09 at 01 00 10" src="https://user-images.githubusercontent.com/26966142/181995806-0eb37f44-5414-4e52-a368-3e0abed36b3a.png">

