### PR TITLE
[feat] implement command check lang folder, and show missing files an…

### DIFF
--- a/src/Commands/CheckLangCommand.php
+++ b/src/Commands/CheckLangCommand.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace Nwidart\Modules\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Symfony\Component\Console\Input\InputArgument;
+
+class CheckLangCommand extends Command
+{
+
+    private $langPath;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'module:lang';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Check missing language keys in the specified module.';
+
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+
+        $this->langPath = DIRECTORY_SEPARATOR . config('modules.paths.generator.lang.path', 'Resources/lang');
+
+        $this->components->alert('Checking languages ...');
+
+        $this->newLine();
+
+        if ($name = $this->argument('module')) {
+            $this->check($name);
+
+            return 0;
+        }
+
+        $this->checkAll();
+
+        return 0;
+
+    }
+
+    /**
+     * enableAll
+     *
+     * @return void
+     */
+    public function checkAll()
+    {
+        $modules = $this->laravel['modules']->all();
+
+        foreach ($modules as $module) {
+            $this->check($module);
+        }
+    }
+
+    /**
+     * enable
+     *
+     * @param string $name
+     * @return void
+     */
+    public function check($name)
+    {
+        if ($name instanceof Module) {
+            $module = $name;
+        } else {
+            $module = $this->laravel['modules']->findOrFail($name);
+        }
+
+        $directories = $this->getDirectories($module);
+
+        if (! $directories) {
+            return;
+        }
+
+        $this->checkMissingFiles($directories);
+
+        $this->checkMissingKeys($directories);
+
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['module', InputArgument::OPTIONAL, 'Module name.'],
+        ];
+    }
+
+    private function getLangFiles($module)
+    {
+        $files = [];
+        $path  = $module->getPath() . $this->langPath;
+        if (is_dir($path)) {
+            $files = array_merge($files, $this->laravel['files']->all($path));
+        }
+
+        return $files;
+    }
+
+    private function getDirectories($module)
+    {
+        $moduleName = $module->getStudlyName();
+        $path       = $module->getPath() . '/Resources/lang';
+        if (is_dir($path)) {
+            $directories = $this->laravel['files']->directories($path);
+            $directories = array_map(function ($directory) use ($moduleName) {
+                return [
+                    'name'   => basename($directory),
+                    'module' => $moduleName,
+                    'path'   => $directory,
+                    'files'  => array_map(function ($file) {
+                        return basename($file);
+                    }, \File::glob($directory . DIRECTORY_SEPARATOR . "*")),
+                ];
+            }, $directories);
+        }
+
+        if (count($directories) == 0) {
+            $this->components->info("No language files found in module $moduleName");
+            return false;
+        }
+
+        if (count($directories) == 1) {
+            $this->components->warn("Only one language file found in module $moduleName");
+            return false;
+        }
+
+        return collect($directories);
+    }
+
+    private function checkMissingFiles(Collection $directories)
+    {
+        //show missing files
+        $missingFilesMessage = [];
+
+        $uniqeLangFiles = $directories->pluck('files')->flatten()->unique()->values();
+
+        $directories->each(function ($directory) use ($uniqeLangFiles, &$missingFilesMessage) {
+
+            $missingFiles = $uniqeLangFiles->diff($directory['files']);
+
+            if ($missingFiles->count() > 0) {
+                $missingFiles->each(function ($missingFile) use ($directory, &$missingFilesMessage) {
+                    $missingFilesMessage[$directory['name']][] = " {$directory['module']} - Missing language file: {$directory['name']}/{$missingFile}";
+                });
+            }
+
+        });
+
+        if (count($missingFilesMessage) > 0) {
+
+            collect($missingFilesMessage)->each(function ($messages, $langDirectory) {
+
+                $this->components->error("Missing language files in $langDirectory directory");
+
+                $this->components->bulletList(
+                    collect($messages)->unique()->values()->toArray()
+                );
+
+                $this->newLine();
+
+            });
+
+        }
+
+    }
+
+    private function checkMissingKeys(Collection $directories)
+    {
+        //show missing keys
+        $uniqeLangFiles  = $directories->pluck('files')->flatten()->unique();
+        $langDirectories = $directories->pluck('name');
+
+
+        $missingKeysMessage = [];
+        $directories->each(function ($directory) use ($uniqeLangFiles, $langDirectories, &$missingKeysMessage) {
+
+            $uniqeLangFiles->each(function ($file) use ($directory, $langDirectories, &$missingKeysMessage) {
+                $langKeys = $this->getLangKeys($directory['path'] . DIRECTORY_SEPARATOR . $file);
+
+                if ($langKeys == false) {
+                    return;
+                }
+
+                $langDirectories->each(function ($langDirectory) use ($directory, $file, $langKeys, &$missingKeysMessage) {
+
+                    if ($directory['name'] != $langDirectory) {
+
+                        $basePath = str_replace($directory['name'], $langDirectory, $directory['path']);
+
+                        $otherLangKeys = $this->getLangKeys($basePath . DIRECTORY_SEPARATOR . $file);
+
+                        if ($otherLangKeys == false) {
+                            return;
+                        }
+
+                        $missingKeys = $langKeys->diff($otherLangKeys);
+                        if ($missingKeys->count() > 0) {
+
+                            $missingKeys->each(function ($missingKey) use ($directory, $langDirectory, $file, &$missingKeysMessage) {
+                                $missingKeysMessage[$langDirectory][] = " {$directory['module']} - Missing language key: {$langDirectory}/{$file} | key: $missingKey";
+                            });
+
+                        }
+                    }
+                });
+            });
+        });
+
+
+        if (count($missingKeysMessage) > 0) {
+
+            collect($missingKeysMessage)->each(function ($messages, $langDirectory) {
+
+                $this->components->error("Missing language keys for directory $langDirectory:");
+
+                $this->components->bulletList(
+                    collect($messages)->unique()->values()->toArray()
+                );
+
+                $this->newLine();
+            });
+        }
+    }
+
+    private function getLangKeys($file)
+    {
+        if (\File::exists($file)) {
+            $lang = \File::getRequire($file);
+            return collect(\Arr::dot($lang))->keys();
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -57,6 +57,7 @@ class ConsoleServiceProvider extends ServiceProvider
         Commands\LaravelModulesV6Migrator::class,
         Commands\ComponentClassMakeCommand::class,
         Commands\ComponentViewMakeCommand::class,
+        Commands\CheckLangCommand::class,
     ];
 
     public function register(): void


### PR DESCRIPTION

Hi,
This PR introduces a new `module:lang` command that displays missing files/keys  of each language.

Like other comments if don't pass module name Arguments check all modules of project.

For Example : this my base module language
```
➜  lang git:(master) ✗ tree
.
├── ar
│   ├── action.php
│   └── test4.php
├── en
│   ├── action.php
│   ├── constant.php
│   ├── footer.php
│   ├── form.php
│   ├── general.php
│   ├── header.php
│   ├── sidebar.php
│   ├── social.php
│   ├── table.php
│   └── test3.php
└── fa
    ├── action.php
    ├── constant.php
    ├── footer.php
    ├── form.php
    ├── general.php
    ├── header.php
    ├── sidebar.php
    ├── social.php
    ├── table.php
    ├── test1.php
    └── test2.php

3 directories, 23 files

```

after run command get this result : 


<img width="867" alt="Screen Shot 1401-07-03 at 01 23 35" src="https://user-images.githubusercontent.com/26966142/192119927-234122ea-b669-4556-ad84-57b7af19b837.png">


also this command showing missing keys of each files 😎
In the example above: 
content of file ar/action.php is: 
```
<?php
return [

    ];

```

and content of file en/action.php is: 
```
<?php

return [
    'action' => 'Action',

    'save'         => 'Save',
    'update'       => 'Update',
    'add'          => 'Add',
    'delete'       => 'Delete',
    'cancel'       => 'Cancel',
    'wait'         => 'Please wait...',
    'apply'        => 'Apply',
    'edit'         => 'Edit',
    'change'       => 'Change',
    'view'         => 'View',
    'show_on_site' => 'Show on site',
    'browse_file'  => 'Browse File',
    'browse_image' => 'Browse Image',
    'browse_video' => 'Browse Video',
    'choose'       => 'Choose',

    'activity_log' => 'Activity Log',
];
```

and content of file fa/action.php is: 
```
<?php

return [
    'action' => 'عملیات',

    'save'         => 'ذخیره',
    'update'       => 'به‌روزرسانی',
    'add'          => 'افزودن',
    'delete'       => 'حذف',
    'cancel'       => 'لغو',
    'back'         => 'بازگشت',
    'close'        => 'بستن',
    'wait'         => 'لطفا منتظر بمانید...',
    'apply'        => 'اعمال',
    'edit'         => 'ویرایش',
    'change'       => 'تغییر',
    'view'         => 'مشاهده',
    'show_on_site' => 'نمایش در سایت',

    'activity_log' => 'تاریخچه فعالیت',
];
```

after run command get this result : 
<img width="782" alt="Screen Shot 1401-07-03 at 01 29 59" src="https://user-images.githubusercontent.com/26966142/192120104-59b33e01-7a26-4ee5-95c1-b8a50863fcb6.png">

