### PR TITLE
Removed the commented code sample. `// return auth()->user()->can('users.create');`

### DIFF
--- a/src/Commands/stubs/request.stub
+++ b/src/Commands/stubs/request.stub
@@ -22,6 +22,5 @@ class $CLASS$ extends FormRequest
     public function authorize(): bool
     {
         return true;
-        // return auth()->user()->can('users.create');
     }
 }


### PR DESCRIPTION
Removed the commented code sample. `// return auth()->user()->can('users.create');`

In response to the issue #1684