### PR TITLE
fix: Failed to load module script for static assets such as images

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -89,6 +89,11 @@ abstract class Module
 
             if (is_array($files)) {
                 foreach ($files as $file) {
+                    // Ignore files which aren't entrypoints.
+                    if (empty($file['isEntry'])) {
+                        continue;
+                    }
+
                     if (isset($file['src'])) {
                         $paths[] = $file['src'];
                     }


### PR DESCRIPTION
This provides a fix for issue #1731 .

Uses a similar bit of code to what has been proposed only with the if statement being flipped. Prior to this fix, I was getting the following console errors.

![CleanShot 2024-03-12 at 12 47 41](https://github.com/nWidart/laravel-modules/assets/18261676/a747fa12-0318-4da2-b3ae-1074355e358a)
