### PR TITLE
fix bug "class not found"

### DIFF
--- a/src/Commands/ModelShowCommand.php
+++ b/src/Commands/ModelShowCommand.php
@@ -2,11 +2,11 @@
 
 namespace Nwidart\Modules\Commands;
 
-use Illuminate\Database\Console\ShowModelCommand;
+use Illuminate\Database\Console\ShowCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand('module:model-show', 'Show information about an Eloquent model in modules')]
-class ModelShowCommand extends ShowModelCommand
+class ModelShowCommand extends ShowCommand
 {
 
 


### PR DESCRIPTION
Hello good time
During the installation today, I encountered the error Class "Illuminate\Database\Console\ShowModelCommand" not found, so I solved this problem. Thank you for confirming.