### PR TITLE
Fix Issue #1752 - Hardcoded string + undefined variable

### DIFF
--- a/src/Commands/CheckLangCommand.php
+++ b/src/Commands/CheckLangCommand.php
@@ -65,7 +65,8 @@ class CheckLangCommand extends BaseCommand
     private function getDirectories($module)
     {
         $moduleName = $module->getStudlyName();
-        $path       = $module->getPath() . '/Resources/lang';
+        $path       = $module->getPath() . $this->langPath;
+        $directories = [];
         if (is_dir($path)) {
             $directories = $this->laravel['files']->directories($path);
             $directories = array_map(function ($directory) use ($moduleName) {


### PR DESCRIPTION
Additionally fixes the hardcoded path to "Resources/lang"