### PR TITLE
loadJsonTranslationsFrom doesn't have 2 parameters

### DIFF
--- a/src/Commands/stubs/scaffold/provider.stub
+++ b/src/Commands/stubs/scaffold/provider.stub
@@ -84,10 +84,10 @@ class $CLASS$ extends ServiceProvider
 
         if (is_dir($langPath)) {
             $this->loadTranslationsFrom($langPath, $this->moduleNameLower);
-            $this->loadJsonTranslationsFrom($langPath, $this->moduleNameLower);
+            $this->loadJsonTranslationsFrom($langPath);
         } else {
             $this->loadTranslationsFrom(module_path($this->moduleName, '$PATH_LANG$'), $this->moduleNameLower);
-            $this->loadJsonTranslationsFrom(module_path($this->moduleName, '$PATH_LANG$'), $this->moduleNameLower);
+            $this->loadJsonTranslationsFrom(module_path($this->moduleName, '$PATH_LANG$'));
         }
     }
 


### PR DESCRIPTION
The method [loadJsonTranslationsFrom](https://laravel.com/api/9.x/Illuminate/Support/ServiceProvider.html#method_loadJsonTranslationsFrom) doesn't want the namespace as second parameter, as is the case for [loadTranslationsFrom](https://laravel.com/api/9.x/Illuminate/Support/ServiceProvider.html#method_loadTranslationsFrom).

The documentation should also be reviewed