### PR TITLE
Fix make-factory command when model path is nested path

### DIFF
--- a/src/Commands/FactoryMakeCommand.php
+++ b/src/Commands/FactoryMakeCommand.php
@@ -107,6 +107,10 @@ class FactoryMakeCommand extends GeneratorCommand
      */
     public function getModelNamespace(): string
     {
-        return $this->laravel['modules']->config('namespace') . '\\' . $this->laravel['modules']->findOrFail($this->getModuleName()) . '\\' . $this->laravel['modules']->config('paths.generator.model.path', 'Entities');
+        $path = $this->laravel['modules']->config('paths.generator.model.path', 'Entities');
+
+        $path = str_replace('/', '\\', $path);
+
+        return $this->laravel['modules']->config('namespace') . '\\' . $this->laravel['modules']->findOrFail($this->getModuleName()) . '\\' . $path;
     }
 }


### PR DESCRIPTION
## Issue

When config `paths.generator.model.path` is set to `Eloquent/Models`, the Factory model generated from `make-factory` command will be like this

```
class UserFactory extends Factory
{
    protected $model = \Modules\Core\Eloquent/Models/User::class;
    // ...
}
```

## Root Cause

When generating model namespace, it assumes only one layer for the folder.

```
public function getModelNamespace(): string
    {
        return $this->laravel['modules']->config('namespace') . '\\' . $this->laravel['modules']->findOrFail($this->getModuleName()) . '\\' . $this->laravel['modules']->config('paths.generator.model.path', 'Entities');
    }
```

## Solution

To replace `/` string with `\\` string in `$this->laravel['modules']->config('paths.generator.model.path', 'Entities')`