### PR TITLE
Module specific config publish path

### DIFF
--- a/src/Commands/stubs/scaffold/provider.stub
+++ b/src/Commands/stubs/scaffold/provider.stub
@@ -48,11 +48,22 @@ class $CLASS$ extends ServiceProvider
     protected function registerConfig()
     {
         $this->publishes([
-            module_path($this->moduleName, '$PATH_CONFIG$/config.php') => config_path($this->moduleNameLower . '.php'),
+            module_path($this->moduleName, '$PATH_CONFIG$/config.php') => $this->getConfigPath($this->moduleNameLower),
         ], 'config');
         $this->mergeConfigFrom(
             module_path($this->moduleName, '$PATH_CONFIG$/config.php'), $this->moduleNameLower
         );
+    }
+
+    /**
+     * Get config path.
+     *
+     * @param  string $configName
+     * @return string
+     */
+    public function getConfigPath(string $configName): string
+    {
+        return config_path("{$this->moduleNameLower}/{$configName}.php");
     }
 
     /**


### PR DESCRIPTION
This pull request introduces a new feature that allows module-specific configuration files to be published to a custom path within the Laravel application.

Summary of Changes:

- Added a new method on provider  called `getConfigPath`.
- The `getConfigPath` method allows module  to specify a custom path where module-specific configuration files should be published.
- Updated the ModuleServiceProvider to utilize the `getConfigPath` option when publishing the module's configuration files.

Motivation:

The motivation behind this feature is to provide more flexibility when publishing their configuration files. By allowing a module-specific config publish path, developers can organize their configuration files within their module directories, making it easier to manage and maintain module-specific configurations separately from the main application's configurations.