### PR TITLE
Add Make Observer Command

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -108,6 +108,7 @@ return [
             'seeder' => ['path' => 'Database/Seeders', 'generate' => true],
             'factory' => ['path' => 'Database/factories', 'generate' => true],
             'model' => ['path' => 'Entities', 'generate' => true],
+            'observer' => ['path' => 'Observers', 'generate' => true],
             'routes' => ['path' => 'Routes', 'generate' => true],
             'controller' => ['path' => 'Http/Controllers', 'generate' => true],
             'filter' => ['path' => 'Http/Middleware', 'generate' => true],

--- a/src/Commands/ObserverMakeCommand.php
+++ b/src/Commands/ObserverMakeCommand.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Nwidart\Modules\Commands;
+
+use Illuminate\Support\Str;
+use Nwidart\Modules\Support\Config\GenerateConfigReader;
+use Nwidart\Modules\Support\Stub;
+use Nwidart\Modules\Traits\ModuleCommandTrait;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class ObserverMakeCommand extends GeneratorCommand
+{
+    use ModuleCommandTrait;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'module:make-observer';
+
+
+    /**
+     * The name of argument name.
+     *
+     * @var string
+     */
+    protected $argumentName = 'name';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new observer for the specified module.';
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['name', InputArgument::REQUIRED, 'The observer name will be created.'],
+            ['module', InputArgument::OPTIONAL, 'The name of module will be created.'],
+        ];
+    }
+
+    /**
+     * @return mixed
+     */
+    protected function getTemplateContents()
+    {
+        $module = $this->laravel['modules']->findOrFail($this->getModuleName());
+        return (new Stub('/observer.stub', [
+            'NAMESPACE' => $this->getClassNamespace($module).'\Observers',
+            'CLASS' => $this->getClass(),
+//            'NAMESPACEMODEL' => $this->getClass()
+        ]))->render();
+    }
+    /**
+     * @return mixed
+     */
+    protected function getDestinationFilePath()
+    {
+        $path = $this->laravel['modules']->getModulePath($this->getModuleName());
+        $observerPath = GenerateConfigReader::read('observer');
+        return $path . $observerPath->getPath() . '/' . $this->getFileName() . '.php';
+    }
+
+    /**
+     * @return string
+     */
+    private function getFileName()
+    {
+        return Str::studly($this->argument('name'));
+    }
+
+
+    public function handle(): int
+    {
+        $this->components->info('Creating observer...');
+
+        parent::handle();
+
+        return 0;
+    }
+
+}

--- a/src/Commands/ObserverMakeCommand.php
+++ b/src/Commands/ObserverMakeCommand.php
@@ -7,7 +7,6 @@ use Nwidart\Modules\Support\Config\GenerateConfigReader;
 use Nwidart\Modules\Support\Stub;
 use Nwidart\Modules\Traits\ModuleCommandTrait;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 
 class ObserverMakeCommand extends GeneratorCommand
 {
@@ -55,19 +54,53 @@ class ObserverMakeCommand extends GeneratorCommand
     {
         $module = $this->laravel['modules']->findOrFail($this->getModuleName());
         return (new Stub('/observer.stub', [
-            'NAMESPACE' => $this->getClassNamespace($module).'\Observers',
-            'CLASS' => $this->getClass(),
-//            'NAMESPACEMODEL' => $this->getClass()
-        ]))->render();
+                'NAMESPACE' => $this->getClassNamespace($module) . '\Observers',
+                'NAME' => $this->getModelName(),
+                'MODEL_NAMESPACE' => $this->getModelNamespace(),
+                'NAME_VARIABLE' => $this->getModelVariable(),
+            ]))->render();
     }
+
+    /**
+     * Get model namespace.
+     *
+     * @return string
+     */
+    public function getModelNamespace(): string
+    {
+        $path = $this->laravel['modules']->config('paths.generator.model.path', 'Entities');
+
+        $path = str_replace('/', '\\', $path);
+
+        return $this->laravel['modules']->config('namespace') . '\\' . $this->laravel['modules']->findOrFail($this->getModuleName()) . '\\' . $path;
+    }
+
+    /**
+     * @return mixed|string
+     */
+    private function getModelName()
+    {
+        return Str::studly($this->argument('name'));
+    }
+
+    /**
+     *  @return mixed|string
+     */
+    private function getModelVariable() : string
+    {
+        return '$'.Str::lower($this->argument('name'));
+    }
+
     /**
      * @return mixed
      */
     protected function getDestinationFilePath()
     {
         $path = $this->laravel['modules']->getModulePath($this->getModuleName());
+
         $observerPath = GenerateConfigReader::read('observer');
-        return $path . $observerPath->getPath() . '/' . $this->getFileName() . '.php';
+
+        return $path . $observerPath->getPath() . '/' . $this->getFileName();
     }
 
     /**
@@ -75,7 +108,7 @@ class ObserverMakeCommand extends GeneratorCommand
      */
     private function getFileName()
     {
-        return Str::studly($this->argument('name'));
+        return Str::studly($this->argument('name')) . 'Observer.php';
     }
 
 
@@ -87,5 +120,4 @@ class ObserverMakeCommand extends GeneratorCommand
 
         return 0;
     }
-
 }

--- a/src/Commands/stubs/observer.stub
+++ b/src/Commands/stubs/observer.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace $NAMESPACE$;
+
+class $CLASS$
+{
+
+}

