### PR TITLE
Fix module performance issue

### DIFF
--- a/src/FileRepository.php
+++ b/src/FileRepository.php
@@ -63,6 +63,13 @@ abstract class FileRepository implements RepositoryInterface, Countable
     private $cache;
 
     /**
+     * Scanned modules array.
+     *
+     * @var array
+     */
+    private static array $modules = [];
+
+    /**
      * The constructor.
      * @param Container $app
      * @param string|null $path
@@ -140,6 +147,10 @@ abstract class FileRepository implements RepositoryInterface, Countable
      */
     public function scan()
     {
+        if (count(static::$modules)) {
+            return static::$modules;
+        }
+
         $paths = $this->getScanPaths();
 
         $modules = [];
@@ -155,6 +166,8 @@ abstract class FileRepository implements RepositoryInterface, Countable
                 $modules[$name] = $this->createModule($this->app, $name, dirname($manifest));
             }
         }
+
+        static::$modules = $modules;
 
         return $modules;
     }

--- a/src/Providers/ContractsServiceProvider.php
+++ b/src/Providers/ContractsServiceProvider.php
@@ -13,6 +13,6 @@ class ContractsServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bind(RepositoryInterface::class, LaravelFileRepository::class);
+        $this->app->singleton(RepositoryInterface::class, LaravelFileRepository::class);
     }
 }


### PR DESCRIPTION
This pull request addresses an issue where the module was being initialized excessively, resulting in a high number of module scans (13 times per module). To resolve this issue, a fix has been implemented by introducing a static property `$modules` on the `FileRepository` class. This property will store the scanned modules' data, and the `scan()` method will retrieve the module information from $modules instead of performing repetitive scans.

Summary of Changes:

- Changed bind to singleton `RepositoryInterface::class, LaravelFileRepository::class` class. 
- Added a new static property `$modules` to the `FileRepository` class.
- When the `scan()` method is invoked, it first checks if `$modules` is already populated.
- If `$modules` is empty, the method performs the module scanning process and stores the result in `$modules`.
- If `$modules` contains data, the method directly returns the module information from `$modules` without performing additional scans.
- Updated relevant documentation and comments to reflect the changes and improvements made.

Motivation:

The motivation behind this fix is to optimize the module initialization process and reduce the number of module scans. The observation that the module was being initialized more often than necessary and the module scan was performed 13 times per module indicated a potential inefficiency in the code. By introducing the `$modules` static property and leveraging its data within the `scan()` method, we can eliminate repetitive scans and improve performance.

Contributor's Note:

Upon analyzing the codebase, I noticed that the module initialization was occurring more frequently than expected, resulting in multiple module scans (13 times per module). To address this issue, I have implemented a fix that introduces a static property `$modules` in the `FileRepository` class. This property stores the scanned module data, and subsequent calls to the `scan()` method will retrieve the module information from `$modules` instead of performing redundant scans. I have thoroughly tested this fix in a local development environment to ensure its correctness and effectiveness.

I kindly request the community and maintainers to review this pull request and provide feedback or suggestions for further improvement.