### PR TITLE
Support for Laravel 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All Notable changes to `laravel-modules` will be documented in this file.
 
 ## Next
 
+## 10.0 - 2022-02-14
+
+### Changed
+
+- Minimum PHP version to 8.1 for supporting Laravel 10
+- Laravel 10 version
+- Increased PHPUnit to 10.0
+- Increased Mockery to 1.5
+
 ## Updated
 
 - [@dev-karpenko](https://github.com/dev-karpenko) updated get attributes cache [#1526](https://github.com/nWidart/laravel-modules/pull/1526)

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
   "scripts": {
     "update-snapshots": "./vendor/bin/phpunit --no-coverage -d --update-snapshots",
     "test": "vendor/bin/phpunit",
-    "test-coverage": "vendor/bin/phpunit --debug --coverage-html coverage",
+    "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
     "pcf": "vendor/bin/php-cs-fixer fix --verbose"
   },
   "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -18,16 +18,16 @@
     }
   ],
   "require": {
-    "php": ">=8.0",
+    "php": ">=8.1",
     "ext-json": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.5",
-    "mockery/mockery": "^1.4",
-    "orchestra/testbench": "^7.0",
+    "phpunit/phpunit": "^10.0",
+    "mockery/mockery": "^1.5",
+    "orchestra/testbench": "^8.0",
     "friendsofphp/php-cs-fixer": "^3.6",
-    "laravel/framework": "^9.21",
-    "spatie/phpunit-snapshot-assertions": "^4.2",
+    "laravel/framework": "^10.0",
+    "spatie/phpunit-snapshot-assertions": "^5.0",
     "phpstan/phpstan": "^1.4"
   },
   "autoload": {
@@ -54,7 +54,7 @@
       }
     },
     "branch-alias": {
-      "dev-master": "9.0-dev"
+      "dev-master": "10.0-dev"
     }
   },
   "scripts": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php"
          backupGlobals="false"
-         backupStaticAttributes="false"
+         backupStaticProperties="false"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>
@@ -14,16 +10,17 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+        <report>
+            <clover outputFile="build/logs/clover.xml"/>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt"/>
+        </report>
+    </coverage>
     <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
+        <junit outputFile="build/report.junit.xml"/>
     </logging>
 </phpunit>

--- a/src/Commands/ModelShowCommand.php
+++ b/src/Commands/ModelShowCommand.php
@@ -2,7 +2,7 @@
 
 namespace Nwidart\Modules\Commands;
 
-use Illuminate\Foundation\Console\ShowModelCommand;
+use Illuminate\Database\Console\ShowModelCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand('module:model-show', 'Show information about an Eloquent model in modules')]

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -39,6 +39,7 @@ abstract class BaseTestCase extends OrchestraTestCase
      */
     protected function getEnvironmentSetUp($app)
     {
+        $app['config']->set('app.asset_url', null);
         $app['config']->set('database.default', 'sqlite');
         $app['config']->set('database.connections.sqlite', [
             'driver' => 'sqlite',

--- a/tests/Commands/ComponentClassMakeCommandTest.php
+++ b/tests/Commands/ComponentClassMakeCommandTest.php
@@ -6,7 +6,7 @@ use Nwidart\Modules\Contracts\RepositoryInterface;
 use Nwidart\Modules\Tests\BaseTestCase;
 use Spatie\Snapshots\MatchesSnapshots;
 
-class ComponentClassCommandTest extends BaseTestCase
+class ComponentClassMakeCommandTest extends BaseTestCase
 {
     use MatchesSnapshots;
     /**

--- a/tests/Commands/ComponentViewMakeCommandTest.php
+++ b/tests/Commands/ComponentViewMakeCommandTest.php
@@ -6,7 +6,7 @@ use Nwidart\Modules\Contracts\RepositoryInterface;
 use Nwidart\Modules\Tests\BaseTestCase;
 use Spatie\Snapshots\MatchesSnapshots;
 
-class ComponentViewCommandTest extends BaseTestCase
+class ComponentViewMakeCommandTest extends BaseTestCase
 {
     use MatchesSnapshots;
     /**

--- a/tests/LaravelModuleTest.php
+++ b/tests/LaravelModuleTest.php
@@ -8,7 +8,7 @@ use Modules\Recipe\Providers\RecipeServiceProvider;
 use Nwidart\Modules\Contracts\ActivatorInterface;
 use Nwidart\Modules\Json;
 
-class ModuleTest extends BaseTestCase
+class LaravelModuleTest extends BaseTestCase
 {
     /**
      * @var TestingModule


### PR DESCRIPTION
Hi there,

I wasn't sure about how you'd handle bumping major version of a package & laravel, but I took a look at the commit for the previous major version bump to L9 and hopefully this PR helps to save some time.

- [x] Update `composer.json` dependencies
- [x] Fixed namespace update for `ShowModelCommand`
- [x] Update `CHANGELOG.md`
- [x] Migrate `phpunit.xml.dist` configuration to the latest schema `phpunit:v10`
- [x] Fixed `LaravelModuleTest`, `ComponentViewMakeCommandTest` & `ComponentClassMakeCommandTest` where class name did not match the file name
- [ ] ~~remove `abstract` keyword from `MigrateCommandTest`~~
- [x] fix `LaravelFileRepositoryTest` failing test on `it_gets_a_specific_module_asset`
- [ ] Update stubs?

Let me know if there's anything else that I can help out with.

Close #1521 