### PR TITLE
Modules now make use of a new 'connection' value in their configs

### DIFF
--- a/src/Commands/MigrateCommand.php
+++ b/src/Commands/MigrateCommand.php
@@ -64,6 +64,11 @@ class MigrateCommand extends Command
      */
     protected function migrate(Module $module)
     {
+        $database = $this->option('database');
+        if(!$database) {
+            $database = $module->getDatabaseName();
+        }
+
         $path = str_replace(base_path(), '', (new Migrator($module, $this->getLaravel()))->getPath());
 
         if ($this->option('subpath')) {
@@ -72,7 +77,7 @@ class MigrateCommand extends Command
 
         $this->call('migrate', [
             '--path' => $path,
-            '--database' => $this->option('database'),
+            '--database' => $database,
             '--pretend' => $this->option('pretend'),
             '--force' => $this->option('force'),
         ]);

--- a/src/Commands/MigrateFreshCommand.php
+++ b/src/Commands/MigrateFreshCommand.php
@@ -38,11 +38,17 @@ class MigrateFreshCommand extends Command
             return E_ERROR;
         }
 
+
+        $database = $this->option('database');
+        if(!$database) {
+            $database = $module->getDatabaseName();
+        }
+
         $this->call('migrate:fresh');
 
         $this->call('module:migrate', [
             'module' => $this->getModuleName(),
-            '--database' => $this->option('database'),
+            '--database' => $database,
             '--force' => $this->option('force'),
             '--seed' => $this->option('seed'),
         ]);

--- a/src/Commands/MigrateRefreshCommand.php
+++ b/src/Commands/MigrateRefreshCommand.php
@@ -38,15 +38,20 @@ class MigrateRefreshCommand extends Command
             return E_ERROR;
         }
 
+        $database = $this->option('database');
+        if(!$database) {
+            $database = $module->getDatabaseName();
+        }
+
         $this->call('module:migrate-reset', [
             'module' => $this->getModuleName(),
-            '--database' => $this->option('database'),
+            '--database' => $database,
             '--force' => $this->option('force'),
         ]);
 
         $this->call('module:migrate', [
             'module' => $this->getModuleName(),
-            '--database' => $this->option('database'),
+            '--database' => $database,
             '--force' => $this->option('force'),
         ]);
 

--- a/src/Commands/MigrateResetCommand.php
+++ b/src/Commands/MigrateResetCommand.php
@@ -69,6 +69,9 @@ class MigrateResetCommand extends Command
         $migrator = new Migrator($module, $this->getLaravel());
 
         $database = $this->option('database');
+        if(!$database) {
+            $database = $module->getDatabaseName();
+        }
 
         if (!empty($database)) {
             $migrator->setDatabase($database);

--- a/src/Commands/MigrateRollbackCommand.php
+++ b/src/Commands/MigrateRollbackCommand.php
@@ -69,6 +69,9 @@ class MigrateRollbackCommand extends Command
         $migrator = new Migrator($module, $this->getLaravel());
 
         $database = $this->option('database');
+        if(!$database) {
+            $database = $module->getDatabaseName();
+        }
 
         if (!empty($database)) {
             $migrator->setDatabase($database);

--- a/src/Commands/MigrateStatusCommand.php
+++ b/src/Commands/MigrateStatusCommand.php
@@ -65,9 +65,14 @@ class MigrateStatusCommand extends Command
     {
         $path = str_replace(base_path(), '', (new Migrator($module, $this->getLaravel()))->getPath());
 
+        $database = $this->option('database');
+        if(!$database) {
+            $database = $module->getDatabaseName();
+        }
+
         $this->call('migrate:status', [
             '--path' => $path,
-            '--database' => $this->option('database'),
+            '--database' => $database,
         ]);
     }
 

--- a/src/Module.php
+++ b/src/Module.php
@@ -420,4 +420,20 @@ abstract class Module
     {
         $this->translator->addNamespace($namespace, $path);
     }
+
+
+    /**
+     * Get the modules connection from its config file.
+     *
+     * @return string|null
+     */
+    public function getDatabaseName(): ?string
+    {
+        $connectionName = config($this->getLowerName().'.connection');
+        if($connectionName) {
+            return DB::connection($connectionName)->getDatabaseName();
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
We use the laravel-modules package in an application at work, rightly or wrongly we separate each modules tables into a new database.

When using the module-migrate commands, if a developer forgets to add the `--database` to manually define which database on which to run we end up with both tables and migration entries on the default laravel connection.

This PR allows a default connection to be defined in each modules config.php file.