### PR TITLE
Command $name property works but it doesn't support options…

### DIFF
--- a/src/Commands/stubs/command.stub
+++ b/src/Commands/stubs/command.stub
@@ -13,7 +13,7 @@ class $CLASS$ extends Command
      *
      * @var string
      */
-    protected $name = '$COMMAND_NAME$';
+    protected $signature = '$COMMAND_NAME$';
 
     /**
      * The console command description.


### PR DESCRIPTION
…and maybe even arguments

I lost more than an hour to realize that the signature was actually the name, and for this reason I couldn't pass options to the command. This was the only command I had generated from this stub and I was punished :-P