### PR TITLE
[fix] revert extend class to ShowModelCommand

### DIFF
--- a/src/Commands/ModelShowCommand.php
+++ b/src/Commands/ModelShowCommand.php
@@ -2,15 +2,12 @@
 
 namespace Nwidart\Modules\Commands;
 
-use Illuminate\Console\Command;
 use Illuminate\Database\Console\ShowModelCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand('module:model-show', 'Show information about an Eloquent model in modules')]
-class ModelShowCommand extends Command
+class ModelShowCommand extends ShowModelCommand
 {
-
-
     /**
      * The console command name.
      *


### PR DESCRIPTION
Hi,

In #1699, the class extension was modified, but it's not correct.

In the attached screenshot, the namespace is `Illuminate\Foundation\Console\ShowModelCommand`, but the correct namespace is `Illuminate\Database\Console\ShowModelCommand` and exist [file_url](https://github.com/laravel/framework/blob/88d6037dcda4f5696b85ce24ad11ff7e97fd14f0/src/Illuminate/Database/Console/ShowModelCommand.php
)


I believe his package has not been updated to the latest version, but the Laravel version has been updated.

This command is based on a Laravel command. The only change made is in the method `qualifyModel` to locate the Model from the modules folder. For more information, please refer to #1429.