### PR TITLE
Implement base command

### DIFF
--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -62,7 +62,7 @@ abstract class BaseCommand extends Command implements PromptsForMissingInput
 
     protected function promptForMissingArguments(InputInterface $input, OutputInterface $output): void
     {
-        $modules = array_keys(Module::all());
+        $modules = array_keys($this->laravel['modules']->all());
 
         if ($input->getOption(strtolower(self::ALL))) {
             $input->setArgument('module', $modules);

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Nwidart\Modules\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\PromptsForMissingInput;
+use Nwidart\Modules\Facades\Module;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use function Laravel\Prompts\multiselect;
+
+abstract class BaseCommand extends Command implements PromptsForMissingInput
+{
+    const ALL = 'All';
+
+    /**
+     * Create a new console command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->getDefinition()->addOption(new InputOption(
+            'all',
+            'a',
+            InputOption::VALUE_NONE,
+            'Check all Modules',
+        ));
+
+        $this->getDefinition()->addArgument(new InputArgument(
+            'module',
+            InputArgument::IS_ARRAY,
+            'The name of module will be used.',
+        ));
+    }
+
+    abstract function executeAction($name);
+
+    public function getInfo(): string|null
+    {
+        return NULL;
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        if (! is_null($info = $this->getInfo())) {
+            $this->components->info($info);
+        }
+
+        $modules = (array) $this->argument('module');
+
+        foreach ($modules as $module) {
+            $this->executeAction($module);
+        }
+    }
+
+    protected function promptForMissingArguments(InputInterface $input, OutputInterface $output): void
+    {
+        $modules = array_keys(Module::all());
+
+        if ($input->getOption('all')) {
+            $input->setArgument('module', $modules);
+            return;
+        }
+
+        if (! empty($input->getArgument('module'))) {
+            return;
+        }
+
+        $selected_item = multiselect(
+            label   : 'What Module want to check?',
+            options : [
+                self::ALL,
+                ...$modules,
+            ],
+            required: 'You must select at least one module',
+        );
+
+        $input->setArgument('module',
+            value: in_array(self::ALL, $selected_item)
+                ? $modules
+                : $selected_item
+        );
+    }
+
+    protected function getModuleModel($name)
+    {
+        return $name instanceof \Nwidart\Modules\Module
+            ? $name
+            : $this->laravel['modules']->findOrFail($name);
+    }
+
+}

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -24,7 +24,7 @@ abstract class BaseCommand extends Command implements PromptsForMissingInput
     {
         parent::__construct();
         $this->getDefinition()->addOption(new InputOption(
-            'all',
+            strtolower(self::ALL),
             'a',
             InputOption::VALUE_NONE,
             'Check all Modules',
@@ -64,7 +64,7 @@ abstract class BaseCommand extends Command implements PromptsForMissingInput
     {
         $modules = array_keys(Module::all());
 
-        if ($input->getOption('all')) {
+        if ($input->getOption(strtolower(self::ALL))) {
             $input->setArgument('module', $modules);
             return;
         }

--- a/src/Commands/CheckLangCommand.php
+++ b/src/Commands/CheckLangCommand.php
@@ -2,11 +2,9 @@
 
 namespace Nwidart\Modules\Commands;
 
-use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
-use Symfony\Component\Console\Input\InputArgument;
 
-class CheckLangCommand extends Command
+class CheckLangCommand extends baseCommand
 {
 
     private $langPath;
@@ -25,58 +23,16 @@ class CheckLangCommand extends Command
      */
     protected $description = 'Check missing language keys in the specified module.';
 
-
-    /**
-     * Execute the console command.
-     */
-    public function handle(): int
+    public function __construct()
     {
+        parent::__construct();
 
         $this->langPath = DIRECTORY_SEPARATOR . config('modules.paths.generator.lang.path', 'Resources/lang');
-
-        $this->components->alert('Checking languages ...');
-
-        $this->newLine();
-
-        if ($name = $this->argument('module')) {
-            $this->check($name);
-
-            return 0;
-        }
-
-        $this->checkAll();
-
-        return 0;
-
     }
 
-    /**
-     * enableAll
-     *
-     * @return void
-     */
-    public function checkAll()
+    public function executeAction($name): void
     {
-        $modules = $this->laravel['modules']->all();
-
-        foreach ($modules as $module) {
-            $this->check($module);
-        }
-    }
-
-    /**
-     * enable
-     *
-     * @param string $name
-     * @return void
-     */
-    public function check($name)
-    {
-        if ($name instanceof Module) {
-            $module = $name;
-        } else {
-            $module = $this->laravel['modules']->findOrFail($name);
-        }
+        $module = $this->getModuleModel($name);
 
         $directories = $this->getDirectories($module);
 
@@ -90,16 +46,9 @@ class CheckLangCommand extends Command
 
     }
 
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
-    protected function getArguments()
+    function getInfo(): string|null
     {
-        return [
-            ['module', InputArgument::OPTIONAL, 'Module name.'],
-        ];
+        return 'Checking languages ...';
     }
 
     private function getLangFiles($module)
@@ -133,12 +82,12 @@ class CheckLangCommand extends Command
 
         if (count($directories) == 0) {
             $this->components->info("No language files found in module $moduleName");
-            return false;
+            return FALSE;
         }
 
         if (count($directories) == 1) {
             $this->components->warn("Only one language file found in module $moduleName");
-            return false;
+            return FALSE;
         }
 
         return collect($directories);
@@ -194,7 +143,7 @@ class CheckLangCommand extends Command
             $uniqeLangFiles->each(function ($file) use ($directory, $langDirectories, &$missingKeysMessage) {
                 $langKeys = $this->getLangKeys($directory['path'] . DIRECTORY_SEPARATOR . $file);
 
-                if ($langKeys == false) {
+                if ($langKeys == FALSE) {
                     return;
                 }
 
@@ -206,7 +155,7 @@ class CheckLangCommand extends Command
 
                         $otherLangKeys = $this->getLangKeys($basePath . DIRECTORY_SEPARATOR . $file);
 
-                        if ($otherLangKeys == false) {
+                        if ($otherLangKeys == FALSE) {
                             return;
                         }
 
@@ -244,8 +193,9 @@ class CheckLangCommand extends Command
         if (\File::exists($file)) {
             $lang = \File::getRequire($file);
             return collect(\Arr::dot($lang))->keys();
-        } else {
-            return false;
+        }
+        else {
+            return FALSE;
         }
     }
 }

--- a/src/Commands/CheckLangCommand.php
+++ b/src/Commands/CheckLangCommand.php
@@ -4,7 +4,7 @@ namespace Nwidart\Modules\Commands;
 
 use Illuminate\Support\Collection;
 
-class CheckLangCommand extends baseCommand
+class CheckLangCommand extends BaseCommand
 {
 
     private $langPath;

--- a/src/Commands/DisableCommand.php
+++ b/src/Commands/DisableCommand.php
@@ -2,11 +2,7 @@
 
 namespace Nwidart\Modules\Commands;
 
-use Illuminate\Console\Command;
-use Nwidart\Modules\Module;
-use Symfony\Component\Console\Input\InputArgument;
-
-class DisableCommand extends Command
+class DisableCommand extends BaseCommand
 {
     /**
      * The console command name.
@@ -29,73 +25,21 @@ class DisableCommand extends Command
      */
     protected $description = 'Disable an array of modules.';
 
-    /**
-     * Execute the console command.
-     */
-    public function handle(): int
+    public function executeAction($name): void
     {
-        $this->components->info('Disabling module ...');
-        
-        if (count($this->argument('module'))) {
-            foreach($this->argument('module') as $name) {
-                $this->disable($name);
-            }
-            return 0;
-        }
+        $module = $this->getModuleModel($name);
 
-        $this->disableAll();
+        $status = $module->isDisabled()
+            ? '<fg=red;options=bold>Disabled</>'
+            : '<fg=green;options=bold>Enabled</>';
 
-        return 0;
-    }
-
-    /**
-     * disableAll
-     *
-     * @return void
-     */
-    public function disableAll()
-    {
-        /** @var Modules $modules */
-        $modules = $this->laravel['modules']->all();
-
-        foreach ($modules as $module) {
-            $this->disable($module);
-        }
-    }
-
-    /**
-     * disable
-     *
-     * @param string $name
-     * @return void
-     */
-    public function disable($name)
-    {
-        if ($name instanceof Module) {
-            $module = $name;
-        }else {
-            $module = $this->laravel['modules']->findOrFail($name);
-        }
-
-        if ($module->isEnabled()) {
+        $this->components->task("Disabling <fg=cyan;options=bold>{$module->getName()}</> Module, old status: $status", function () use ($module) {
             $module->disable();
-
-            $this->components->info("Module [{$module}] disabled successful.");
-        } else {
-            $this->components->warn("Module [{$module}] has already disabled.");
-        }
-
+        });
     }
 
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
-    protected function getArguments()
+    function getInfo(): string|null
     {
-        return [
-            ['module', InputArgument::OPTIONAL, 'Module name.'],
-        ];
+        return 'Disabling module ...';
     }
 }

--- a/src/Commands/DisableCommand.php
+++ b/src/Commands/DisableCommand.php
@@ -16,7 +16,7 @@ class DisableCommand extends BaseCommand
      *
      * @var string
      */
-    protected $signature = 'module:disable {module?*}';
+    protected $signature = 'module:disable';
 
     /**
      * The console command description.

--- a/src/Commands/DumpCommand.php
+++ b/src/Commands/DumpCommand.php
@@ -2,11 +2,7 @@
 
 namespace Nwidart\Modules\Commands;
 
-use Illuminate\Console\Command;
-use Nwidart\Modules\Module;
-use Symfony\Component\Console\Input\InputArgument;
-
-class DumpCommand extends Command
+class DumpCommand extends BaseCommand
 {
     /**
      * The console command name.
@@ -22,64 +18,19 @@ class DumpCommand extends Command
      */
     protected $description = 'Dump-autoload the specified module or for all module.';
 
-    /**
-     * Execute the console command.
-     */
-    public function handle(): int
+    public function executeAction($name): void
     {
-        $this->components->info('Generating optimized autoload modules.');
+        $module = $this->getModuleModel($name);
 
-        if ($name = $this->argument('module') ) {
-            $this->dump($name);
-
-            return 0;
-        }
-
-        $this->dumpAll();
-
-        return 0;
-    }
-
-    /**
-     * dumpAll
-     *
-     * @return void
-     */
-    public function dumpAll()
-    {
-        /** @var Modules $modules */
-        $modules = $this->laravel['modules']->all();
-
-        foreach ($modules as $module) {
-            $this->dump($module);
-        }
-    }
-
-    public function dump($name)
-    {
-        if ($name instanceof Module) {
-            $module = $name;
-        } else {
-            $module = $this->laravel['modules']->findOrFail($name);
-        }
-
-        $this->components->task("$module", function () use ($module) {
+        $this->components->task("Generating for <fg=cyan;options=bold>{$module->getName()}</> Module", function () use ($module) {
             chdir($module->getPath());
 
             passthru('composer dump -o -n -q');
         });
-
     }
 
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
-    protected function getArguments()
+    function getInfo(): string|null
     {
-        return [
-            ['module', InputArgument::OPTIONAL, 'Module name.'],
-        ];
+        return 'Generating optimized autoload modules';
     }
 }

--- a/src/Commands/EnableCommand.php
+++ b/src/Commands/EnableCommand.php
@@ -2,11 +2,7 @@
 
 namespace Nwidart\Modules\Commands;
 
-use Illuminate\Console\Command;
-use Nwidart\Modules\Module;
-use Symfony\Component\Console\Input\InputArgument;
-
-class EnableCommand extends Command
+class EnableCommand extends BaseCommand
 {
     /**
      * The console command name.
@@ -22,73 +18,21 @@ class EnableCommand extends Command
      */
     protected $description = 'Enable the specified module.';
 
-    /**
-     * Execute the console command.
-     */
-    public function handle(): int
+    public function executeAction($name): void
     {
+        $module = $this->getModuleModel($name);
 
-        $this->components->info('Enabling module ...');
+        $status = $module->isDisabled()
+            ? '<fg=red;options=bold>Disabled</>'
+            : '<fg=green;options=bold>Enabled</>';
 
-        if ($name = $this->argument('module') ) {
-            $this->enable($name);
-
-            return 0;
-        }
-
-        $this->enableAll();
-
-        return 0;
-    }
-
-    /**
-     * enableAll
-     *
-     * @return void
-     */
-    public function enableAll()
-    {
-        /** @var Modules $modules */
-        $modules = $this->laravel['modules']->all();
-
-        foreach ($modules as $module) {
-            $this->enable($module);
-        }
-    }
-
-    /**
-     * enable
-     *
-     * @param string $name
-     * @return void
-     */
-    public function enable($name)
-    {
-        if ($name instanceof Module) {
-            $module = $name;
-        }else {
-            $module = $this->laravel['modules']->findOrFail($name);
-        }
-
-        if ($module->isDisabled()) {
+        $this->components->task("Enabling <fg=cyan;options=bold>{$module->getName()}</> Module, old status: $status", function () use ($module) {
             $module->enable();
-
-            $this->components->info("Module [{$module}] enabled successful.");
-        }else {
-            $this->components->warn("Module [{$module}] has already enabled.");
-        }
-
+        });
     }
 
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
-    protected function getArguments()
+    function getInfo(): string|null
     {
-        return [
-            ['module', InputArgument::OPTIONAL, 'Module name.'],
-        ];
+        return 'Disabling module ...';
     }
 }

--- a/src/Commands/EnableCommand.php
+++ b/src/Commands/EnableCommand.php
@@ -2,11 +2,7 @@
 
 namespace Nwidart\Modules\Commands;
 
-use Illuminate\Console\Command;
-use Nwidart\Modules\Module;
-use Symfony\Component\Console\Input\InputArgument;
-
-class EnableCommand extends Command
+class EnableCommand extends BaseCommand
 {
     /**
      * The console command name.
@@ -22,73 +18,21 @@ class EnableCommand extends Command
      */
     protected $description = 'Enable the specified module.';
 
-    /**
-     * Execute the console command.
-     */
-    public function handle(): int
+    public function executeAction($name): void
     {
+        $module = $this->getModuleModel($name);
 
-        $this->components->info('Enabling module ...');
+        $status = $module->isDisabled()
+            ? '<fg=red;options=bold>Disabled</>'
+            : '<fg=green;options=bold>Enabled</>';
 
-        if ($name = $this->argument('module') ) {
-            $this->enable($name);
-
-            return 0;
-        }
-
-        $this->enableAll();
-
-        return 0;
-    }
-
-    /**
-     * enableAll
-     *
-     * @return void
-     */
-    public function enableAll()
-    {
-        /** @var Modules $modules */
-        $modules = $this->laravel['modules']->all();
-
-        foreach ($modules as $module) {
-            $this->enable($module);
-        }
-    }
-
-    /**
-     * enable
-     *
-     * @param string $name
-     * @return void
-     */
-    public function enable($name)
-    {
-        if ($name instanceof Module) {
-            $module = $name;
-        }else {
-            $module = $this->laravel['modules']->findOrFail($name);
-        }
-
-        if ($module->isDisabled()) {
+        $this->components->task("Enabling <fg=cyan;options=bold>{$module->getName()}</> Module, old status: $status", function () use ($module) {
             $module->enable();
-
-            $this->components->info("Module [{$module}] enabled successful.");
-        }else {
-            $this->components->warn("Module [{$module}] has already enabled.");
-        }
-
+        });
     }
 
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
-    protected function getArguments()
+    function getInfo(): string|null
     {
-        return [
-            ['module', InputArgument::OPTIONAL, 'Module name.'],
-        ];
+        return 'Enabling module ...';
     }
 }

--- a/src/Commands/MigrateResetCommand.php
+++ b/src/Commands/MigrateResetCommand.php
@@ -2,13 +2,11 @@
 
 namespace Nwidart\Modules\Commands;
 
-use Illuminate\Console\Command;
 use Nwidart\Modules\Migrations\Migrator;
 use Nwidart\Modules\Traits\MigrationLoaderTrait;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
-class MigrateResetCommand extends Command
+class MigrateResetCommand extends BaseCommand
 {
     use MigrationLoaderTrait;
 
@@ -26,51 +24,15 @@ class MigrateResetCommand extends Command
      */
     protected $description = 'Reset the modules migrations.';
 
-    /**
-     * @var \Nwidart\Modules\Contracts\RepositoryInterface
-     */
-    protected $module;
-
-    /**
-     * Execute the console command.
-     */
-    public function handle(): int
+    public function executeAction($name): void
     {
-        $this->module = $this->laravel['modules'];
-
-        $name = $this->argument('module');
-
-        if (!empty($name)) {
-            $this->reset($name);
-
-            return 0;
-        }
-
-        foreach ($this->module->getOrdered($this->option('direction')) as $module) {
-            $this->line('Running for module: <info>' . $module->getName() . '</info>');
-
-            $this->reset($module);
-        }
-
-        return 0;
-    }
-
-    /**
-     * Rollback migration from the specified module.
-     *
-     * @param $module
-     */
-    public function reset($module)
-    {
-        if (is_string($module)) {
-            $module = $this->module->findOrFail($module);
-        }
+        $module = $this->getModuleModel($name);
 
         $migrator = new Migrator($module, $this->getLaravel());
 
         $database = $this->option('database');
 
-        if (!empty($database)) {
+        if (! empty($database)) {
             $migrator->setDatabase($database);
         }
 
@@ -84,19 +46,12 @@ class MigrateResetCommand extends Command
             return;
         }
 
-        $this->comment('Nothing to rollback.');
+        $this->components->warn("Nothing to rollback on module {$module->getName()}");
     }
 
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
-    protected function getArguments()
+    public function getInfo(): string|null
     {
-        return [
-            ['module', InputArgument::OPTIONAL, 'The name of module will be used.'],
-        ];
+        return NULL;
     }
 
     /**
@@ -108,9 +63,9 @@ class MigrateResetCommand extends Command
     {
         return [
             ['direction', 'd', InputOption::VALUE_OPTIONAL, 'The direction of ordering.', 'desc'],
-            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
-            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
-            ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
+            ['database', NULL, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
+            ['force', NULL, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
+            ['pretend', NULL, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
         ];
     }
 }

--- a/src/Commands/MigrateResetCommand.php
+++ b/src/Commands/MigrateResetCommand.php
@@ -46,7 +46,7 @@ class MigrateResetCommand extends BaseCommand
             return;
         }
 
-        $this->components->warn("Nothing to rollback on module {$module->getName()}");
+        $this->components->warn("Nothing to rollback on module <fg=cyan;options=bold>{$module->getName()}</>");
     }
 
     public function getInfo(): string|null

--- a/src/Commands/MigrateRollbackCommand.php
+++ b/src/Commands/MigrateRollbackCommand.php
@@ -46,7 +46,7 @@ class MigrateRollbackCommand extends BaseCommand
             return;
         }
 
-        $this->components->warn("Nothing to rollback on module {$module->getName()}");
+        $this->components->warn("Nothing to rollback on module <fg=cyan;options=bold>{$module->getName()}</>");
 
     }
 

--- a/src/Commands/MigrateRollbackCommand.php
+++ b/src/Commands/MigrateRollbackCommand.php
@@ -2,7 +2,6 @@
 
 namespace Nwidart\Modules\Commands;
 
-use Illuminate\Console\Command;
 use Nwidart\Modules\Migrations\Migrator;
 use Nwidart\Modules\Traits\MigrationLoaderTrait;
 use Symfony\Component\Console\Input\InputOption;
@@ -41,7 +40,7 @@ class MigrateRollbackCommand extends BaseCommand
 
         if (count($migrated)) {
             foreach ($migrated as $migration) {
-                $this->components->task("Rollback: <info>{$migration}</info>", );
+                $this->components->task("Rollback: <info>{$migration}</info>",);
             }
 
             return;

--- a/src/Commands/MigrateStatusCommand.php
+++ b/src/Commands/MigrateStatusCommand.php
@@ -2,13 +2,10 @@
 
 namespace Nwidart\Modules\Commands;
 
-use Illuminate\Console\Command;
 use Nwidart\Modules\Migrations\Migrator;
-use Nwidart\Modules\Module;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
-class MigrateStatusCommand extends Command
+class MigrateStatusCommand extends BaseCommand
 {
     /**
      * The console command name.
@@ -29,58 +26,21 @@ class MigrateStatusCommand extends Command
      */
     protected $module;
 
-    /**
-     * Execute the console command.
-     *
-     * @return mixed
-     */
-    public function handle(): int
+    public function executeAction($name): void
     {
-        $this->module = $this->laravel['modules'];
+        $module = $this->getModuleModel($name);
 
-        $name = $this->argument('module');
-
-        if ($name) {
-            $module = $this->module->findOrFail($name);
-
-            $this->migrateStatus($module);
-
-            return 0;
-        }
-
-        foreach ($this->module->getOrdered($this->option('direction')) as $module) {
-            $this->line('Running for module: <info>' . $module->getName() . '</info>');
-            $this->migrateStatus($module);
-        }
-
-        return 0;
-    }
-
-    /**
-     * Run the migration from the specified module.
-     *
-     * @param Module $module
-     */
-    protected function migrateStatus(Module $module)
-    {
         $path = str_replace(base_path(), '', (new Migrator($module, $this->getLaravel()))->getPath());
 
         $this->call('migrate:status', [
-            '--path' => $path,
+            '--path'     => $path,
             '--database' => $this->option('database'),
         ]);
     }
 
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
-    protected function getArguments()
+    public function getInfo(): string|null
     {
-        return [
-            ['module', InputArgument::OPTIONAL, 'The name of module will be used.'],
-        ];
+        return NULL;
     }
 
     /**
@@ -92,7 +52,7 @@ class MigrateStatusCommand extends Command
     {
         return [
             ['direction', 'd', InputOption::VALUE_OPTIONAL, 'The direction of ordering.', 'asc'],
-            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
+            ['database', NULL, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
         ];
     }
 }

--- a/src/Commands/ModuleDeleteCommand.php
+++ b/src/Commands/ModuleDeleteCommand.php
@@ -2,27 +2,22 @@
 
 namespace Nwidart\Modules\Commands;
 
-use Illuminate\Console\Command;
-use Symfony\Component\Console\Input\InputArgument;
-
-class ModuleDeleteCommand extends Command
+class ModuleDeleteCommand extends BaseCommand
 {
-    protected $name = 'module:delete';
+    protected $name        = 'module:delete';
     protected $description = 'Delete a module from the application';
 
-    public function handle(): int
+    public function executeAction($name): void
     {
-        $this->laravel['modules']->delete($this->argument('module'));
-
-        $this->components->info("Module {$this->argument('module')} has been deleted.");
-
-        return 0;
+        $module = $this->getModuleModel($name);
+        $this->components->task("Deleting <fg=cyan;options=bold>{$module->getName()}</> Module", function () use ($module) {
+            $module->delete();
+        });
     }
 
-    protected function getArguments()
+    public function getInfo(): string|null
     {
-        return [
-            ['module', InputArgument::REQUIRED, 'The name of module to delete.'],
-        ];
+        return 'deleting module ...';
     }
+
 }

--- a/src/Commands/PublishCommand.php
+++ b/src/Commands/PublishCommand.php
@@ -2,12 +2,9 @@
 
 namespace Nwidart\Modules\Commands;
 
-use Illuminate\Console\Command;
-use Nwidart\Modules\Module;
 use Nwidart\Modules\Publishing\AssetPublisher;
-use Symfony\Component\Console\Input\InputArgument;
 
-class PublishCommand extends Command
+class PublishCommand extends BaseCommand
 {
     /**
      * The console command name.
@@ -23,64 +20,23 @@ class PublishCommand extends Command
      */
     protected $description = 'Publish a module\'s assets to the application';
 
-    /**
-     * Execute the console command.
-     */
-    public function handle(): int
+
+    public function executeAction($name): void
     {
-        $this->components->info('Publishing module assets...');
+        $module = $this->getModuleModel($name);
 
-        if ($name = $this->argument('module')) {
-            $this->publish($name);
+        $this->components->task("Publishing Assets <fg=cyan;options=bold>{$module->getName()}</> Module", function () use ($module) {
+            with(new AssetPublisher($module))
+                ->setRepository($this->laravel['modules'])
+                ->setConsole($this)
+                ->publish();
+        });
 
-            return 0;
-        }
-
-        $this->publishAll();
-
-        return 0;
     }
 
-    /**
-     * Publish assets from all modules.
-     */
-    public function publishAll()
+    function getInfo(): string|null
     {
-        foreach ($this->laravel['modules']->allEnabled() as $module) {
-            $this->publish($module);
-        }
+        return 'Publishing module asset files ...';
     }
 
-    /**
-     * Publish assets from the specified module.
-     *
-     * @param string $name
-     */
-    public function publish($name)
-    {
-        if ($name instanceof Module) {
-            $module = $name;
-        } else {
-            $module = $this->laravel['modules']->findOrFail($name);
-        }
-
-        with(new AssetPublisher($module))
-            ->setRepository($this->laravel['modules'])
-            ->setConsole($this)
-            ->publish();
-
-        $this->components->task($module->getStudlyName(), fn()=>true);
-    }
-
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
-    protected function getArguments()
-    {
-        return [
-            ['module', InputArgument::OPTIONAL, 'The name of module will be used.'],
-        ];
-    }
 }

--- a/src/Commands/PublishConfigurationCommand.php
+++ b/src/Commands/PublishConfigurationCommand.php
@@ -2,12 +2,10 @@
 
 namespace Nwidart\Modules\Commands;
 
-use Illuminate\Console\Command;
 use Illuminate\Support\Str;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
-class PublishConfigurationCommand extends Command
+class PublishConfigurationCommand extends BaseCommand
 {
     /**
      * The console command name.
@@ -23,68 +21,38 @@ class PublishConfigurationCommand extends Command
      */
     protected $description = 'Publish a module\'s config files to the application';
 
-    /**
-     * Execute the console command.
-     */
-    public function handle(): int
+    public function executeAction($name): void
     {
-        $this->components->info('publishing module config files...');
+        $this->call('vendor:publish', [
+            '--provider' => $this->getServiceProviderForModule($name),
+            '--force'    => $this->option('force'),
+            '--tag'      => ['config'],
+        ]);
+    }
 
-        if ($module = $this->argument('module')) {
-            $this->publishConfiguration($module);
-
-            return 0;
-        }
-
-        foreach ($this->laravel['modules']->allEnabled() as $module) {
-            $this->publishConfiguration($module->getName());
-        }
-
-        return 0;
+    function getInfo(): string|null
+    {
+        return 'Publishing module config files ...';
     }
 
     /**
      * @param string $module
      * @return string
      */
-    private function getServiceProviderForModule($module)
+    private function getServiceProviderForModule($module): string
     {
-        $namespace = $this->laravel['config']->get('modules.namespace');
+        $namespace  = $this->laravel['config']->get('modules.namespace');
         $studlyName = Str::studly($module);
-        $provider = $this->laravel['config']->get('modules.paths.generator.provider.path');
-        $provider = str_replace('/', '\\', $provider);
+        $provider   = $this->laravel['config']->get('modules.paths.generator.provider.path');
+        $provider   = str_replace('/', '\\', $provider);
 
         return "$namespace\\$studlyName\\$provider\\{$studlyName}ServiceProvider";
     }
 
     /**
-     * @param string $module
-     */
-    private function publishConfiguration($module)
-    {
-        $this->call('vendor:publish', [
-            '--provider' => $this->getServiceProviderForModule($module),
-            '--force' => $this->option('force'),
-            '--tag' => ['config'],
-        ]);
-    }
-
-    /**
-     * Get the console command arguments.
-     *
      * @return array
      */
-    protected function getArguments()
-    {
-        return [
-            ['module', InputArgument::OPTIONAL, 'The name of module being used.'],
-        ];
-    }
-
-    /**
-     * @return array
-     */
-    protected function getOptions()
+    protected function getOptions(): array
     {
         return [
             ['--force', '-f', InputOption::VALUE_NONE, 'Force the publishing of config files'],

--- a/src/Commands/PublishMigrationCommand.php
+++ b/src/Commands/PublishMigrationCommand.php
@@ -5,9 +5,8 @@ namespace Nwidart\Modules\Commands;
 use Illuminate\Console\Command;
 use Nwidart\Modules\Migrations\Migrator;
 use Nwidart\Modules\Publishing\MigrationPublisher;
-use Symfony\Component\Console\Input\InputArgument;
 
-class PublishMigrationCommand extends Command
+class PublishMigrationCommand extends BaseCommand
 {
     /**
      * The console command name.
@@ -23,50 +22,20 @@ class PublishMigrationCommand extends Command
      */
     protected $description = "Publish a module's migrations to the application";
 
-    /**
-     * Execute the console command.
-     */
-    public function handle(): int
+    public function executeAction($name): void
     {
-        $this->components->info('publishing module migrations...');
+        $module = $this->getModuleModel($name);
 
-        if ($name = $this->argument('module')) {
-            $module = $this->laravel['modules']->findOrFail($name);
-
-            $this->publish($module);
-
-            return 0;
-        }
-
-        foreach ($this->laravel['modules']->allEnabled() as $module) {
-            $this->publish($module);
-        }
-
-        return 0;
+        $this->components->task("Publishing Migration <fg=cyan;options=bold>{$module->getName()}</> Module", function () use ($module) {
+            with(new MigrationPublisher(new Migrator($module, $this->getLaravel())))
+                ->setRepository($this->laravel['modules'])
+                ->setConsole($this)
+                ->publish();
+        });
     }
 
-    /**
-     * Publish migration for the specified module.
-     *
-     * @param \Nwidart\Modules\Module $module
-     */
-    public function publish($module)
+    function getInfo(): string|null
     {
-        with(new MigrationPublisher(new Migrator($module, $this->getLaravel())))
-            ->setRepository($this->laravel['modules'])
-            ->setConsole($this)
-            ->publish();
-    }
-
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
-    protected function getArguments()
-    {
-        return [
-            ['module', InputArgument::OPTIONAL, 'The name of module being used.'],
-        ];
+        return 'Publishing module migrations ...';
     }
 }

--- a/src/Commands/PublishTranslationCommand.php
+++ b/src/Commands/PublishTranslationCommand.php
@@ -2,12 +2,9 @@
 
 namespace Nwidart\Modules\Commands;
 
-use Illuminate\Console\Command;
-use Nwidart\Modules\Module;
 use Nwidart\Modules\Publishing\LangPublisher;
-use Symfony\Component\Console\Input\InputArgument;
 
-class PublishTranslationCommand extends Command
+class PublishTranslationCommand extends BaseCommand
 {
     /**
      * The console command name.
@@ -23,64 +20,20 @@ class PublishTranslationCommand extends Command
      */
     protected $description = 'Publish a module\'s translations to the application';
 
-    /**
-     * Execute the console command.
-     */
-    public function handle(): int
+    public function executeAction($name): void
     {
-        $this->components->info('Publishing module translations...');
+        $module = $this->getModuleModel($name);
 
-        if ($name = $this->argument('module')) {
-            $this->publish($name);
-
-            return 0;
-        }
-
-        $this->publishAll();
-
-        return 0;
+        $this->components->task("Publishing Translations <fg=cyan;options=bold>{$module->getName()}</> Module", function () use ($module) {
+            with(new LangPublisher($module))
+                ->setRepository($this->laravel['modules'])
+                ->setConsole($this)
+                ->publish();
+        });
     }
 
-    /**
-     * Publish assets from all modules.
-     */
-    public function publishAll()
+    function getInfo(): string|null
     {
-        foreach ($this->laravel['modules']->allEnabled() as $module) {
-            $this->publish($module);
-        }
-    }
-
-    /**
-     * Publish assets from the specified module.
-     *
-     * @param string $name
-     */
-    public function publish($name)
-    {
-        if ($name instanceof Module) {
-            $module = $name;
-        } else {
-            $module = $this->laravel['modules']->findOrFail($name);
-        }
-
-        with(new LangPublisher($module))
-            ->setRepository($this->laravel['modules'])
-            ->setConsole($this)
-            ->publish();
-
-        $this->line("<info>Published</info>: {$module->getStudlyName()}");
-    }
-
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
-    protected function getArguments()
-    {
-        return [
-            ['module', InputArgument::OPTIONAL, 'The name of module will be used.'],
-        ];
+        return 'Publishing module translations ...';
     }
 }

--- a/src/Commands/UnUseCommand.php
+++ b/src/Commands/UnUseCommand.php
@@ -4,7 +4,7 @@ namespace Nwidart\Modules\Commands;
 
 use Illuminate\Console\Command;
 
-class UnUseCommand extends Command
+class UnUseCommand extends BaseCommand
 {
     /**
      * The console command name.
@@ -20,15 +20,17 @@ class UnUseCommand extends Command
      */
     protected $description = 'Forget the used module with module:use';
 
-    /**
-     * Execute the console command.
-     */
-    public function handle(): int
+    public function executeAction($name): void
     {
-        $this->laravel['modules']->forgetUsed();
+        $module = $this->getModuleModel($name);
 
-        $this->components->info('Previous module used successfully forgotten.');
+        $this->components->task("Forget Using {$module->getName()} module", function () use ($module) {
+            $this->laravel['modules']->forgetUsed($module);
+        });
+    }
 
-        return 0;
+    function getInfo(): string|null
+    {
+        return 'Forget Using Module ...';
     }
 }

--- a/src/Commands/UnUseCommand.php
+++ b/src/Commands/UnUseCommand.php
@@ -24,7 +24,7 @@ class UnUseCommand extends BaseCommand
     {
         $module = $this->getModuleModel($name);
 
-        $this->components->task("Forget Using {$module->getName()} module", function () use ($module) {
+        $this->components->task("Forget Using <fg=cyan;options=bold>{$module->getName()}</> Module", function () use ($module) {
             $this->laravel['modules']->forgetUsed($module);
         });
     }

--- a/src/Commands/UpdateCommand.php
+++ b/src/Commands/UpdateCommand.php
@@ -2,15 +2,8 @@
 
 namespace Nwidart\Modules\Commands;
 
-use Illuminate\Console\Command;
-use Nwidart\Modules\Module;
-use Nwidart\Modules\Traits\ModuleCommandTrait;
-use Symfony\Component\Console\Input\InputArgument;
-
-class UpdateCommand extends Command
+class UpdateCommand extends BaseCommand
 {
-    use ModuleCommandTrait;
-
     /**
      * The console command name.
      *
@@ -25,61 +18,17 @@ class UpdateCommand extends Command
      */
     protected $description = 'Update dependencies for the specified module or for all modules.';
 
-    /**
-     * Execute the console command.
-     */
-    public function handle(): int
+    public function executeAction($name): void
     {
-        $this->components->info('Updating module ...');
-
-        if ($name = $this->argument('module')) {
-            $this->updateModule($name);
-
-            return 0;
-        }
-
-        $this->updateAllModule();
-
-        return 0;
-    }
-
-
-    protected function updateAllModule()
-    {
-        /** @var \Nwidart\Modules\Module $module */
-        $modules = $this->laravel['modules']->getOrdered();
-
-        foreach ($modules as $module) {
-            $this->updateModule($module);
-        }
-
-    }
-
-    protected function updateModule($name)
-    {
-
-        if ($name instanceof Module) {
-            $module = $name;
-        }else {
-            $module = $this->laravel['modules']->findOrFail($name);
-        }
+        $module = $this->getModuleModel($name);
 
         $this->components->task("Updating {$module->getName()} module", function () use ($module) {
             $this->laravel['modules']->update($module);
         });
-        $this->laravel['modules']->update($name);
-
     }
 
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
-    protected function getArguments()
+    function getInfo(): string|null
     {
-        return [
-            ['module', InputArgument::OPTIONAL, 'The name of module will be updated.'],
-        ];
+        return 'Updating Module ...';
     }
 }

--- a/src/Commands/UpdateCommand.php
+++ b/src/Commands/UpdateCommand.php
@@ -22,7 +22,7 @@ class UpdateCommand extends BaseCommand
     {
         $module = $this->getModuleModel($name);
 
-        $this->components->task("Updating {$module->getName()} module", function () use ($module) {
+        $this->components->task("Updating <fg=cyan;options=bold>{$module->getName()}</> Module", function () use ($module) {
             $this->laravel['modules']->update($module);
         });
     }

--- a/src/Commands/UseCommand.php
+++ b/src/Commands/UseCommand.php
@@ -22,7 +22,7 @@ class UseCommand extends BaseCommand
     {
         $module = $this->getModuleModel($name);
 
-        $this->components->task("Using {$module->getName()} module", function () use ($module) {
+        $this->components->task("Using <fg=cyan;options=bold>{$module->getName()}</> Module", function () use ($module) {
             $this->laravel['modules']->setUsed($module);
         });
     }

--- a/src/Commands/UseCommand.php
+++ b/src/Commands/UseCommand.php
@@ -2,11 +2,7 @@
 
 namespace Nwidart\Modules\Commands;
 
-use Illuminate\Console\Command;
-use Illuminate\Support\Str;
-use Symfony\Component\Console\Input\InputArgument;
-
-class UseCommand extends Command
+class UseCommand extends BaseCommand
 {
     /**
      * The console command name.
@@ -22,35 +18,17 @@ class UseCommand extends Command
      */
     protected $description = 'Use the specified module.';
 
-    /**
-     * Execute the console command.
-     */
-    public function handle(): int
+    public function executeAction($name): void
     {
-        $module = Str::studly($this->argument('module'));
+        $module = $this->getModuleModel($name);
 
-        if (!$this->laravel['modules']->has($module)) {
-            $this->error("Module [{$module}] does not exists.");
-
-            return E_ERROR;
-        }
-
-        $this->laravel['modules']->setUsed($module);
-
-        $this->info("Module [{$module}] used successfully.");
-
-        return 0;
+        $this->components->task("Using {$module->getName()} module", function () use ($module) {
+            $this->laravel['modules']->setUsed($module);
+        });
     }
 
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
-    protected function getArguments()
+    function getInfo(): string|null
     {
-        return [
-            ['module', InputArgument::REQUIRED, 'The name of module will be used.'],
-        ];
+        return 'Using Module ...';
     }
 }

--- a/tests/Commands/DisableCommandTest.php
+++ b/tests/Commands/DisableCommandTest.php
@@ -63,7 +63,7 @@ class DisableCommandTest extends BaseTestCase
         $taxonomyModule = $this->app[RepositoryInterface::class]->find('Taxonomy');
         $taxonomyModule->enable();
 
-        $code = $this->artisan('module:disable');
+        $code = $this->artisan('module:disable',['--all' => true]);
 
         $this->assertTrue($blogModule->isDisabled() && $taxonomyModule->isDisabled());
         $this->assertSame(0, $code);

--- a/tests/Commands/EnableCommandTest.php
+++ b/tests/Commands/EnableCommandTest.php
@@ -46,7 +46,7 @@ class EnableCommandTest extends BaseTestCase
         $taxonomyModule = $this->app[RepositoryInterface::class]->find('Taxonomy');
         $taxonomyModule->disable();
 
-        $code = $this->artisan('module:enable');
+        $code = $this->artisan('module:enable', ['--all' => true]);
 
         $this->assertTrue($blogModule->isEnabled() && $taxonomyModule->isEnabled());
         $this->assertSame(0, $code);


### PR DESCRIPTION
Hi,

In this pull request, I've begun refactoring the structure of the command. The rules for all commands are as follows:

1. When called without any arguments, it will show a multiselect of Laravel prompts to choose which module should be checked.
2. When the option `--all` is passed, it will check all modules.
3. Module names can be passed as arguments to the command.

Example:

### Option 1:
   ```sh
   php artisan module:use
   ```
<img width="490" alt="image" src="https://github.com/nWidart/laravel-modules/assets/26966142/2cb23281-847c-47d3-9590-f536336cc40e">

---

### Option 2:
   ```sh
   php artisan module:use --all
   ```
<img width="705" alt="image" src="https://github.com/nWidart/laravel-modules/assets/26966142/ec1b9bf6-47ce-42e2-8f3d-ed12d4ef5af5">

---

### Option 3:
   ```sh
   php artisan module:use base wallet
   ```
<img width="707" alt="image" src="https://github.com/nWidart/laravel-modules/assets/26966142/80ba7688-eb23-47ba-bf46-e686b75dc4e7">

In this PR, I've updated the following commands:
- [x] module:use
- [x] module:unuse
- [x] module:update
- [x] module:publish
- [x] module:publish-config
- [x] module:publish-migration
- [x] module:publish-translation
- [x] module:delete
- [x] module:migrate
- [x] module:migrate-status
- [x] module:migrate-rollback
- [x] module:migrate-reset
- [x] module:migrate-refresh
- [x] module:disable
- [x] module:enable
- [x] module:dump
- [x] module:lang
- [x] module:seed
