### PR TITLE
:bug: Fix ModelShowCommand extends property

### DIFF
--- a/src/Commands/ModelShowCommand.php
+++ b/src/Commands/ModelShowCommand.php
@@ -2,11 +2,12 @@
 
 namespace Nwidart\Modules\Commands;
 
+use Illuminate\Console\Command;
 use Illuminate\Database\Console\ShowModelCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand('module:model-show', 'Show information about an Eloquent model in modules')]
-class ModelShowCommand extends ShowModelCommand
+class ModelShowCommand extends Command
 {
 
 


### PR DESCRIPTION
Hello there!

When runnning `php artisan package:discover` I had this error ` Class "Illuminate\Foundation\Console\ShowModelCommand" not found`

<img width="1162" alt="Capture d’écran 2023-12-07 à 10 12 39" src="https://github.com/nWidart/laravel-modules/assets/1109647/c81dcfe3-5e50-4d39-8b0f-7521ded7fa48">

I found the reason and fixed it.
Thanks
Ben