### PR TITLE
Update DisableCommand.php

### DIFF
--- a/src/Commands/DisableCommand.php
+++ b/src/Commands/DisableCommand.php
@@ -32,6 +32,7 @@ class DisableCommand extends Command
          */
         if ($this->argument('module') === null) {
             $this->disableAll();
+            return 0;
         }
 
         /** @var Module $module */


### PR DESCRIPTION
Fix the below issue on run 
`php artisan module:disable`

Nwidart\Modules\FileRepository::findOrFail(): Argument #1 ($name) must be of type string, null given, called in 
/vendor/nwidart/laravel-modules/src/Commands/DisableCommand.php on line 38