### PR TITLE
[feat] Indicate a sub-path for modules specific migration file

### DIFF
--- a/src/Commands/MigrateRollbackCommand.php
+++ b/src/Commands/MigrateRollbackCommand.php
@@ -66,7 +66,7 @@ class MigrateRollbackCommand extends Command
             $module = $this->module->findOrFail($module);
         }
 
-        $migrator = new Migrator($module, $this->getLaravel());
+        $migrator = new Migrator($module, $this->getLaravel(), $this->option('subpath'));
 
         $database = $this->option('database');
 
@@ -111,6 +111,7 @@ class MigrateRollbackCommand extends Command
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
             ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
+            ['subpath', null, InputOption::VALUE_OPTIONAL, 'Indicate a subpath for modules specific migration file']
         ];
     }
 }

--- a/src/Migrations/Migrator.php
+++ b/src/Migrations/Migrator.php
@@ -29,7 +29,7 @@ class Migrator
      * @var string|null
      * @example subpath 2000_01_01_000000_create_example_table.php
      */
-    protected $subpath = null;
+    protected $subpath = '';
 
     /**
      * The database connection to be used
@@ -98,7 +98,7 @@ class Migrator
      */
     public function getMigrations($reverse = false)
     {
-        if ($this->subpath) {
+        if (!empty($this->subpath)) {
             $files = $this->laravel['files']->glob($this->getPath() . '/' . $this->subpath);
         } else {
             $files = $this->laravel['files']->glob($this->getPath() . '/*_*.php');

--- a/src/Migrations/Migrator.php
+++ b/src/Migrations/Migrator.php
@@ -24,6 +24,14 @@ class Migrator
     protected $laravel;
 
     /**
+     * Optional subpath for specific migration file.
+     *
+     * @var string|null
+     * @example subpath 2000_01_01_000000_create_example_table.php
+     */
+    protected $subpath = null;
+
+    /**
      * The database connection to be used
      *
      * @var string
@@ -34,11 +42,13 @@ class Migrator
      * Create new instance.
      * @param Module $module
      * @param Application $application
+     * @param string|null $subpath
      */
-    public function __construct(Module $module, Application $application)
+    public function __construct(Module $module, Application $application, $subpath = null)
     {
         $this->module = $module;
         $this->laravel = $application;
+        $this->subpath = $subpath;
     }
 
     /**
@@ -88,7 +98,11 @@ class Migrator
      */
     public function getMigrations($reverse = false)
     {
-        $files = $this->laravel['files']->glob($this->getPath() . '/*_*.php');
+        if ($this->subpath) {
+            $files = $this->laravel['files']->glob($this->getPath() . '/' . $this->subpath);
+        } else {
+            $files = $this->laravel['files']->glob($this->getPath() . '/*_*.php');
+        }
 
         // Once we have the array of files in the directory we will just remove the
         // extension and take the basename of the file which is all we need when


### PR DESCRIPTION
This pull request is against the issue #1423 

Use optional `subpath` flag for migrating specific migration file of a Module. 

**Usage**

`php artisan module:migrate-rollback --subpath="2023_04_27_101427_create_users_table.php" Blog`