### PR TITLE
Edited stub to be able to use variables in a command

### DIFF
--- a/src/Commands/stubs/command.stub
+++ b/src/Commands/stubs/command.stub
@@ -13,7 +13,7 @@ class $CLASS$ extends Command
      *
      * @var string
      */
-    protected $name = '$COMMAND_NAME$';
+    protected $signature = '$COMMAND_NAME$';
 
     /**
      * The console command description.


### PR DESCRIPTION
I found this bug when i was working on a command, after reading the official [docs](https://laravel.com/docs/10.x/artisan#input-descriptions) i found out that that the variable needed to be changed.