### PR TITLE
Update ModelMakeCommand.php

### DIFF
--- a/src/Commands/ModelMakeCommand.php
+++ b/src/Commands/ModelMakeCommand.php
@@ -56,18 +56,7 @@ class ModelMakeCommand extends GeneratorCommand
      */
     private function createMigrationName()
     {
-        $pieces = preg_split('/(?=[A-Z])/', $this->argument('model'), -1, PREG_SPLIT_NO_EMPTY);
-
-        $string = '';
-        foreach ($pieces as $i => $piece) {
-            if ($i+1 < count($pieces)) {
-                $string .= strtolower($piece) . '_';
-            } else {
-                $string .= Str::plural(strtolower($piece));
-            }
-        }
-
-        return $string;
+        return Str::snake(Str::pluralStudly($this->argument('model')));
     }
 
     /**


### PR DESCRIPTION
When the model name is in all uppercase, the table name in the migration file needs to be updated to match the expected naming convention.

For example, if the model name is SOA, the old table name might be s_o_as. To fix this, you should rename the table to s_o_a_s, which follows Laravel's default table naming convention for uppercase model names.