### PR TITLE
Add RouteServiceProvider Configuration in Generator

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -124,6 +124,7 @@ return [
             'observer' => ['path' => 'app/Observers', 'generate' => false],
             'policies' => ['path' => 'app/Policies', 'generate' => false],
             'provider' => ['path' => 'app/Providers', 'generate' => true],
+            'route-provider' => ['path' => 'app/Providers', 'generate' => true],
             'repository' => ['path' => 'app/Repositories', 'generate' => false],
             'resource' => ['path' => 'app/Transformers', 'generate' => false],
             'rules' => ['path' => 'app/Rules', 'generate' => false],

--- a/src/Commands/Make/ModuleMakeCommand.php
+++ b/src/Commands/Make/ModuleMakeCommand.php
@@ -54,7 +54,7 @@ class ModuleMakeCommand extends Command
         // to discover new service providers
         Process::path(base_path())
             ->command('composer dump-autoload')
-            ->run();
+            ->run()->output();
 
         return $success ? 0 : E_ERROR;
     }

--- a/src/Generators/ModuleGenerator.php
+++ b/src/Generators/ModuleGenerator.php
@@ -409,15 +409,40 @@ class ModuleGenerator extends Generator
             ]);
         }
 
-        if (GenerateConfigReader::read('provider')->generate() === true) {
+        $providerGenerator = GenerateConfigReader::read('provider');
+        if ($providerGenerator->generate() === true) {
             $this->console->call('module:make-provider', [
                 'name' => $this->getName() . 'ServiceProvider',
                 'module' => $this->getName(),
                 '--master' => true,
             ]);
+        } else {
+            // delete register ServiceProvider on module.json
+            $path           = $this->module->getModulePath($this->getName()) . DIRECTORY_SEPARATOR . 'module.json';
+            $module_file  =   $this->filesystem->get($path);
+            $this->filesystem->put(
+                $path,
+                preg_replace('/"providers": \[.*?\],/s', '"providers": [ ],', $module_file)
+            );
+        }
+
+        $routeGeneratorConfig = GenerateConfigReader::read('route-provider');
+        if (
+            (is_null($routeGeneratorConfig->getPath()) && $providerGenerator->generate())
+            || (!is_null($routeGeneratorConfig->getPath()) && $routeGeneratorConfig->generate())
+        ) {
             $this->console->call('module:route-provider', [
                 'module' => $this->getName(),
             ]);
+        } else {
+            if ($providerGenerator->generate()) {
+                // comment register RouteServiceProvider
+                $this->filesystem->replaceInFile(
+                    '$this->app->register(Route',
+                    '// $this->app->register(Route',
+                    $this->module->getModulePath($this->getName()) . DIRECTORY_SEPARATOR . $providerGenerator->getPath() . DIRECTORY_SEPARATOR . sprintf('%sServiceProvider.php', $this->getName())
+                );
+            }
         }
 
         if (GenerateConfigReader::read('controller')->generate() === true) {

--- a/src/Generators/ModuleGenerator.php
+++ b/src/Generators/ModuleGenerator.php
@@ -361,7 +361,7 @@ class ModuleGenerator extends Generator
 
             $path = $this->module->getModulePath($this->getName()) . '/' . $folder->getPath();
 
-            $this->filesystem->makeDirectory($path, 0755, true);
+            $this->filesystem->ensureDirectoryExists($path, 0755, true);
             if (config('modules.stubs.gitkeep')) {
                 $this->generateGitKeep($path);
             }

--- a/tests/Commands/ModuleMakeCommandTest.php
+++ b/tests/Commands/ModuleMakeCommandTest.php
@@ -4,6 +4,7 @@ namespace Nwidart\Modules\Tests\Commands;
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Str;
+use Modules\Bae\Providers\RouteServiceProvider;
 use Nwidart\Modules\Contracts\ActivatorInterface;
 use Nwidart\Modules\Contracts\RepositoryInterface;
 use Nwidart\Modules\Tests\BaseTestCase;
@@ -297,6 +298,7 @@ class ModuleMakeCommandTest extends BaseTestCase
     {
         $this->app['config']->set('modules.paths.generator.seeder', ['path' => 'Database/Seeders', 'generate' => false]);
         $this->app['config']->set('modules.paths.generator.provider', ['path' => 'Providers', 'generate' => false]);
+        $this->app['config']->set('modules.paths.generator.route-provider', ['path' => 'Providers', 'generate' => false]);
         $this->app['config']->set('modules.paths.generator.controller', ['path' => 'Http/Controllers', 'generate' => false]);
 
         $code = $this->artisan('module:make', ['name' => ['Blog']]);
@@ -404,5 +406,63 @@ class ModuleMakeCommandTest extends BaseTestCase
         $this->assertMatchesSnapshot($this->finder->get($path));
 
         $this->assertSame(0, $code);
+    }
+
+    public function test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable()
+    {
+        $this->app['config']->set('modules.paths.generator.provider.generate', true);
+        $this->app['config']->set('modules.paths.generator.route-provider.generate', true);
+
+        $this->artisan('module:make', ['name' => ['Blog']]);
+
+        $providerPath = $this->getModuleAppPath() . '/Providers/BlogServiceProvider.php';
+        $this->assertTrue($this->finder->exists($providerPath));
+        $this->assertMatchesSnapshot($this->finder->get($providerPath));
+
+        $RouteProviderPath = $this->getModuleAppPath() . '/Providers/RouteServiceProvider.php';
+        $this->assertTrue($this->finder->exists($RouteProviderPath));
+        $this->assertMatchesSnapshot($this->finder->get($RouteProviderPath));
+
+        $content = $this->finder->get($providerPath);
+
+        $this->assertStringContainsString('$this->app->register(RouteServiceProvider::class);', $content);
+        $this->assertStringNotContainsString('// $this->app->register(RouteServiceProvider::class);', $content);
+    }
+
+    public function test_it_generate_module_when_provider_is_enable_and_route_provider_is_disable()
+    {
+        $this->app['config']->set('modules.paths.generator.provider.generate', true);
+        $this->app['config']->set('modules.paths.generator.route-provider.generate', false);
+
+        $this->artisan('module:make', ['name' => ['Blog']]);
+
+        $providerPath = $this->getModuleAppPath() . '/Providers/BlogServiceProvider.php';
+        $this->assertTrue($this->finder->exists($providerPath));
+        $this->assertMatchesSnapshot($this->finder->get($providerPath));
+
+        $RouteProviderPath = $this->getModuleAppPath() . '/Providers/RouteServiceProvider.php';
+        $this->assertTrue(!$this->finder->exists($RouteProviderPath));
+
+        $content = $this->finder->get($providerPath);
+
+        $this->assertStringContainsString('// $this->app->register(RouteServiceProvider::class);', $content);
+    }
+
+    public function test_it_generate_module_when_provider_is_disable_and_route_provider_is_disable()
+    {
+        $this->app['config']->set('modules.paths.generator.provider.generate', false);
+        $this->app['config']->set('modules.paths.generator.route-provider.generate', false);
+
+        $this->artisan('module:make', ['name' => ['Blog']]);
+
+        $providerPath = $this->getModuleAppPath() . '/Providers/BlogServiceProvider.php';
+        $this->assertTrue(!$this->finder->exists($providerPath));
+
+        $RouteProviderPath = $this->getModuleAppPath() . '/Providers/RouteServiceProvider.php';
+        $this->assertTrue(!$this->finder->exists($RouteProviderPath));
+
+        $content = $this->finder->get($this->getModuleBasePath() . '/module.json');
+
+        $this->assertStringNotContainsString('Modules\Blog\Providers\BlogServiceProvider', $content);
     }
 }

--- a/tests/Commands/ModuleMakeCommandTest.php
+++ b/tests/Commands/ModuleMakeCommandTest.php
@@ -4,7 +4,6 @@ namespace Nwidart\Modules\Tests\Commands;
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Str;
-use Modules\Bae\Providers\RouteServiceProvider;
 use Nwidart\Modules\Contracts\ActivatorInterface;
 use Nwidart\Modules\Contracts\RepositoryInterface;
 use Nwidart\Modules\Tests\BaseTestCase;

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_disable__1.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_disable__1.txt
@@ -1,0 +1,114 @@
+<?php
+
+namespace Modules\Blog\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class BlogServiceProvider extends ServiceProvider
+{
+    protected string $moduleName = 'Blog';
+
+    protected string $moduleNameLower = 'blog';
+
+    /**
+     * Boot the application events.
+     */
+    public function boot(): void
+    {
+        $this->registerCommands();
+        $this->registerCommandSchedules();
+        $this->registerTranslations();
+        $this->registerConfig();
+        $this->registerViews();
+        $this->loadMigrationsFrom(module_path($this->moduleName, 'database/migrations'));
+    }
+
+    /**
+     * Register the service provider.
+     */
+    public function register(): void
+    {
+        // $this->app->register(RouteServiceProvider::class);
+    }
+
+    /**
+     * Register commands in the format of Command::class
+     */
+    protected function registerCommands(): void
+    {
+        // $this->commands([]);
+    }
+
+    /**
+     * Register command Schedules.
+     */
+    protected function registerCommandSchedules(): void
+    {
+        // $this->app->booted(function () {
+        //     $schedule = $this->app->make(Schedule::class);
+        //     $schedule->command('inspire')->hourly();
+        // });
+    }
+
+    /**
+     * Register translations.
+     */
+    public function registerTranslations(): void
+    {
+        $langPath = resource_path('lang/modules/'.$this->moduleNameLower);
+
+        if (is_dir($langPath)) {
+            $this->loadTranslationsFrom($langPath, $this->moduleNameLower);
+            $this->loadJsonTranslationsFrom($langPath);
+        } else {
+            $this->loadTranslationsFrom(module_path($this->moduleName, 'lang'), $this->moduleNameLower);
+            $this->loadJsonTranslationsFrom(module_path($this->moduleName, 'lang'));
+        }
+    }
+
+    /**
+     * Register config.
+     */
+    protected function registerConfig(): void
+    {
+        $this->publishes([module_path($this->moduleName, 'config/config.php') => config_path($this->moduleNameLower.'.php')], 'config');
+        $this->mergeConfigFrom(module_path($this->moduleName, 'config/config.php'), $this->moduleNameLower);
+    }
+
+    /**
+     * Register views.
+     */
+    public function registerViews(): void
+    {
+        $viewPath = resource_path('views/modules/'.$this->moduleNameLower);
+        $sourcePath = module_path($this->moduleName, 'resources/views');
+
+        $this->publishes([$sourcePath => $viewPath], ['views', $this->moduleNameLower.'-module-views']);
+
+        $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
+
+        $componentNamespace = str_replace('/', '\\', config('modules.namespace').'\\'.$this->moduleName.'\\'.ltrim(config('modules.paths.generator.component-class.path'), config('modules.paths.app_folder','')));
+        Blade::componentNamespace($componentNamespace, $this->moduleNameLower);
+    }
+
+    /**
+     * Get the services provided by the provider.
+     */
+    public function provides(): array
+    {
+        return [];
+    }
+
+    private function getPublishableViewPaths(): array
+    {
+        $paths = [];
+        foreach (config('view.paths') as $path) {
+            if (is_dir($path.'/modules/'.$this->moduleNameLower)) {
+                $paths[] = $path.'/modules/'.$this->moduleNameLower;
+            }
+        }
+
+        return $paths;
+    }
+}

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__1.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__1.txt
@@ -1,0 +1,114 @@
+<?php
+
+namespace Modules\Blog\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class BlogServiceProvider extends ServiceProvider
+{
+    protected string $moduleName = 'Blog';
+
+    protected string $moduleNameLower = 'blog';
+
+    /**
+     * Boot the application events.
+     */
+    public function boot(): void
+    {
+        $this->registerCommands();
+        $this->registerCommandSchedules();
+        $this->registerTranslations();
+        $this->registerConfig();
+        $this->registerViews();
+        $this->loadMigrationsFrom(module_path($this->moduleName, 'database/migrations'));
+    }
+
+    /**
+     * Register the service provider.
+     */
+    public function register(): void
+    {
+        $this->app->register(RouteServiceProvider::class);
+    }
+
+    /**
+     * Register commands in the format of Command::class
+     */
+    protected function registerCommands(): void
+    {
+        // $this->commands([]);
+    }
+
+    /**
+     * Register command Schedules.
+     */
+    protected function registerCommandSchedules(): void
+    {
+        // $this->app->booted(function () {
+        //     $schedule = $this->app->make(Schedule::class);
+        //     $schedule->command('inspire')->hourly();
+        // });
+    }
+
+    /**
+     * Register translations.
+     */
+    public function registerTranslations(): void
+    {
+        $langPath = resource_path('lang/modules/'.$this->moduleNameLower);
+
+        if (is_dir($langPath)) {
+            $this->loadTranslationsFrom($langPath, $this->moduleNameLower);
+            $this->loadJsonTranslationsFrom($langPath);
+        } else {
+            $this->loadTranslationsFrom(module_path($this->moduleName, 'lang'), $this->moduleNameLower);
+            $this->loadJsonTranslationsFrom(module_path($this->moduleName, 'lang'));
+        }
+    }
+
+    /**
+     * Register config.
+     */
+    protected function registerConfig(): void
+    {
+        $this->publishes([module_path($this->moduleName, 'config/config.php') => config_path($this->moduleNameLower.'.php')], 'config');
+        $this->mergeConfigFrom(module_path($this->moduleName, 'config/config.php'), $this->moduleNameLower);
+    }
+
+    /**
+     * Register views.
+     */
+    public function registerViews(): void
+    {
+        $viewPath = resource_path('views/modules/'.$this->moduleNameLower);
+        $sourcePath = module_path($this->moduleName, 'resources/views');
+
+        $this->publishes([$sourcePath => $viewPath], ['views', $this->moduleNameLower.'-module-views']);
+
+        $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
+
+        $componentNamespace = str_replace('/', '\\', config('modules.namespace').'\\'.$this->moduleName.'\\'.ltrim(config('modules.paths.generator.component-class.path'), config('modules.paths.app_folder','')));
+        Blade::componentNamespace($componentNamespace, $this->moduleNameLower);
+    }
+
+    /**
+     * Get the services provided by the provider.
+     */
+    public function provides(): array
+    {
+        return [];
+    }
+
+    private function getPublishableViewPaths(): array
+    {
+        $paths = [];
+        foreach (config('view.paths') as $path) {
+            if (is_dir($path.'/modules/'.$this->moduleNameLower)) {
+                $paths[] = $path.'/modules/'.$this->moduleNameLower;
+            }
+        }
+
+        return $paths;
+    }
+}

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__2.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__2.txt
@@ -1,0 +1,49 @@
+<?php
+
+namespace Modules\Blog\Providers;
+
+use Illuminate\Support\Facades\Route;
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    /**
+     * Called before routes are registered.
+     *
+     * Register any model bindings or pattern based filters.
+     */
+    public function boot(): void
+    {
+        parent::boot();
+    }
+
+    /**
+     * Define the routes for the application.
+     */
+    public function map(): void
+    {
+        $this->mapApiRoutes();
+
+        $this->mapWebRoutes();
+    }
+
+    /**
+     * Define the "web" routes for the application.
+     *
+     * These routes all receive session state, CSRF protection, etc.
+     */
+    protected function mapWebRoutes(): void
+    {
+        Route::middleware('web')->group(module_path('Blog', '/routes/web.php'));
+    }
+
+    /**
+     * Define the "api" routes for the application.
+     *
+     * These routes are typically stateless.
+     */
+    protected function mapApiRoutes(): void
+    {
+        Route::middleware('api')->prefix('api')->name('api.')->group(module_path('Blog', '/routes/api.php'));
+    }
+}


### PR DESCRIPTION
Hi,

This pull request fix issue #1779 by adding configuration for RouteServiceProvider in the generator.

Additionally, when the provider is disabled, it removes the namespace from `module.json`. Furthermore, if the route provider is disabled, it comments out the registration of RouteServiceProvider in the ServiceProvider as follows:

```php
/**
 * Register the service provider.
 */
public function register(): void
{
    // $this->app->register(RouteServiceProvider::class);
}
```

These changes aim to improve the configuration and flexibility of the generator.