### PR TITLE
Passing the values of vendor, author's name, and author's email in a line during module creation.

### DIFF
--- a/src/Commands/Make/ModuleMakeCommand.php
+++ b/src/Commands/Make/ModuleMakeCommand.php
@@ -44,6 +44,8 @@ class ModuleMakeCommand extends Command
                 ->setForce($this->option('force'))
                 ->setType($this->getModuleType())
                 ->setActive(!$this->option('disabled'))
+                ->setVendor($this->option('author-vendor'))
+                ->setAuthor($this->option('author-name'), $this->option('author-email'))
                 ->generate();
 
             if ($code === E_ERROR) {
@@ -79,6 +81,9 @@ class ModuleMakeCommand extends Command
             ['web', null, InputOption::VALUE_NONE, 'Generate a web module.'],
             ['disabled', 'd', InputOption::VALUE_NONE, 'Do not enable the module at creation.'],
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when the module already exists.'],
+            ['author-name', 'an', InputOption::VALUE_OPTIONAL, 'Author name.'],
+            ['author-email', 'ae', InputOption::VALUE_OPTIONAL, 'Author email.'],
+            ['author-vendor', 'av', InputOption::VALUE_OPTIONAL, 'Author vendor.'],
         ];
     }
 

--- a/src/Commands/Make/ModuleMakeCommand.php
+++ b/src/Commands/Make/ModuleMakeCommand.php
@@ -81,9 +81,9 @@ class ModuleMakeCommand extends Command
             ['web', null, InputOption::VALUE_NONE, 'Generate a web module.'],
             ['disabled', 'd', InputOption::VALUE_NONE, 'Do not enable the module at creation.'],
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when the module already exists.'],
-            ['author-name', 'an', InputOption::VALUE_OPTIONAL, 'Author name.'],
-            ['author-email', 'ae', InputOption::VALUE_OPTIONAL, 'Author email.'],
-            ['author-vendor', 'av', InputOption::VALUE_OPTIONAL, 'Author vendor.'],
+            ['author-name', null, InputOption::VALUE_OPTIONAL, 'Author name.'],
+            ['author-email', null, InputOption::VALUE_OPTIONAL, 'Author email.'],
+            ['author-vendor', null, InputOption::VALUE_OPTIONAL, 'Author vendor.'],
         ];
     }
 

--- a/src/Generators/ModuleGenerator.php
+++ b/src/Generators/ModuleGenerator.php
@@ -84,6 +84,22 @@ class ModuleGenerator extends Generator
     protected $isActive = false;
 
     /**
+     * Module author
+     *
+     * @var array
+     */
+    protected array $author = [
+        'name', 'email'
+    ];
+
+    /**
+     * Vendor name
+     *
+     * @var string
+     */
+    protected ?string $vendor = null;
+
+    /**
      * The constructor.
      * @param $name
      * @param FileRepository $module
@@ -269,6 +285,34 @@ class ModuleGenerator extends Generator
     public function setModule($module)
     {
         $this->module = $module;
+
+        return $this;
+    }
+
+    /**
+     * Setting the author from the command
+     *
+     * @param string|null $name
+     * @param string|null $email
+     * @return $this
+     */
+    function setAuthor(string $name = null, string $email = null)
+    {
+        $this->author['name'] = $name;
+        $this->author['email'] = $email;
+
+        return $this;
+    }
+
+    /**
+     * Installing vendor from the command
+     *
+     * @param string|null $vendor
+     * @return $this
+     */
+    function setVendor(string $vendor = null)
+    {
+        $this->vendor = $vendor;
 
         return $this;
     }
@@ -575,7 +619,7 @@ class ModuleGenerator extends Generator
      */
     protected function getVendorReplacement()
     {
-        return $this->module->config('composer.vendor');
+        return $this->vendor ?: $this->module->config('composer.vendor');
     }
 
     /**
@@ -605,7 +649,7 @@ class ModuleGenerator extends Generator
      */
     protected function getAuthorNameReplacement()
     {
-        return $this->module->config('composer.author.name');
+        return $this->author['name'] ?: $this->module->config('composer.author.name');
     }
 
     /**
@@ -615,7 +659,7 @@ class ModuleGenerator extends Generator
      */
     protected function getAuthorEmailReplacement()
     {
-        return $this->module->config('composer.author.email');
+        return $this->author['email'] ?: $this->module->config('composer.author.email');
     }
 
     protected function getProviderNamespaceReplacement(): string


### PR DESCRIPTION
Example of usage:
--author-name=value
--author-email=value
--author-vendor=value

All values are optional.

`php artisan module:make --author-name=Alex`

It is useful for modular development to avoid being tied to the system configuration.