### PR TITLE
FIX - DisableCommand.php

### DIFF
--- a/src/Commands/DisableCommand.php
+++ b/src/Commands/DisableCommand.php
@@ -32,6 +32,7 @@ class DisableCommand extends Command
          */
         if ($this->argument('module') === null) {
             $this->disableAll();
+            return 0;
         }
 
         /** @var Module $module */


### PR DESCRIPTION
Despite allowing to disable all modules at once, the command `artisan module:disable` returns an exception when it receive `null` in the `module` argument

![image](https://user-images.githubusercontent.com/62029328/183748805-b225b594-b5c5-46bf-9b8d-c0b042f54c3f.png)

This setting allows the command to be output after disabling all modules.