### PR TITLE
WIP add vite support for central vite.config.js

### DIFF
--- a/scripts/vite-module-loader.js
+++ b/scripts/vite-module-loader.js
@@ -1,0 +1,45 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+async function collectModuleAssetsPaths(paths, modulesPath) {
+  modulesPath = path.join(__dirname, modulesPath);
+
+  const moduleStatusesPath = path.join(__dirname, 'modules_statuses.json');
+
+  try {
+    // Read module_statuses.json
+    const moduleStatusesContent = await fs.readFile(moduleStatusesPath, 'utf-8');
+    const moduleStatuses = JSON.parse(moduleStatusesContent);
+
+    // Read module directories
+    const moduleDirectories = await fs.readdir(modulesPath);
+
+    for (const moduleDir of moduleDirectories) {
+      if (moduleDir === '.DS_Store') {
+        // Skip .DS_Store directory
+        continue;
+      }
+
+      // Check if the module is enabled (status is true)
+      if (moduleStatuses[moduleDir] === true) {
+        const viteConfigPath = path.join(modulesPath, moduleDir, 'vite.config.js');
+        const stat = await fs.stat(viteConfigPath);
+
+        if (stat.isFile()) {
+          // Import the module-specific Vite configuration
+          const moduleConfig = await import(viteConfigPath);
+
+          if (moduleConfig.paths && Array.isArray(moduleConfig.paths)) {
+            paths.push(...moduleConfig.paths);
+          }
+        }
+      }
+    }
+  } catch (error) {
+    console.error(`Error reading module statuses or module configurations: ${error}`);
+  }
+
+  return paths;
+}
+
+export default collectModuleAssetsPaths;

--- a/src/Commands/stubs/package.stub
+++ b/src/Commands/stubs/package.stub
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build"

--- a/src/Module.php
+++ b/src/Module.php
@@ -75,6 +75,26 @@ abstract class Module
     }
 
     /**
+     * Returns an array of assets
+     *
+     * @return array
+     */
+    public static function getAssets(): array
+    {
+        $paths = [];
+
+        if (file_exists('build/manifest.json')) {
+            $files = json_decode(file_get_contents('build/manifest.json'), true);
+
+            foreach ($files as $file) {
+                $paths[] = $file['src'];
+            }
+        }
+
+        return $paths;
+    }
+
+    /**
      * Get name.
      *
      * @return string

--- a/src/ModulesServiceProvider.php
+++ b/src/ModulesServiceProvider.php
@@ -46,6 +46,10 @@ abstract class ModulesServiceProvider extends ServiceProvider
         $this->publishes([
             $stubsPath => base_path('stubs/nwidart-stubs'),
         ], 'stubs');
+
+        $this->publishes([
+            __DIR__.'/../scripts/vite-module-loader.js' => base_path('vite-module-loader.js'),
+        ], 'vite');
     }
 
     /**

--- a/tests/LaravelModuleTest.php
+++ b/tests/LaravelModuleTest.php
@@ -23,7 +23,7 @@ class LaravelModuleTest extends BaseTestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->module = new TestingModule($this->app, 'Recipe Name', __DIR__ . '/stubs/valid/Recipe');
+        $this->module = new TestingModule($this->app, 'Recipe Name', __DIR__.'/stubs/valid/Recipe');
         $this->activator = $this->app[ActivatorInterface::class];
     }
 
@@ -36,13 +36,13 @@ class LaravelModuleTest extends BaseTestCase
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
-        symlink(__DIR__ . '/stubs/valid', __DIR__ . '/stubs/valid_symlink');
+        symlink(__DIR__.'/stubs/valid', __DIR__.'/stubs/valid_symlink');
     }
 
     public static function tearDownAfterClass(): void
     {
         parent::tearDownAfterClass();
-        unlink(__DIR__ . '/stubs/valid_symlink');
+        unlink(__DIR__.'/stubs/valid_symlink');
     }
 
     /** @test */
@@ -78,7 +78,7 @@ class LaravelModuleTest extends BaseTestCase
     /** @test */
     public function it_gets_module_path()
     {
-        $this->assertEquals(__DIR__ . '/stubs/valid/Recipe', $this->module->getPath());
+        $this->assertEquals(__DIR__.'/stubs/valid/Recipe', $this->module->getPath());
     }
 
     /** @test */
