### PR TITLE
[feat] delete except section

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -149,10 +149,7 @@ return [
     */
     'commands' => ConsoleServiceProvider::defaultCommands()
         ->merge([
-            //
-        ])
-        ->except([
-            //
+            // New commands go here
         ])->toArray(),
 
     /*


### PR DESCRIPTION
Hi,

In the last PR (#1720), a section except was added, but it is not functioning as intended. This is because it deletes keys. Based on @dcblogdev's suggestion, it is recommended to drop it.