--- a/src/Commands/stubs/observer.stub
+++ b/src/Commands/stubs/observer.stub
@@ -2,7 +2,47 @@
 
 namespace $NAMESPACE$;
 
-class $CLASS$
-{
+use $MODEL_NAMESPACE$\$NAME$;
 
+class $NAME$Observer
+{
+    /**
+     * Handle the $NAME$ "created" event.
+     */
+    public function created($NAME$ $NAME_VARIABLE$): void
+    {
+        //
+    }
+
+    /**
+     * Handle the $NAME$ "updated" event.
+     */
+    public function updated($NAME$ $NAME_VARIABLE$): void
+    {
+        //
+    }
+
+    /**
+     * Handle the $NAME$ "deleted" event.
+     */
+    public function deleted($NAME$ $NAME_VARIABLE$): void
+    {
+        //
+    }
+
+    /**
+     * Handle the $NAME$ "restored" event.
+     */
+    public function restored($NAME$ $NAME_VARIABLE$): void
+    {
+        //
+    }
+
+    /**
+     * Handle the $NAME$ "force deleted" event.
+     */
+    public function forceDeleted($NAME$ $NAME_VARIABLE$): void
+    {
+        //
+    }
 }

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -42,6 +42,7 @@ class ConsoleServiceProvider extends ServiceProvider
         Commands\MigrateStatusCommand::class,
         Commands\MigrationMakeCommand::class,
         Commands\ModelMakeCommand::class,
+        Commands\ObserverMakeCommand::class,
         Commands\ModelShowCommand::class,
         Commands\PublishCommand::class,
         Commands\PublishConfigurationCommand::class,

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -61,6 +61,7 @@ abstract class BaseTestCase extends OrchestraTestCase
                 'migration' => ['path' => 'Database/Migrations', 'generate' => true],
                 'factory' => ['path' => 'Database/factories', 'generate' => true],
                 'model' => ['path' => 'Entities', 'generate' => true],
+                'observer' => ['path' => 'Observers', 'generate' => true],
                 'repository' => ['path' => 'Repositories', 'generate' => true],
                 'seeder' => ['path' => 'Database/Seeders', 'generate' => true],
                 'controller' => ['path' => 'Http/Controllers', 'generate' => true],

--- a/tests/Commands/ObserverMakeCommandTest.php
+++ b/tests/Commands/ObserverMakeCommandTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Nwidart\Modules\Tests\Commands;
+
+use Nwidart\Modules\Contracts\RepositoryInterface;
+use Nwidart\Modules\Tests\BaseTestCase;
+use Spatie\Snapshots\MatchesSnapshots;
+
+class ObserverMakeCommandTest extends BaseTestCase
+{
+    use MatchesSnapshots;
+    /**
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    private $finder;
+    /**
+     * @var string
+     */
+    private $modulePath;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->modulePath = base_path('modules/Blog');
+        $this->finder = $this->app['files'];
+        $this->artisan('module:make', ['name' => ['Blog']]);
+    }
+
+    public function tearDown(): void
+    {
+        $this->app[RepositoryInterface::class]->delete('Blog');
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_makes_observer()
+    {
+        $code = $this->artisan('module:make-observer', ['name' => 'Post', 'module' => 'Blog']);
+
+        $observerFile = $this->modulePath . '/Observers/PostObserver.php';
+        // dd($observerFile);
+
+        $this->assertTrue(is_file($observerFile), 'Observer file was not created.');
+        $this->assertMatchesSnapshot($this->finder->get($observerFile));
+        $this->assertSame(0, $code);
+    }
+}

--- a/tests/Commands/__snapshots__/ObserverMakeCommandTest__it_makes_observer__1.php
+++ b/tests/Commands/__snapshots__/ObserverMakeCommandTest__it_makes_observer__1.php
@@ -1,0 +1,50 @@
+<?php return '<?php
+
+namespace Modules\Blog\Observers;
+
+use Modules\Blog\Entities\Post;
+
+class PostObserver
+{
+    /**
+     * Handle the Post "created" event.
+     */
+    public function created(Post $post): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Post "updated" event.
+     */
+    public function updated(Post $post): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Post "deleted" event.
+     */
+    public function deleted(Post $post): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Post "restored" event.
+     */
+    public function restored(Post $post): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Post "force deleted" event.
+     */
+    public function forceDeleted(Post $post): void
+    {
+        //
+    }
+}
+
+';

--- a/tests/Commands/__snapshots__/ObserverMakeCommandTest__it_makes_observer__1.txt
+++ b/tests/Commands/__snapshots__/ObserverMakeCommandTest__it_makes_observer__1.txt
@@ -1,0 +1,48 @@
+<?php
+
+namespace Modules\Blog\Observers;
+
+use Modules\Blog\Entities\Post;
+
+class PostObserver
+{
+    /**
+     * Handle the Post "created" event.
+     */
+    public function created(Post $post): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Post "updated" event.
+     */
+    public function updated(Post $post): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Post "deleted" event.
+     */
+    public function deleted(Post $post): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Post "restored" event.
+     */
+    public function restored(Post $post): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Post "force deleted" event.
+     */
+    public function forceDeleted(Post $post): void
+    {
+        //
+    }
+}


### PR DESCRIPTION
After merging this PR we can make a new observer based on the selected model, The related command to be run is:

```
php artisan module:make-observer Post Blog
```

This command will create `PostObserver` inside the `Moudles\Blog\Observers` directory and contain all necessary functions to be observed.