@@ -86,9 +86,9 @@ class LaravelModuleTest extends BaseTestCase
     {
         // symlink created in setUpBeforeClass
 
-        $this->module = new TestingModule($this->app, 'Recipe Name', __DIR__ . '/stubs/valid_symlink/Recipe');
+        $this->module = new TestingModule($this->app, 'Recipe Name', __DIR__.'/stubs/valid_symlink/Recipe');
 
-        $this->assertEquals(__DIR__ . '/stubs/valid_symlink/Recipe', $this->module->getPath());
+        $this->assertEquals(__DIR__.'/stubs/valid_symlink/Recipe', $this->module->getPath());
 
         // symlink deleted in tearDownAfterClass
     }
@@ -96,7 +96,7 @@ class LaravelModuleTest extends BaseTestCase
     /** @test */
     public function it_loads_module_translations()
     {
-        (new TestingModule($this->app, 'Recipe', __DIR__ . '/stubs/valid/Recipe'))->boot();
+        (new TestingModule($this->app, 'Recipe', __DIR__.'/stubs/valid/Recipe'))->boot();
         $this->assertEquals('Recipe', trans('recipe::recipes.title.recipes'));
     }
 
@@ -205,9 +205,9 @@ class LaravelModuleTest extends BaseTestCase
                 RecipeServiceProvider::class,
                 DeferredServiceProvider::class,
             ],
-            'eager'     => [RecipeServiceProvider::class],
-            'deferred'  => ['deferred' => DeferredServiceProvider::class],
-            'when'      =>
+            'eager' => [RecipeServiceProvider::class],
+            'deferred' => ['deferred' => DeferredServiceProvider::class],
+            'when' =>
                 [DeferredServiceProvider::class => []],
         ], $manifest);
     }
@@ -229,6 +229,48 @@ class LaravelModuleTest extends BaseTestCase
         app('deferred');
 
         $this->assertEquals('bar', app('foo'));
+    }
+
+    /** @test */
+    public function it_can_load_assets_is_empty_when_no_manifest_exists()
+    {
+        $result = $this->module->getAssets();
+
+        $this->assertEquals([], $result);
+    }
+
+    /** @test */
+    public function it_can_load_assets_when_manifest_exists()
+    {
+        mkdir('build');
+        file_put_contents('build/manifest.json', '{
+          "Modules/Books/resources/assets/sass/app.scss": {
+            "file": "assets/app-4ed993c7.js",
+            "isEntry": true,
+            "src": "Modules/Books/resources/assets/sass/app.scss"
+          },
+          "Modules/Pages/resources/css/app.css": {
+            "file": "assets/app-5a5d3a39.css",
+            "isEntry": true,
+            "src": "Modules/Pages/resources/css/app.css"
+          },
+          "resources/css/app.css": {
+            "file": "assets/app-3ebdfa1f.css",
+            "isEntry": true,
+            "src": "resources/css/app.css"
+          }
+        }');
+
+        $result = $this->module->getAssets();
+
+        $this->assertEquals([
+            'Modules/Books/resources/assets/sass/app.scss',
+            'Modules/Pages/resources/css/app.css',
+            'resources/css/app.css'
+        ], $result);
+
+        unlink('build/manifest.json');
+        rmdir('build');
     }
 }
 


### PR DESCRIPTION
# WIP

This PR allows for the main vite.config.js to load paths from the base application as well as from modules. The idea is to have a single place to load all the css and js files into vite.

This is OPT in, the default setup that now exists allows you to load vite into a module. That will remain. This is to optionally load all assets globally.

The main vite.config.js will need to be updated to use a new `vite-module-loader.js` file. This needs to be published by running:

```bash
php artisan vendor:publish --provider="Nwidart\Modules\LaravelModulesServiceProvider" --tag="vite"
```

This created a file called `vite-module-loader.js` inside the project root.

Now `vite.config.js` will combine all paths from modules as well as those defined in this file.

```js
import {defineConfig} from 'vite';
import laravel from 'laravel-vite-plugin';
import collectModuleAssetsPaths from './vite-module-loader.js';

const paths = [
    'resources/css/app.css'
];

const allPaths = await collectModuleAssetsPaths(paths, 'Modules');

export default defineConfig({
    plugins: [
        laravel({
            input:  allPaths,
            refresh: true,
        }),
    ],
});
```

Modules `vite.config.js` should be updated to contain only the assets:

```php
export const paths = [
    'Modules/Books/resources/assets/sass/app.scss',
    'Modules/Books/resources/assets/js/app.js',
];
```

Then in the layout file to load all assets use:

```php
@vite(\Nwidart\Modules\Module::getAssets())
```