### PR TITLE
New rule stub

### DIFF
--- a/src/Commands/stubs/rule.stub
+++ b/src/Commands/stubs/rule.stub
@@ -2,31 +2,16 @@
 
 namespace $NAMESPACE$;
 
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 
-class $CLASS$ implements Rule
+class $CLASS$ implements ValidationRule
 {
     /**
-     * Create a new rule instance.
+     * Run the validation rule.
      */
-    public function __construct()
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         //
-    }
-
-    /**
-     * Determine if the validation rule passes.
-     */
-    public function passes(string $attribute, $value): bool
-    {
-        //
-    }
-
-    /**
-     * Get the validation error message.
-     */
-    public function message(): string
-    {
-        return 'The validation error message.';
     }
 }

--- a/tests/Commands/__snapshots__/ControllerMakeCommandTest__it_generates_an_api_controller__1.txt
+++ b/tests/Commands/__snapshots__/ControllerMakeCommandTest__it_generates_an_api_controller__1.txt
@@ -17,7 +17,7 @@ class MyController extends Controller
     {
         //
 
-        return response()->json($this->data)->setStatusCode(200);
+        return response()->json($this->data);
     }
 
     /**
@@ -27,7 +27,7 @@ class MyController extends Controller
     {
         //
 
-        return response()->json($this->data)->setStatusCode(200);
+        return response()->json($this->data);
     }
 
     /**
@@ -37,7 +37,7 @@ class MyController extends Controller
     {
         //
 
-        return response()->json($this->data)->setStatusCode(200);
+        return response()->json($this->data);
     }
 
     /**
@@ -47,7 +47,7 @@ class MyController extends Controller
     {
         //
 
-        return response()->json($this->data)->setStatusCode(200);
+        return response()->json($this->data);
     }
 
     /**
@@ -57,6 +57,6 @@ class MyController extends Controller
     {
         //
 
-        return response()->json($this->data)->setStatusCode(200);
+        return response()->json($this->data);
     }
 }

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_api_module_with_resources__2.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__it_generates_api_module_with_resources__2.txt
@@ -17,7 +17,7 @@ class BlogController extends Controller
     {
         //
 
-        return response()->json($this->data)->setStatusCode(200);
+        return response()->json($this->data);
     }
 
     /**
@@ -27,7 +27,7 @@ class BlogController extends Controller
     {
         //
 
-        return response()->json($this->data)->setStatusCode(200);
+        return response()->json($this->data);
     }
 
     /**
@@ -37,7 +37,7 @@ class BlogController extends Controller
     {
         //
 
-        return response()->json($this->data)->setStatusCode(200);
+        return response()->json($this->data);
     }
 
     /**
@@ -47,7 +47,7 @@ class BlogController extends Controller
     {
         //
 
-        return response()->json($this->data)->setStatusCode(200);
+        return response()->json($this->data);
     }
 
     /**
@@ -57,6 +57,6 @@ class BlogController extends Controller
     {
         //
 
-        return response()->json($this->data)->setStatusCode(200);
+        return response()->json($this->data);
     }
 }

--- a/tests/Commands/__snapshots__/RuleMakeCommandTest__it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/__snapshots__/RuleMakeCommandTest__it_can_change_the_default_namespace__1.txt
@@ -2,31 +2,16 @@
 
 namespace Modules\Blog\SuperRules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 
-class UniqueRule implements Rule
+class UniqueRule implements ValidationRule
 {
     /**
-     * Create a new rule instance.
+     * Run the validation rule.
      */
-    public function __construct()
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         //
-    }
-
-    /**
-     * Determine if the validation rule passes.
-     */
-    public function passes(string $attribute, $value): bool
-    {
-        //
-    }
-
-    /**
-     * Get the validation error message.
-     */
-    public function message(): string
-    {
-        return 'The validation error message.';
     }
 }

--- a/tests/Commands/__snapshots__/RuleMakeCommandTest__it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/__snapshots__/RuleMakeCommandTest__it_can_change_the_default_namespace_specific__1.txt
@@ -2,31 +2,16 @@
 
 namespace Modules\Blog\SuperRules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 
-class UniqueRule implements Rule
+class UniqueRule implements ValidationRule
 {
     /**
-     * Create a new rule instance.
+     * Run the validation rule.
      */
-    public function __construct()
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         //
-    }
-
-    /**
-     * Determine if the validation rule passes.
-     */
-    public function passes(string $attribute, $value): bool
-    {
-        //
-    }
-
-    /**
-     * Get the validation error message.
-     */
-    public function message(): string
-    {
-        return 'The validation error message.';
     }
 }

--- a/tests/Commands/__snapshots__/RuleMakeCommandTest__it_makes_rule__1.txt
+++ b/tests/Commands/__snapshots__/RuleMakeCommandTest__it_makes_rule__1.txt
@@ -2,31 +2,16 @@
 
 namespace Modules\Blog\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 
-class UniqueRule implements Rule
+class UniqueRule implements ValidationRule
 {
     /**
-     * Create a new rule instance.
+     * Run the validation rule.
      */
-    public function __construct()
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         //
-    }
-
-    /**
-     * Determine if the validation rule passes.
-     */
-    public function passes(string $attribute, $value): bool
-    {
-        //
-    }
-
-    /**
-     * Get the validation error message.
-     */
-    public function message(): string
-    {
-        return 'The validation error message.';
     }
 }


### PR DESCRIPTION
This PR ships new rule stub because `Illuminate\Contracts\Validation\Rule` has been deprecated in Laravel 10.
https://github.com/laravel/framework/pull/45954