### PR TITLE
Update config.php

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -107,7 +107,7 @@ return [
             'migration' => ['path' => 'database/migrations', 'generate' => true],
             'seeder' => [
                 'path' => 'database/seeders',
-                'namespace' => 'Database/Seeders',
+                'namespace' => 'database/seeders',
                 'generate' => true,
             ],
             'factory' => ['path' => 'database/factories', 'generate' => true],


### PR DESCRIPTION
Fix: *** does not comply with the psr-4 autoloading standard.

The namespace `Database/Seeders` has not been fully implemented yet.

Until another pull request is submitted to address this issue, it is advised to continue using the default namespace 'database/seeders'