### PR TITLE
Add command module prune

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "mockery/mockery": "^1.5",
     "orchestra/testbench": "^8.0",
     "friendsofphp/php-cs-fixer": "^3.6",
-    "laravel/framework": "^10.0",
+    "laravel/framework": "^10.41",
     "spatie/phpunit-snapshot-assertions": "^5.0",
     "phpstan/phpstan": "^1.4"
   },

--- a/src/Commands/ModelPruneCommand.php
+++ b/src/Commands/ModelPruneCommand.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Nwidart\Modules\Commands;
+
+use Illuminate\Contracts\Console\PromptsForMissingInput;
+use Illuminate\Database\Console\PruneCommand;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use Nwidart\Modules\Facades\Module;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Finder\Finder;
+use function Laravel\Prompts\multiselect;
+
+class ModelPruneCommand extends PruneCommand implements PromptsForMissingInput
+{
+    const ALL = 'All';
+
+    protected $name = 'module:prune';
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'module:prune {module*}
+                                {--all : Check all Modules}
+                                {--model=* : Class names of the models to be pruned}
+                                {--except=* : Class names of the models to be excluded from pruning}
+                                {--path=* : Absolute path(s) to directories where models are located}
+                                {--chunk=1000 : The number of models to retrieve per chunk of models to be deleted}
+                                {--pretend : Display the number of prunable records found instead of deleting them}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Prune models by module that are no longer needed';
+
+    protected function promptForMissingArguments(InputInterface $input, OutputInterface $output): void
+    {
+        if ($this->option('all')) {
+            $input->setArgument('module', [self::ALL]);
+            return;
+        }
+
+        $selected_item = multiselect(
+            label   : 'What Module want to check?',
+            options : [
+                self::ALL,
+                ...array_keys(Module::all()),
+            ],
+            required: 'You must select at least one module',
+        );
+
+        $input->setArgument('module',
+            value: in_array(self::ALL, $selected_item)
+                ? [self::ALL]
+                : $selected_item
+        );
+    }
+
+
+    /**
+     * Determine the models that should be pruned.
+     *
+     * @return Collection
+     */
+    protected function models(): Collection
+    {
+        if (! empty($models = $this->option('model'))) {
+            return collect($models)->filter(function ($model) {
+                return class_exists($model);
+            })->values();
+        }
+
+        $except = $this->option('except');
+
+        if (! empty($models) && ! empty($except)) {
+            throw new InvalidArgumentException('The --models and --except options cannot be combined.');
+        }
+
+        if ($this->argument('module') == [self::ALL]) {
+            $path = sprintf('%s/*/%s',
+                config('modules.paths.modules'),
+                config('modules.paths.generator.model.path')
+            );
+        }
+        else {
+            $path = sprintf('%s/{%s}/%s',
+                config('modules.paths.modules'),
+                collect($this->argument('module'))->implode(','),
+                config('modules.paths.generator.model.path'));
+        }
+
+        return collect(Finder::create()->in($path)->files()->name('*.php'))
+            ->map(function ($model) {
+
+                $namespace = config('modules.namespace');
+                return $namespace . str_replace(
+                        ['/', '.php'],
+                        ['\\', ''],
+                        Str::after($model->getRealPath(), realpath(config('modules.paths.modules')))
+                    );
+            })->values()
+            ->when(! empty($except), function ($models) use ($except) {
+                return $models->reject(function ($model) use ($except) {
+                    return in_array($model, $except);
+                });
+            })->filter(function ($model) {
+                return class_exists($model);
+            })->filter(function ($model) {
+                return $this->isPrunable($model);
+            })->values();
+    }
+
+}

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Nwidart\Modules\Providers;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
 use Nwidart\Modules\Commands;
 
@@ -20,9 +21,9 @@ class ConsoleServiceProvider extends ServiceProvider
     /**
      * Get the package default commands.
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
-    public static function defaultCommands(): \Illuminate\Support\Collection
+    public static function defaultCommands(): Collection
     {
         return collect([
             Commands\ChannelMakeCommand::class,
@@ -51,6 +52,7 @@ class ConsoleServiceProvider extends ServiceProvider
             Commands\MigrateStatusCommand::class,
             Commands\MigrationMakeCommand::class,
             Commands\ModelMakeCommand::class,
+            Commands\ModelPruneCommand::class,
             Commands\ModelShowCommand::class,
             Commands\ModuleDeleteCommand::class,
             Commands\ModuleMakeCommand::class,


### PR DESCRIPTION
Hi,

In this PR, a new command `module:prune` is added to this package. This command extends from the base `module:prune` and only modifies the method `models` to find Prunable models from modules. Additionally, some arguments are added to the command.

The usage of this command is as follows:

1. When calling the command without arguments, it shows a multiselect prompt in Laravel, allowing you to choose which module to check. You can also choose the 'All' option to check all modules.
   ```sh
   php artisan module:prune
   ```
   ![Screenshot](https://github.com/nWidart/laravel-modules/assets/26966142/413ae838-5306-49ac-916c-65742efe3c0a)

2. To check all modules, use the `--all` option when running the command.
   ```sh
   php artisan module:prune --all
   ```

3. Pass the module name as an argument:
   ```sh
   php artisan module:prune Base Cloud
   ```

Additionally, the Laravel/framework version is updated in this PR.

If you need further clarification or have any questions, please let me know. 