### PR TITLE
Fix namespace - Resolved StudlyCase Namespace Generation Issues and App\\ Path

### DIFF
--- a/src/Commands/Make/ChannelMakeCommand.php
+++ b/src/Commands/Make/ChannelMakeCommand.php
@@ -26,7 +26,7 @@ final class ChannelMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.channels.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.channels.path', 'app/Broadcasting'));
+        return config('modules.paths.generator.channels.namespace', $this->getPathNamespace(config('modules.paths.generator.channels.path', 'app/Broadcasting')));
     }
 
     /**

--- a/src/Commands/Make/ChannelMakeCommand.php
+++ b/src/Commands/Make/ChannelMakeCommand.php
@@ -14,32 +14,25 @@ final class ChannelMakeCommand extends GeneratorCommand
 
     /**
      * The console command name.
-     *
-     * @var string
      */
     protected $name = 'module:make-channel';
 
-    protected $argumentName = 'name';
-
     /**
      * The console command description.
-     *
-     * @var string
      */
     protected $description = 'Create a new channel class for the specified module.';
 
+    protected $argumentName = 'name';
+
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.channels.namespace')
-            ?? ltrim(config('modules.paths.generator.channels.path', 'Broadcasting'), config('modules.paths.app_folder', ''));
+        return config('modules.paths.generator.channels.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.channels.path', 'app/Broadcasting'));
     }
 
     /**
      * Get template contents.
-     *
-     * @return string
      */
-    protected function getTemplateContents()
+    protected function getTemplateContents(): string
     {
         $module = $this->laravel['modules']->findOrFail($this->getModuleName());
 
@@ -51,10 +44,8 @@ final class ChannelMakeCommand extends GeneratorCommand
 
     /**
      * Get the destination file path.
-     *
-     * @return string
      */
-    protected function getDestinationFilePath()
+    protected function getDestinationFilePath(): string
     {
         $path = $this->laravel['modules']->getModulePath($this->getModuleName());
 
@@ -63,20 +54,15 @@ final class ChannelMakeCommand extends GeneratorCommand
         return $path . $channelPath->getPath() . '/' . $this->getFileName() . '.php';
     }
 
-    /**
-     * @return string
-     */
-    private function getFileName()
+    private function getFileName(): string
     {
         return Str::studly($this->argument('name'));
     }
 
     /**
      * Get the console command arguments.
-     *
-     * @return array
      */
-    protected function getArguments()
+    protected function getArguments(): array
     {
         return [
             ['name', InputArgument::REQUIRED, 'The name of the channel class.'],

--- a/src/Commands/Make/CommandMakeCommand.php
+++ b/src/Commands/Make/CommandMakeCommand.php
@@ -36,7 +36,7 @@ class CommandMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.command.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.command.path', 'app/Console'));
+        return config('modules.paths.generator.command.namespace', $this->getPathNamespace(config('modules.paths.generator.command.path', 'app/Console')));
     }
 
     /**

--- a/src/Commands/Make/CommandMakeCommand.php
+++ b/src/Commands/Make/CommandMakeCommand.php
@@ -36,8 +36,7 @@ class CommandMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.command.namespace')
-            ?? ltrim(config('modules.paths.generator.command.path', 'Console'), config('modules.paths.app_folder', ''));
+        return config('modules.paths.generator.command.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.command.path', 'app/Console'));
     }
 
     /**

--- a/src/Commands/Make/ComponentClassMakeCommand.php
+++ b/src/Commands/Make/ComponentClassMakeCommand.php
@@ -54,7 +54,7 @@ class ComponentClassMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.component-class.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.component-class.path', 'app/View/Components'));
+        return config('modules.paths.generator.component-class.namespace', $this->getPathNamespace(config('modules.paths.generator.component-class.path', 'app/View/Components')));
     }
 
     /**

--- a/src/Commands/Make/ComponentClassMakeCommand.php
+++ b/src/Commands/Make/ComponentClassMakeCommand.php
@@ -49,13 +49,12 @@ class ComponentClassMakeCommand extends GeneratorCommand
      */
     protected function writeComponentViewTemplate()
     {
-        $this->call('module:make-component-view', ['name' => $this->argument('name') , 'module' => $this->argument('module')]);
+        $this->call('module:make-component-view', ['name' => $this->argument('name'), 'module' => $this->argument('module')]);
     }
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.component-class.namespace')
-            ?? ltrim(config('modules.paths.generator.component-class.path', 'View/Component'), config('modules.paths.app_folder', ''));
+        return config('modules.paths.generator.component-class.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.component-class.path', 'app/View/Components'));
     }
 
     /**

--- a/src/Commands/Make/ControllerMakeCommand.php
+++ b/src/Commands/Make/ControllerMakeCommand.php
@@ -117,8 +117,7 @@ class ControllerMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.controller.namespace')
-            ?? ltrim(config('modules.paths.generator.controller.path', 'Http/Controllers'), config('modules.paths.app_folder'));
+        return config('modules.paths.generator.controller.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.controller.path', 'app/Http/Controllers'));
     }
 
     /**

--- a/src/Commands/Make/ControllerMakeCommand.php
+++ b/src/Commands/Make/ControllerMakeCommand.php
@@ -117,7 +117,7 @@ class ControllerMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.controller.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.controller.path', 'app/Http/Controllers'));
+        return config('modules.paths.generator.controller.namespace', $this->getPathNamespace(config('modules.paths.generator.controller.path', 'app/Http/Controllers')));
     }
 
     /**

--- a/src/Commands/Make/EventMakeCommand.php
+++ b/src/Commands/Make/EventMakeCommand.php
@@ -57,7 +57,7 @@ class EventMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.event.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.event.path', 'app/Events'));
+        return config('modules.paths.generator.event.namespace', $this->getPathNamespace(config('modules.paths.generator.event.path', 'app/Events')));
     }
 
     /**

--- a/src/Commands/Make/EventMakeCommand.php
+++ b/src/Commands/Make/EventMakeCommand.php
@@ -57,8 +57,7 @@ class EventMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.event.namespace')
-            ?? ltrim(config('modules.paths.generator.event.path', 'Events'), config('modules.paths.app_folder', ''));
+        return config('modules.paths.generator.event.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.event.path', 'app/Events'));
     }
 
     /**

--- a/src/Commands/Make/FactoryMakeCommand.php
+++ b/src/Commands/Make/FactoryMakeCommand.php
@@ -14,31 +14,23 @@ class FactoryMakeCommand extends GeneratorCommand
 
     /**
      * The name of argument name.
-     *
-     * @var string
      */
     protected $argumentName = 'name';
 
     /**
      * The console command name.
-     *
-     * @var string
      */
     protected $name = 'module:make-factory';
 
     /**
      * The console command description.
-     *
-     * @var string
      */
     protected $description = 'Create a new model factory for the specified module.';
 
     /**
      * Get the console command arguments.
-     *
-     * @return array
      */
-    protected function getArguments()
+    protected function getArguments(): array
     {
         return [
             ['name', InputArgument::REQUIRED, 'The name of the model.'],
@@ -46,9 +38,6 @@ class FactoryMakeCommand extends GeneratorCommand
         ];
     }
 
-    /**
-     * @return mixed
-     */
     protected function getTemplateContents()
     {
         $module = $this->laravel['modules']->findOrFail($this->getModuleName());
@@ -60,10 +49,7 @@ class FactoryMakeCommand extends GeneratorCommand
         ]))->render();
     }
 
-    /**
-     * @return mixed
-     */
-    protected function getDestinationFilePath()
+    protected function getDestinationFilePath(): string
     {
         $path = $this->laravel['modules']->getModulePath($this->getModuleName());
 
@@ -72,44 +58,29 @@ class FactoryMakeCommand extends GeneratorCommand
         return $path . $factoryPath->getPath() . '/' . $this->getFileName();
     }
 
-    /**
-     * @return string
-     */
-    private function getFileName()
+    private function getFileName(): string
     {
         return Str::studly($this->argument('name')) . 'Factory.php';
     }
 
-    /**
-     * @return mixed|string
-     */
-    private function getModelName()
+    private function getModelName(): string
     {
         return Str::studly($this->argument('name'));
     }
 
     /**
      * Get default namespace.
-     *
-     * @return string
      */
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.factory.namespace')
-            ?? ltrim(config('modules.paths.generator.factory.path', 'Database/Factories'), config('modules.paths.app_folder', ''));
+        return config('modules.paths.generator.factory.namespace', $this->getPathNamespace(config('modules.paths.generator.factory.path', 'database/factories')));
     }
 
     /**
      * Get model namespace.
-     *
-     * @return string
      */
     public function getModelNamespace(): string
     {
-        $path = ltrim(config('modules.paths.generator.model.path', 'Entities'), config('modules.paths.app_folder', ''));
-
-        $path = str_replace('/', '\\', $path);
-
-        return $this->laravel['modules']->config('namespace') . '\\' . $this->laravel['modules']->findOrFail($this->getModuleName()) . '\\' . $path;
+        return $this->getModuleNamespace(config('modules.paths.generator.model.path', 'app/Models'));
     }
 }

--- a/src/Commands/Make/GeneratorCommand.php
+++ b/src/Commands/Make/GeneratorCommand.php
@@ -3,6 +3,7 @@
 namespace Nwidart\Modules\Commands\Make;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Str;
 use Nwidart\Modules\Exceptions\FileAlreadyExistException;
 use Nwidart\Modules\Generators\FileGenerator;
 
@@ -47,7 +48,6 @@ abstract class GeneratorCommand extends Command
                 $overwriteFile = $this->hasOption('force') ? $this->option('force') : false;
                 (new FileGenerator($path, $contents))->withFileOverwrite($overwriteFile)->generate();
             });
-
         } catch (FileAlreadyExistException $e) {
             $this->components->error("File : {$path} already exists.");
 
@@ -101,5 +101,10 @@ abstract class GeneratorCommand extends Command
         $namespace = str_replace('/', '\\', $namespace);
 
         return trim($namespace, '\\');
+    }
+
+    public function getPathNamespace(string $path): string
+    {
+        return str_replace('/', '\\', collect(explode('/', $path))->map(fn ($dir) => Str::studly($dir))->implode('/'));
     }
 }

--- a/src/Commands/Make/GeneratorCommand.php
+++ b/src/Commands/Make/GeneratorCommand.php
@@ -103,8 +103,27 @@ abstract class GeneratorCommand extends Command
         return trim($namespace, '\\');
     }
 
+    public function getStudly(string $string, $separator = '/'): string
+    {
+        return collect(explode($separator, Str::of($string)->replace("{$separator}{$separator}", $separator)->trim($separator)))->map(fn ($dir) => Str::studly($dir))->implode($separator);
+    }
+
+    public function getStudlyNamespace(string $namespace): string
+    {
+        return $this->getStudly($namespace, '\\');
+    }
+
     public function getPathNamespace(string $path): string
     {
-        return str_replace('/', '\\', collect(explode('/', $path))->map(fn ($dir) => Str::studly($dir))->implode('/'));
+        return Str::of($this->getStudly($path))->replace('/', '\\')->trim('\\');
+    }
+
+    public function getModuleNamespace(string $path = null, string $module = null): string
+    {
+        return $this->getStudlyNamespace(
+            $this->laravel['modules']->config('namespace') . '\\'
+                . ($module ?? $this->laravel['modules']->findOrFail($this->getModuleName())) . '\\'
+                . $this->getPathNamespace($path)
+        );
     }
 }

--- a/src/Commands/Make/JobMakeCommand.php
+++ b/src/Commands/Make/JobMakeCommand.php
@@ -31,7 +31,7 @@ class JobMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.jobs.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.jobs.path', 'app/Jobs'));
+        return config('modules.paths.generator.jobs.namespace', $this->getPathNamespace(config('modules.paths.generator.jobs.path', 'app/Jobs')));
     }
 
     /**

--- a/src/Commands/Make/JobMakeCommand.php
+++ b/src/Commands/Make/JobMakeCommand.php
@@ -31,8 +31,7 @@ class JobMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.jobs.namespace')
-            ?? ltrim(config('modules.paths.generator.jobs.path', 'Jobs'), config('modules.paths.app_folder', ''));
+        return config('modules.paths.generator.jobs.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.jobs.path', 'app/Jobs'));
     }
 
     /**

--- a/src/Commands/Make/ListenerMakeCommand.php
+++ b/src/Commands/Make/ListenerMakeCommand.php
@@ -70,8 +70,7 @@ class ListenerMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.listener.namespace')
-            ?? ltrim(config('modules.paths.generator.listener.path', 'Listeners'), config('modules.paths.app_folder', ''));
+        return config('modules.paths.generator.listener.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.listener.path', 'app/Listeners'));
     }
 
     protected function getEventName(Module $module)
@@ -79,9 +78,7 @@ class ListenerMakeCommand extends GeneratorCommand
         $namespace = $this->laravel['modules']->config('namespace') . "\\" . $module->getStudlyName();
         $eventPath = GenerateConfigReader::read('event');
 
-        $eventName = $namespace . "\\" . $eventPath->getPath() . "\\" . $this->option('event');
-
-        return str_replace('/', '\\', $eventName);
+        return $this->getPathNamespace($namespace . "\\" . $eventPath->getPath() . "\\" . $this->option('event'));
     }
 
     protected function getShortEventName()

--- a/src/Commands/Make/ListenerMakeCommand.php
+++ b/src/Commands/Make/ListenerMakeCommand.php
@@ -70,7 +70,7 @@ class ListenerMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.listener.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.listener.path', 'app/Listeners'));
+        return config('modules.paths.generator.listener.namespace', $this->getPathNamespace(config('modules.paths.generator.listener.path', 'app/Listeners')));
     }
 
     protected function getEventName(Module $module)

--- a/src/Commands/Make/MailMakeCommand.php
+++ b/src/Commands/Make/MailMakeCommand.php
@@ -30,8 +30,7 @@ class MailMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.emails.namespace')
-            ?? ltrim(config('modules.paths.generator.emails.path', 'Emails'), config('modules.paths.app_folder', ''));
+        return config('modules.paths.generator.emails.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.emails.path', 'app/Emails'));
     }
 
     /**

--- a/src/Commands/Make/MailMakeCommand.php
+++ b/src/Commands/Make/MailMakeCommand.php
@@ -30,7 +30,7 @@ class MailMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.emails.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.emails.path', 'app/Emails'));
+        return config('modules.paths.generator.emails.namespace', $this->getPathNamespace(config('modules.paths.generator.emails.path', 'app/Emails')));
     }
 
     /**

--- a/src/Commands/Make/MiddlewareMakeCommand.php
+++ b/src/Commands/Make/MiddlewareMakeCommand.php
@@ -35,7 +35,7 @@ class MiddlewareMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.filter.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.filter.path', 'app/Http/Middleware'));
+        return config('modules.paths.generator.filter.namespace', $this->getPathNamespace(config('modules.paths.generator.filter.path', 'app/Http/Middleware')));
     }
 
     /**

--- a/src/Commands/Make/MiddlewareMakeCommand.php
+++ b/src/Commands/Make/MiddlewareMakeCommand.php
@@ -35,8 +35,7 @@ class MiddlewareMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.filter.namespace')
-            ?? ltrim(config('modules.paths.generator.filter.path', 'Http/Middleware'), config('modules.paths.app_folder', ''));
+        return config('modules.paths.generator.filter.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.filter.path', 'app/Http/Middleware'));
     }
 
     /**

--- a/src/Commands/Make/ModelMakeCommand.php
+++ b/src/Commands/Make/ModelMakeCommand.php
@@ -238,6 +238,6 @@ class ModelMakeCommand extends GeneratorCommand
      */
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.model.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.model.path', 'app/Models'));
+        return config('modules.paths.generator.model.namespace', $this->getPathNamespace(config('modules.paths.generator.model.path', 'app/Models')));
     }
 }

--- a/src/Commands/Make/ModelMakeCommand.php
+++ b/src/Commands/Make/ModelMakeCommand.php
@@ -238,7 +238,6 @@ class ModelMakeCommand extends GeneratorCommand
      */
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.model.namespace')
-            ?? ltrim(config('modules.paths.generator.model.path', 'Models'), config('modules.paths.app_folder', ''));
+        return config('modules.paths.generator.model.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.model.path', 'app/Models'));
     }
 }

--- a/src/Commands/Make/NotificationMakeCommand.php
+++ b/src/Commands/Make/NotificationMakeCommand.php
@@ -30,7 +30,7 @@ final class NotificationMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.notifications.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.notifications.path', 'app/Notifications'));
+        return config('modules.paths.generator.notifications.namespace', $this->getPathNamespace(config('modules.paths.generator.notifications.path', 'app/Notifications')));
     }
 
     /**

--- a/src/Commands/Make/NotificationMakeCommand.php
+++ b/src/Commands/Make/NotificationMakeCommand.php
@@ -30,8 +30,7 @@ final class NotificationMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.notifications.namespace')
-            ?? ltrim(config('modules.paths.generator.notifications.path', 'Notifications'), config('modules.paths.app_folder', ''));
+        return config('modules.paths.generator.notifications.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.notifications.path', 'app/Notifications'));
     }
 
     /**

--- a/src/Commands/Make/ObserverMakeCommand.php
+++ b/src/Commands/Make/ObserverMakeCommand.php
@@ -125,6 +125,6 @@ class ObserverMakeCommand extends GeneratorCommand
      */
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.observer.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.observer.path', 'app/Observers'));
+        return config('modules.paths.generator.observer.namespace', $this->getPathNamespace(config('modules.paths.generator.observer.path', 'app/Observers')));
     }
 }

--- a/src/Commands/Make/ObserverMakeCommand.php
+++ b/src/Commands/Make/ObserverMakeCommand.php
@@ -54,11 +54,11 @@ class ObserverMakeCommand extends GeneratorCommand
         $module = $this->laravel['modules']->findOrFail($this->getModuleName());
 
         return (new Stub('/observer.stub', [
-                'NAMESPACE' => $this->getClassNamespace($module),
-                'NAME' => $this->getModelName(),
-                'MODEL_NAMESPACE' => $this->getModelNamespace(),
-                'NAME_VARIABLE' => $this->getModelVariable(),
-            ]))->render();
+            'NAMESPACE' => $this->getClassNamespace($module),
+            'NAME' => $this->getModelName(),
+            'MODEL_NAMESPACE' => $this->getModelNamespace(),
+            'NAME_VARIABLE' => $this->getModelVariable(),
+        ]))->render();
     }
 
     /**
@@ -68,11 +68,9 @@ class ObserverMakeCommand extends GeneratorCommand
      */
     public function getModelNamespace(): string
     {
-        $path = $this->laravel['modules']->config('paths.generator.model.path', 'Entities');
+        $path = $this->laravel['modules']->config('paths.generator.model.path', 'app/Models');
 
-        $path = str_replace('/', '\\', $path);
-
-        return $this->laravel['modules']->config('namespace') . '\\' . $this->laravel['modules']->findOrFail($this->getModuleName()) . '\\' . $path;
+        return $this->getPathNamespace($this->laravel['modules']->config('namespace') . '\\' . $this->laravel['modules']->findOrFail($this->getModuleName()) . '\\' . $path);
     }
 
     /**
@@ -127,7 +125,6 @@ class ObserverMakeCommand extends GeneratorCommand
      */
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.observer.namespace')
-            ?? ltrim(config('modules.paths.generator.observer.path', 'Observers'), config('modules.paths.app_folder', ''));
+        return config('modules.paths.generator.observer.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.observer.path', 'app/Observers'));
     }
 }

--- a/src/Commands/Make/PolicyMakeCommand.php
+++ b/src/Commands/Make/PolicyMakeCommand.php
@@ -35,7 +35,7 @@ class PolicyMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.policies.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.policies.path', 'app/Policies'));
+        return config('modules.paths.generator.policies.namespace', $this->getPathNamespace(config('modules.paths.generator.policies.path', 'app/Policies')));
     }
 
     /**

--- a/src/Commands/Make/PolicyMakeCommand.php
+++ b/src/Commands/Make/PolicyMakeCommand.php
@@ -35,8 +35,7 @@ class PolicyMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.policies.namespace')
-            ?? ltrim(config('modules.paths.generator.policies.path', 'Policies'), config('modules.paths.app_folder', ''));
+        return config('modules.paths.generator.policies.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.policies.path', 'app/Policies'));
     }
 
     /**

--- a/src/Commands/Make/ProviderMakeCommand.php
+++ b/src/Commands/Make/ProviderMakeCommand.php
@@ -37,8 +37,7 @@ class ProviderMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.provider.namespace')
-            ?? ltrim(config('modules.paths.generator.provider.path', 'Providers'), config('modules.paths.app_folder', ''));
+        return config('modules.paths.generator.provider.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.provider.path', 'app/Providers'));
     }
 
     /**

--- a/src/Commands/Make/ProviderMakeCommand.php
+++ b/src/Commands/Make/ProviderMakeCommand.php
@@ -37,7 +37,7 @@ class ProviderMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.provider.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.provider.path', 'app/Providers'));
+        return config('modules.paths.generator.provider.namespace', $this->getPathNamespace(config('modules.paths.generator.provider.path', 'app/Providers')));
     }
 
     /**

--- a/src/Commands/Make/RequestMakeCommand.php
+++ b/src/Commands/Make/RequestMakeCommand.php
@@ -35,7 +35,7 @@ class RequestMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.request.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.request.path', 'app/Http/Requests'));
+        return config('modules.paths.generator.request.namespace', $this->getPathNamespace(config('modules.paths.generator.request.path', 'app/Http/Requests')));
     }
 
     /**

--- a/src/Commands/Make/RequestMakeCommand.php
+++ b/src/Commands/Make/RequestMakeCommand.php
@@ -35,8 +35,7 @@ class RequestMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.request.namespace')
-            ?? ltrim(config('modules.paths.generator.request.path', 'Http/Requests'), config('modules.paths.app_folder', ''));
+        return config('modules.paths.generator.request.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.request.path', 'app/Http/Requests'));
     }
 
     /**

--- a/src/Commands/Make/ResourceMakeCommand.php
+++ b/src/Commands/Make/ResourceMakeCommand.php
@@ -19,7 +19,7 @@ class ResourceMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.resource.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.resource.path', 'app/Transformers'));
+        return config('modules.paths.generator.resource.namespace', $this->getPathNamespace(config('modules.paths.generator.resource.path', 'app/Transformers')));
     }
 
     /**

--- a/src/Commands/Make/ResourceMakeCommand.php
+++ b/src/Commands/Make/ResourceMakeCommand.php
@@ -19,8 +19,7 @@ class ResourceMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.resource.namespace')
-            ?? ltrim(config('modules.paths.generator.resource.path', 'Transformers'), config('modules.paths.app_folder', ''));
+        return config('modules.paths.generator.resource.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.resource.path', 'app/Transformers'));
     }
 
     /**

--- a/src/Commands/Make/RouteProviderMakeCommand.php
+++ b/src/Commands/Make/RouteProviderMakeCommand.php
@@ -108,7 +108,7 @@ class RouteProviderMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.provider.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.provider.path', 'app/Providers'));
+        return config('modules.paths.generator.provider.namespace', $this->getPathNamespace(config('modules.paths.generator.provider.path', 'app/Providers')));
     }
 
     /**
@@ -116,6 +116,6 @@ class RouteProviderMakeCommand extends GeneratorCommand
      */
     private function getControllerNameSpace(): string
     {
-        return config('modules.paths.generator.controller.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.controller.path', 'app/Http/Controllers'));
+        return config('modules.paths.generator.controller.namespace', $this->getPathNamespace(config('modules.paths.generator.controller.path', 'app/Http/Controllers')));
     }
 }

--- a/src/Commands/Make/RouteProviderMakeCommand.php
+++ b/src/Commands/Make/RouteProviderMakeCommand.php
@@ -95,7 +95,7 @@ class RouteProviderMakeCommand extends GeneratorCommand
      */
     protected function getWebRoutesPath()
     {
-        return '/' . $this->laravel['modules']->config('stubs.files.routes/web', 'Routes/web.php');
+        return '/' . $this->laravel['modules']->config('stubs.files.routes/web', 'routes/web.php');
     }
 
     /**
@@ -103,13 +103,12 @@ class RouteProviderMakeCommand extends GeneratorCommand
      */
     protected function getApiRoutesPath()
     {
-        return '/' . $this->laravel['modules']->config('stubs.files.routes/api', 'Routes/api.php');
+        return '/' . $this->laravel['modules']->config('stubs.files.routes/api', 'routes/api.php');
     }
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.provider.namespace')
-            ?? ltrim(config('modules.paths.generator.provider.path', 'Providers'), config('modules.paths.app_folder', ''));
+        return config('modules.paths.generator.provider.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.provider.path', 'app/Providers'));
     }
 
     /**
@@ -117,8 +116,6 @@ class RouteProviderMakeCommand extends GeneratorCommand
      */
     private function getControllerNameSpace(): string
     {
-        $module = $this->laravel['modules'];
-
-        return str_replace('/', '\\', $module->config('paths.generator.controller.namespace') ?: $module->config('paths.generator.controller.path', 'Controller'));
+        return config('modules.paths.generator.controller.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.controller.path', 'app/Http/Controllers'));
     }
 }

--- a/src/Commands/Make/RuleMakeCommand.php
+++ b/src/Commands/Make/RuleMakeCommand.php
@@ -30,7 +30,7 @@ class RuleMakeCommand extends GeneratorCommand
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.rules.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.rules.path', 'app/Rules'));
+        return config('modules.paths.generator.rules.namespace', $this->getPathNamespace(config('modules.paths.generator.rules.path', 'app/Rules')));
     }
 
     /**

--- a/src/Commands/Make/RuleMakeCommand.php
+++ b/src/Commands/Make/RuleMakeCommand.php
@@ -15,37 +15,28 @@ class RuleMakeCommand extends GeneratorCommand
 
     /**
      * The name of argument name.
-     *
-     * @var string
      */
     protected $argumentName = 'name';
 
     /**
      * The console command name.
-     *
-     * @var string
      */
     protected $name = 'module:make-rule';
 
     /**
      * The console command description.
-     *
-     * @var string
      */
     protected $description = 'Create a new validation rule for the specified module.';
 
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.rules.namespace')
-            ?? ltrim(config('modules.paths.generator.rules.path', 'Rules'), config('modules.paths.app_folder', ''));
+        return config('modules.paths.generator.rules.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.rules.path', 'app/Rules'));
     }
 
     /**
      * Get the console command arguments.
-     *
-     * @return array
      */
-    protected function getArguments()
+    protected function getArguments(): array
     {
         return [
             ['name', InputArgument::REQUIRED, 'The name of the rule class.'],
@@ -55,19 +46,14 @@ class RuleMakeCommand extends GeneratorCommand
 
     /**
      * Get the console command options.
-     *
-     * @return array
      */
-    protected function getOptions()
+    protected function getOptions(): array
     {
         return [
             ['implicit', 'i', InputOption::VALUE_NONE, 'Generate an implicit rule'],
         ];
     }
 
-    /**
-     * @return mixed
-     */
     protected function getTemplateContents()
     {
         $module = $this->laravel['modules']->findOrFail($this->getModuleName());
@@ -82,9 +68,6 @@ class RuleMakeCommand extends GeneratorCommand
         ]))->render();
     }
 
-    /**
-     * @return mixed
-     */
     protected function getDestinationFilePath()
     {
         $path = $this->laravel['modules']->getModulePath($this->getModuleName());
@@ -94,10 +77,7 @@ class RuleMakeCommand extends GeneratorCommand
         return $path . $rulePath->getPath() . '/' . $this->getFileName() . '.php';
     }
 
-    /**
-     * @return string
-     */
-    private function getFileName()
+    private function getFileName(): string
     {
         return Str::studly($this->argument('name'));
     }

--- a/src/Commands/Make/SeedMakeCommand.php
+++ b/src/Commands/Make/SeedMakeCommand.php
@@ -97,6 +97,6 @@ class SeedMakeCommand extends GeneratorCommand
      */
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.seeder.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.seeder.path', 'database/seeders'));
+        return config('modules.paths.generator.seeder.namespace', $this->getPathNamespace(config('modules.paths.generator.seeder.path', 'database/seeders')));
     }
 }

--- a/src/Commands/Make/SeedMakeCommand.php
+++ b/src/Commands/Make/SeedMakeCommand.php
@@ -97,7 +97,6 @@ class SeedMakeCommand extends GeneratorCommand
      */
     public function getDefaultNamespace(): string
     {
-        return config('modules.paths.generator.seeder.namespace')
-            ?? ltrim(config('modules.paths.generator.seeder.path', 'Database/Seeders'), config('modules.paths.app_folder', ''));
+        return config('modules.paths.generator.seeder.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.seeder.path', 'database/seeders'));
     }
 }

--- a/src/Commands/Make/TestMakeCommand.php
+++ b/src/Commands/Make/TestMakeCommand.php
@@ -20,12 +20,10 @@ class TestMakeCommand extends GeneratorCommand
     public function getDefaultNamespace(): string
     {
         if ($this->option('feature')) {
-            return config('modules.paths.generator.test-feature.namespace')
-                ?? config('modules.paths.generator.test-feature.path', 'tests/Feature');
+            return config('modules.paths.generator.test-feature.namespace', config('modules.paths.generator.test-feature.path', 'tests/Feature'));
         }
 
-        return config('modules.paths.generator.test-unit.namespace')
-            ?? config('modules.paths.generator.test-unit.path', 'tests/Unit');
+        return config('modules.paths.generator.test-unit.namespace', config('modules.paths.generator.test-unit.path', 'tests/Unit'));
     }
 
     /**

--- a/src/Commands/stubs/composer.stub
+++ b/src/Commands/stubs/composer.stub
@@ -17,7 +17,7 @@
     },
     "autoload": {
         "psr-4": {
-            "$MODULE_NAMESPACE$\\$STUDLY_NAME$\\": "app/",
+            "$MODULE_NAMESPACE$\\$STUDLY_NAME$\\App\\": "app/",
             "$MODULE_NAMESPACE$\\$STUDLY_NAME$\\Database\\Factories\\": "database/factories/",
             "$MODULE_NAMESPACE$\\$STUDLY_NAME$\\Database\\Seeders\\": "database/seeders/"
         }

--- a/src/Commands/stubs/controller.stub
+++ b/src/Commands/stubs/controller.stub
@@ -3,9 +3,7 @@
 namespace $CLASS_NAMESPACE$;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class $CLASS$ extends Controller
 {
@@ -28,7 +26,7 @@ class $CLASS$ extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request): RedirectResponse
+    public function store(Request $request)
     {
         //
     }
@@ -52,7 +50,7 @@ class $CLASS$ extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id): RedirectResponse
+    public function update(Request $request, $id)
     {
         //
     }

--- a/src/Commands/stubs/model.stub
+++ b/src/Commands/stubs/model.stub
@@ -15,8 +15,8 @@ class $CLASS$ extends Model
      */
     protected $fillable = $FILLABLE$;
 
-    protected static function newFactory(): $NAME$Factory
+    protected static function newFactory()
     {
-        //return $NAME$Factory::new();
+        // return $NAME$Factory::new();
     }
 }

--- a/src/Commands/stubs/scaffold/provider.stub
+++ b/src/Commands/stubs/scaffold/provider.stub
@@ -4,6 +4,7 @@ namespace $NAMESPACE$;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 
 class $CLASS$ extends ServiceProvider
 {
@@ -88,8 +89,9 @@ class $CLASS$ extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
 
-        $componentNamespace = str_replace('/', '\\', config('modules.namespace').'\\'.$this->moduleName.'\\'.ltrim(config('modules.paths.generator.component-class.path'), config('modules.paths.app_folder','')));
-        Blade::componentNamespace($componentNamespace, $this->moduleNameLower);
+        $path = config('modules.namespace').'\\'.$this->moduleName.'\\'.config('modules.paths.generator.component-class.path');
+        $namespace = str_replace('/', '\\', collect(explode('/', $path))->map(fn ($dir) => Str::studly($dir))->implode('/'));
+        Blade::componentNamespace($namespace, $this->moduleNameLower);
     }
 
     /**

--- a/src/Generators/ModuleGenerator.php
+++ b/src/Generators/ModuleGenerator.php
@@ -558,12 +558,11 @@ class ModuleGenerator extends Generator
         $studlyName = $this->getStudlyNameReplacement();
         $class = "{$studlyName}ServiceProvider";
 
-        $provider_namespace = str_replace('\\', '\\\\', config('modules.paths.generator.provider.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.provider.path', 'app/Providers')));
+        $provider_namespace = str_replace('\\', '\\\\', config('modules.paths.generator.provider.namespace', $this->getPathNamespace(config('modules.paths.generator.provider.path', 'app/Providers'))));
         $provider = '"' . $namespace . '\\\\' . $studlyName . '\\\\' . $provider_namespace . '\\\\' . $class  . '"';
 
         $content = str_replace($provider, '', $content);
 
-        // dd($namespace);
         $this->filesystem->put($path, $content);
     }
 

--- a/src/Generators/ModuleGenerator.php
+++ b/src/Generators/ModuleGenerator.php
@@ -277,12 +277,8 @@ class ModuleGenerator extends Generator
 
     /**
      * Set the module instance.
-     *
-     * @param mixed $module
-     *
-     * @return $this
      */
-    public function setModule($module)
+    public function setModule($module): self
     {
         $this->module = $module;
 
@@ -291,12 +287,8 @@ class ModuleGenerator extends Generator
 
     /**
      * Setting the author from the command
-     *
-     * @param string|null $name
-     * @param string|null $email
-     * @return $this
      */
-    function setAuthor(string $name = null, string $email = null)
+    function setAuthor(?string $name = null, ?string $email = null): self
     {
         $this->author['name'] = $name;
         $this->author['email'] = $email;
@@ -306,11 +298,8 @@ class ModuleGenerator extends Generator
 
     /**
      * Installing vendor from the command
-     *
-     * @param string|null $vendor
-     * @return $this
      */
-    function setVendor(string $vendor = null)
+    function setVendor(?string $vendor = null): self
     {
         $this->vendor = $vendor;
 
@@ -319,32 +308,24 @@ class ModuleGenerator extends Generator
 
     /**
      * Get the list of folders will created.
-     *
-     * @return array
      */
-    public function getFolders()
+    public function getFolders(): array
     {
         return $this->module->config('paths.generator');
     }
 
     /**
      * Get the list of files will created.
-     *
-     * @return array
      */
-    public function getFiles()
+    public function getFiles(): array
     {
         return $this->module->config('stubs.files');
     }
 
     /**
      * Set force status.
-     *
-     * @param bool|int $force
-     *
-     * @return $this
      */
-    public function setForce($force)
+    public function setForce(bool|int $force): self
     {
         $this->force = $force;
 
@@ -414,10 +395,8 @@ class ModuleGenerator extends Generator
 
     /**
      * Generate git keep to the specified path.
-     *
-     * @param string $path
      */
-    public function generateGitKeep($path)
+    public function generateGitKeep(string $path)
     {
         $this->filesystem->put($path . '/.gitkeep', '');
     }
@@ -500,12 +479,8 @@ class ModuleGenerator extends Generator
 
     /**
      * Get the contents of the specified stub file by given stub name.
-     *
-     * @param $stub
-     *
-     * @return string
      */
-    protected function getStubContents($stub)
+    protected function getStubContents($stub): string
     {
         return (new Stub(
             '/' . $stub . '.stub',
@@ -524,12 +499,8 @@ class ModuleGenerator extends Generator
 
     /**
      * Get array replacement for the specified stub.
-     *
-     * @param $stub
-     *
-     * @return array
      */
-    protected function getReplacement($stub)
+    protected function getReplacement($stub): array
     {
         $replacements = $this->module->config('stubs.replacements');
 
@@ -598,70 +569,56 @@ class ModuleGenerator extends Generator
 
     /**
      * Get the module name in lower case.
-     *
-     * @return string
      */
-    protected function getLowerNameReplacement()
+    protected function getLowerNameReplacement(): string
     {
         return strtolower($this->getName());
     }
 
     /**
      * Get the module name in studly case.
-     *
-     * @return string
      */
-    protected function getStudlyNameReplacement()
+    protected function getStudlyNameReplacement(): string
     {
         return $this->getName();
     }
 
     /**
      * Get replacement for $VENDOR$.
-     *
-     * @return string
      */
-    protected function getVendorReplacement()
+    protected function getVendorReplacement(): string
     {
         return $this->vendor ?: $this->module->config('composer.vendor');
     }
 
     /**
      * Get replacement for $MODULE_NAMESPACE$.
-     *
-     * @return string
      */
-    protected function getModuleNamespaceReplacement()
+    protected function getModuleNamespaceReplacement(): string
     {
         return str_replace('\\', '\\\\', $this->module->config('namespace'));
     }
 
     /**
      * Get replacement for $CONTROLLER_NAMESPACE$.
-     *
-     * @return string
      */
     private function getControllerNamespaceReplacement(): string
     {
-        return str_replace('/', '\\', $this->module->config('paths.generator.controller.namespace') ?: ltrim($this->module->config('paths.generator.controller.path', 'Controller'), config('modules.paths.app_folder')));
+        return $this->module->config('paths.generator.controller.namespace') ?? $this->getPathNamespace($this->module->config('paths.generator.controller.path', 'app/Http/Controllers'));
     }
 
     /**
      * Get replacement for $AUTHOR_NAME$.
-     *
-     * @return string
      */
-    protected function getAuthorNameReplacement()
+    protected function getAuthorNameReplacement(): string
     {
         return $this->author['name'] ?: $this->module->config('composer.author.name');
     }
 
     /**
      * Get replacement for $AUTHOR_EMAIL$.
-     *
-     * @return string
      */
-    protected function getAuthorEmailReplacement()
+    protected function getAuthorEmailReplacement(): string
     {
         return $this->author['email'] ?: $this->module->config('composer.author.email');
     }

--- a/src/Generators/ModuleGenerator.php
+++ b/src/Generators/ModuleGenerator.php
@@ -546,6 +546,7 @@ class ModuleGenerator extends Generator
                 $keys[] = 'PROVIDER_NAMESPACE';
             }
         }
+
         foreach ($keys as $key) {
             if (method_exists($this, $method = 'get' . ucfirst(Str::studly(strtolower($key))) . 'Replacement')) {
                 $replaces[$key] = $this->$method();
@@ -584,11 +585,14 @@ class ModuleGenerator extends Generator
         $content = $this->filesystem->get($path);
         $namespace = $this->getModuleNamespaceReplacement();
         $studlyName = $this->getStudlyNameReplacement();
+        $class = "{$studlyName}ServiceProvider";
 
-        $provider = '"' . $namespace . '\\\\' . $studlyName . '\\\\Providers\\\\' . $studlyName . 'ServiceProvider"';
+        $provider_namespace = str_replace('\\', '\\\\', config('modules.paths.generator.provider.namespace') ?? $this->getPathNamespace(config('modules.paths.generator.provider.path', 'app/Providers')));
+        $provider = '"' . $namespace . '\\\\' . $studlyName . '\\\\' . $provider_namespace . '\\\\' . $class  . '"';
 
         $content = str_replace($provider, '', $content);
 
+        // dd($namespace);
         $this->filesystem->put($path, $content);
     }
 
@@ -665,5 +669,12 @@ class ModuleGenerator extends Generator
     protected function getProviderNamespaceReplacement(): string
     {
         return str_replace('\\', '\\\\', GenerateConfigReader::read('provider')->getNamespace());
+    }
+
+    public function getPathNamespace(string $path): string
+    {
+        $path = str_replace('/', '\\', collect(explode('/', $path))->map(fn ($dir) => Str::studly($dir))->implode('/'));
+
+        return $path;
     }
 }

--- a/src/ModulesServiceProvider.php
+++ b/src/ModulesServiceProvider.php
@@ -44,7 +44,7 @@ abstract class ModulesServiceProvider extends ServiceProvider
         ], 'config');
 
         $this->publishes([
-            $stubsPath => base_path('stubs/nwidart-stubs'),
+            $stubsPath => base_path('stubs/modules'),
         ], 'stubs');
 
         $this->publishes([

--- a/src/Support/Config/GeneratorPath.php
+++ b/src/Support/Config/GeneratorPath.php
@@ -2,6 +2,8 @@
 
 namespace Nwidart\Modules\Support\Config;
 
+use Illuminate\Support\Str;
+
 class GeneratorPath
 {
     private $path;
@@ -13,7 +15,7 @@ class GeneratorPath
         if (is_array($config)) {
             $this->path      = $config['path'];
             $this->generate  = $config['generate'];
-            $this->namespace = $config['namespace'] ?? $this->convertPathToNamespace($config['path']);
+            $this->namespace = $config['namespace'] ?? $this->getPathNamespace($config['path']);
 
             return;
         }
@@ -37,8 +39,8 @@ class GeneratorPath
         return $this->namespace;
     }
 
-    private function convertPathToNamespace($path)
+    public function getPathNamespace(string $path): string
     {
-        return str_replace('/', '\\', ltrim($path, config('modules.paths.app_folder', '')));
+        return str_replace('/', '\\', collect(explode('/', $path))->map(fn ($dir) => Str::studly($dir))->implode('/'));
     }
 }

--- a/tests/Commands/__snapshots__/ChannelMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/__snapshots__/ChannelMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Broadcasting;
+namespace Modules\Blog\App\Broadcasting;
 
 class WelcomeChannel
 {

--- a/tests/Commands/__snapshots__/CommandMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/__snapshots__/CommandMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\CustomCommands;
+namespace Modules\Blog\App\CustomCommands;
 
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;

--- a/tests/Commands/__snapshots__/CommandMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/__snapshots__/CommandMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Console;
+namespace Modules\Blog\App\Console;
 
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;

--- a/tests/Commands/__snapshots__/CommandMakeCommandTest__test_it_uses_set_command_name_in_class__1.txt
+++ b/tests/Commands/__snapshots__/CommandMakeCommandTest__test_it_uses_set_command_name_in_class__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Console;
+namespace Modules\Blog\App\Console;
 
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;

--- a/tests/Commands/__snapshots__/ComponentClassMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/__snapshots__/ComponentClassMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\View\Components\newDirectory;
+namespace Modules\Blog\View\Components\NewDirectory;
 
 use Illuminate\View\Component;
 use Illuminate\View\View;

--- a/tests/Commands/__snapshots__/ComponentClassMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/__snapshots__/ComponentClassMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\View\Components;
+namespace Modules\Blog\App\View\Components;
 
 use Illuminate\View\Component;
 use Illuminate\View\View;

--- a/tests/Commands/__snapshots__/ControllerMakeCommandTest__test_it_appends_controller_to_class_name_if_not_present__1.txt
+++ b/tests/Commands/__snapshots__/ControllerMakeCommandTest__test_it_appends_controller_to_class_name_if_not_present__1.txt
@@ -1,11 +1,9 @@
 <?php
 
-namespace Modules\Blog\Http\Controllers;
+namespace Modules\Blog\App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class MyController extends Controller
 {
@@ -28,7 +26,7 @@ class MyController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request): RedirectResponse
+    public function store(Request $request)
     {
         //
     }
@@ -52,7 +50,7 @@ class MyController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id): RedirectResponse
+    public function update(Request $request, $id)
     {
         //
     }

--- a/tests/Commands/__snapshots__/ControllerMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/__snapshots__/ControllerMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -3,9 +3,7 @@
 namespace Modules\Blog\Controllers;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class MyController extends Controller
 {
@@ -28,7 +26,7 @@ class MyController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request): RedirectResponse
+    public function store(Request $request)
     {
         //
     }
@@ -52,7 +50,7 @@ class MyController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id): RedirectResponse
+    public function update(Request $request, $id)
     {
         //
     }

--- a/tests/Commands/__snapshots__/ControllerMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/__snapshots__/ControllerMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
@@ -3,9 +3,7 @@
 namespace Modules\Blog\Controllers;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class MyController extends Controller
 {
@@ -28,7 +26,7 @@ class MyController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request): RedirectResponse
+    public function store(Request $request)
     {
         //
     }
@@ -52,7 +50,7 @@ class MyController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id): RedirectResponse
+    public function update(Request $request, $id)
     {
         //
     }

--- a/tests/Commands/__snapshots__/ControllerMakeCommandTest__test_it_can_generate_a_controller_in_sub_namespace_with_correct_generated_file__1.txt
+++ b/tests/Commands/__snapshots__/ControllerMakeCommandTest__test_it_can_generate_a_controller_in_sub_namespace_with_correct_generated_file__1.txt
@@ -1,11 +1,9 @@
 <?php
 
-namespace Modules\Blog\Http\Controllers\Api;
+namespace Modules\Blog\App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class MyController extends Controller
 {
@@ -28,7 +26,7 @@ class MyController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request): RedirectResponse
+    public function store(Request $request)
     {
         //
     }
@@ -52,7 +50,7 @@ class MyController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id): RedirectResponse
+    public function update(Request $request, $id)
     {
         //
     }

--- a/tests/Commands/__snapshots__/ControllerMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/__snapshots__/ControllerMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -1,11 +1,9 @@
 <?php
 
-namespace Modules\Blog\Http\Controllers;
+namespace Modules\Blog\App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class MyController extends Controller
 {
@@ -28,7 +26,7 @@ class MyController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request): RedirectResponse
+    public function store(Request $request)
     {
         //
     }
@@ -52,7 +50,7 @@ class MyController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id): RedirectResponse
+    public function update(Request $request, $id)
     {
         //
     }

--- a/tests/Commands/__snapshots__/ControllerMakeCommandTest__test_it_generates_a_plain_controller__1.txt
+++ b/tests/Commands/__snapshots__/ControllerMakeCommandTest__test_it_generates_a_plain_controller__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Http\Controllers;
+namespace Modules\Blog\App\Http\Controllers;
 
 use Illuminate\Routing\Controller;
 

--- a/tests/Commands/__snapshots__/ControllerMakeCommandTest__test_it_generates_an_api_controller__1.txt
+++ b/tests/Commands/__snapshots__/ControllerMakeCommandTest__test_it_generates_an_api_controller__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Http\Controllers;
+namespace Modules\Blog\App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;

--- a/tests/Commands/__snapshots__/EventMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/__snapshots__/EventMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Events;
+namespace Modules\Blog\App\Events;
 
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Broadcasting\InteractsWithSockets;

--- a/tests/Commands/__snapshots__/FactoryMakeCommandTest__test_it_makes_factory__1.txt
+++ b/tests/Commands/__snapshots__/FactoryMakeCommandTest__test_it_makes_factory__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\database\factories;
+namespace Modules\Blog\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -9,7 +9,7 @@ class PostFactory extends Factory
     /**
      * The name of the factory's corresponding model.
      */
-    protected $model = \Modules\Blog\Models\Post::class;
+    protected $model = \Modules\Blog\App\Models\Post::class;
 
     /**
      * Define the model's default state.

--- a/tests/Commands/__snapshots__/JobMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/__snapshots__/JobMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Jobs;
+namespace Modules\Blog\App\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Queue\SerializesModels;

--- a/tests/Commands/__snapshots__/JobMakeCommandTest__test_it_generated_correct_sync_job_file_with_content__1.txt
+++ b/tests/Commands/__snapshots__/JobMakeCommandTest__test_it_generated_correct_sync_job_file_with_content__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Jobs;
+namespace Modules\Blog\App\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Foundation\Bus\Dispatchable;

--- a/tests/Commands/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_queued_duck_event_with_content__1.txt
+++ b/tests/Commands/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_queued_duck_event_with_content__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Listeners;
+namespace Modules\Blog\App\Listeners;
 
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;

--- a/tests/Commands/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_queued_event_in_a_subdirectory_with_content__1.txt
+++ b/tests/Commands/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_queued_event_in_a_subdirectory_with_content__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Listeners;
+namespace Modules\Blog\App\Listeners;
 
 use Modules\Blog\app\Events\User\WasCreated;
 use Illuminate\Queue\InteractsWithQueue;

--- a/tests/Commands/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_queued_event_with_content__1.txt
+++ b/tests/Commands/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_queued_event_with_content__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Listeners;
+namespace Modules\Blog\App\Listeners;
 
 use Modules\Blog\app\Events\UserWasCreated;
 use Illuminate\Queue\InteractsWithQueue;

--- a/tests/Commands/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_sync_duck_event_with_content__1.txt
+++ b/tests/Commands/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_sync_duck_event_with_content__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Listeners;
+namespace Modules\Blog\App\Listeners;
 
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;

--- a/tests/Commands/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_sync_event_in_a_subdirectory_with_content__1.txt
+++ b/tests/Commands/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_sync_event_in_a_subdirectory_with_content__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Listeners;
+namespace Modules\Blog\App\Listeners;
 
 use Modules\Blog\app\Events\User\WasCreated;
 use Illuminate\Queue\InteractsWithQueue;

--- a/tests/Commands/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_sync_event_with_content__1.txt
+++ b/tests/Commands/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_sync_event_with_content__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Listeners;
+namespace Modules\Blog\App\Listeners;
 
 use Modules\Blog\app\Events\UserWasCreated;
 use Illuminate\Queue\InteractsWithQueue;

--- a/tests/Commands/__snapshots__/MailMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/__snapshots__/MailMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Emails;
+namespace Modules\Blog\App\Emails;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;

--- a/tests/Commands/__snapshots__/MiddlewareMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/__snapshots__/MiddlewareMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Http\Middleware;
+namespace Modules\Blog\App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;

--- a/tests/Commands/__snapshots__/ModelMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/__snapshots__/ModelMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -15,8 +15,8 @@ class Post extends Model
      */
     protected $fillable = [];
 
-    protected static function newFactory(): PostFactory
+    protected static function newFactory()
     {
-        //return PostFactory::new();
+        // return PostFactory::new();
     }
 }

--- a/tests/Commands/__snapshots__/ModelMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/__snapshots__/ModelMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
@@ -15,8 +15,8 @@ class Post extends Model
      */
     protected $fillable = [];
 
-    protected static function newFactory(): PostFactory
+    protected static function newFactory()
     {
-        //return PostFactory::new();
+        // return PostFactory::new();
     }
 }

--- a/tests/Commands/__snapshots__/ModelMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/__snapshots__/ModelMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Models;
+namespace Modules\Blog\App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -15,8 +15,8 @@ class Post extends Model
      */
     protected $fillable = [];
 
-    protected static function newFactory(): PostFactory
+    protected static function newFactory()
     {
-        //return PostFactory::new();
+        // return PostFactory::new();
     }
 }

--- a/tests/Commands/__snapshots__/ModelMakeCommandTest__test_it_generates_controller_and_migration_when_both_flags_are_present__1.txt
+++ b/tests/Commands/__snapshots__/ModelMakeCommandTest__test_it_generates_controller_and_migration_when_both_flags_are_present__1.txt
@@ -1,11 +1,9 @@
 <?php
 
-namespace Modules\Blog\Http\Controllers;
+namespace Modules\Blog\App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class PostController extends Controller
 {
@@ -28,7 +26,7 @@ class PostController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request): RedirectResponse
+    public function store(Request $request)
     {
         //
     }
@@ -52,7 +50,7 @@ class PostController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id): RedirectResponse
+    public function update(Request $request, $id)
     {
         //
     }

--- a/tests/Commands/__snapshots__/ModelMakeCommandTest__test_it_generates_controller_file_with_model__1.txt
+++ b/tests/Commands/__snapshots__/ModelMakeCommandTest__test_it_generates_controller_file_with_model__1.txt
@@ -1,11 +1,9 @@
 <?php
 
-namespace Modules\Blog\Http\Controllers;
+namespace Modules\Blog\App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class PostController extends Controller
 {
@@ -28,7 +26,7 @@ class PostController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request): RedirectResponse
+    public function store(Request $request)
     {
         //
     }
@@ -52,7 +50,7 @@ class PostController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id): RedirectResponse
+    public function update(Request $request, $id)
     {
         //
     }

--- a/tests/Commands/__snapshots__/ModelMakeCommandTest__test_it_generates_controller_file_with_model_using_shortcut_option__1.txt
+++ b/tests/Commands/__snapshots__/ModelMakeCommandTest__test_it_generates_controller_file_with_model_using_shortcut_option__1.txt
@@ -1,11 +1,9 @@
 <?php
 
-namespace Modules\Blog\Http\Controllers;
+namespace Modules\Blog\App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class PostController extends Controller
 {
@@ -28,7 +26,7 @@ class PostController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request): RedirectResponse
+    public function store(Request $request)
     {
         //
     }
@@ -52,7 +50,7 @@ class PostController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id): RedirectResponse
+    public function update(Request $request, $id)
     {
         //
     }

--- a/tests/Commands/__snapshots__/ModelMakeCommandTest__test_it_generates_correct_fillable_fields__1.txt
+++ b/tests/Commands/__snapshots__/ModelMakeCommandTest__test_it_generates_correct_fillable_fields__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Models;
+namespace Modules\Blog\App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -15,8 +15,8 @@ class Post extends Model
      */
     protected $fillable = ["title","slug"];
 
-    protected static function newFactory(): PostFactory
+    protected static function newFactory()
     {
-        //return PostFactory::new();
+        // return PostFactory::new();
     }
 }

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_disable__1.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_disable__1.txt
@@ -1,9 +1,10 @@
 <?php
 
-namespace Modules\Blog\Providers;
+namespace Modules\Blog\App\Providers;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 
 class BlogServiceProvider extends ServiceProvider
 {
@@ -88,8 +89,9 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
 
-        $componentNamespace = str_replace('/', '\\', config('modules.namespace').'\\'.$this->moduleName.'\\'.ltrim(config('modules.paths.generator.component-class.path'), config('modules.paths.app_folder','')));
-        Blade::componentNamespace($componentNamespace, $this->moduleNameLower);
+        $path = config('modules.namespace').'\\'.$this->moduleName.'\\'.config('modules.paths.generator.component-class.path');
+        $namespace = str_replace('/', '\\', collect(explode('/', $path))->map(fn ($dir) => Str::studly($dir))->implode('/'));
+        Blade::componentNamespace($namespace, $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__1.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__1.txt
@@ -1,9 +1,10 @@
 <?php
 
-namespace Modules\Blog\Providers;
+namespace Modules\Blog\App\Providers;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 
 class BlogServiceProvider extends ServiceProvider
 {
@@ -88,8 +89,9 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
 
-        $componentNamespace = str_replace('/', '\\', config('modules.namespace').'\\'.$this->moduleName.'\\'.ltrim(config('modules.paths.generator.component-class.path'), config('modules.paths.app_folder','')));
-        Blade::componentNamespace($componentNamespace, $this->moduleNameLower);
+        $path = config('modules.namespace').'\\'.$this->moduleName.'\\'.config('modules.paths.generator.component-class.path');
+        $namespace = str_replace('/', '\\', collect(explode('/', $path))->map(fn ($dir) => Str::studly($dir))->implode('/'));
+        Blade::componentNamespace($namespace, $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__2.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__2.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Providers;
+namespace Modules\Blog\App\Providers;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__1.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__1.txt
@@ -1,9 +1,10 @@
 <?php
 
-namespace Modules\Blog\Providers;
+namespace Modules\Blog\App\Providers;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 
 class BlogServiceProvider extends ServiceProvider
 {
@@ -88,8 +89,9 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
 
-        $componentNamespace = str_replace('/', '\\', config('modules.namespace').'\\'.$this->moduleName.'\\'.ltrim(config('modules.paths.generator.component-class.path'), config('modules.paths.app_folder','')));
-        Blade::componentNamespace($componentNamespace, $this->moduleNameLower);
+        $path = config('modules.namespace').'\\'.$this->moduleName.'\\'.config('modules.paths.generator.component-class.path');
+        $namespace = str_replace('/', '\\', collect(explode('/', $path))->map(fn ($dir) => Str::studly($dir))->implode('/'));
+        Blade::componentNamespace($namespace, $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__2.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__2.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Http\Controllers;
+namespace Modules\Blog\App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__3.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__3.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\database\seeders;
+namespace Modules\Blog\Database\Seeders;
 
 use Illuminate\Database\Seeder;
 

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__4.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__4.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Providers;
+namespace Modules\Blog\App\Providers;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_route_file__1.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_route_file__1.txt
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use Modules\Blog\Http\Controllers\BlogController;
+use Modules\Blog\App\Http\Controllers\BlogController;
 
 /*
  *--------------------------------------------------------------------------

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_correct_composerjson_file__1.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_correct_composerjson_file__1.txt
@@ -17,7 +17,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Modules\\Blog\\": "app/",
+            "Modules\\Blog\\App\\": "app/",
             "Modules\\Blog\\Database\\Factories\\": "database/factories/",
             "Modules\\Blog\\Database\\Seeders\\": "database/seeders/"
         }

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_files__1.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_files__1.txt
@@ -5,7 +5,7 @@
     "keywords": [],
     "priority": 0,
     "providers": [
-        "Modules\\Blog\\Providers\\BlogServiceProvider"
+        "Modules\\Blog\\App\\Providers\\BlogServiceProvider"
     ],
     "files": []
 }

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_namespace_using_studly_case__1.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_namespace_using_studly_case__1.txt
@@ -1,9 +1,10 @@
 <?php
 
-namespace Modules\ModuleName\Providers;
+namespace Modules\ModuleName\App\Providers;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 
 class ModuleNameServiceProvider extends ServiceProvider
 {
@@ -88,8 +89,9 @@ class ModuleNameServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
 
-        $componentNamespace = str_replace('/', '\\', config('modules.namespace').'\\'.$this->moduleName.'\\'.ltrim(config('modules.paths.generator.component-class.path'), config('modules.paths.app_folder','')));
-        Blade::componentNamespace($componentNamespace, $this->moduleNameLower);
+        $path = config('modules.namespace').'\\'.$this->moduleName.'\\'.config('modules.paths.generator.component-class.path');
+        $namespace = str_replace('/', '\\', collect(explode('/', $path))->map(fn ($dir) => Str::studly($dir))->implode('/'));
+        Blade::componentNamespace($namespace, $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__1.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__1.txt
@@ -1,9 +1,10 @@
 <?php
 
-namespace Modules\Blog\Providers;
+namespace Modules\Blog\App\Providers;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 
 class BlogServiceProvider extends ServiceProvider
 {
@@ -88,8 +89,9 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
 
-        $componentNamespace = str_replace('/', '\\', config('modules.namespace').'\\'.$this->moduleName.'\\'.ltrim(config('modules.paths.generator.component-class.path'), config('modules.paths.app_folder','')));
-        Blade::componentNamespace($componentNamespace, $this->moduleNameLower);
+        $path = config('modules.namespace').'\\'.$this->moduleName.'\\'.config('modules.paths.generator.component-class.path');
+        $namespace = str_replace('/', '\\', collect(explode('/', $path))->map(fn ($dir) => Str::studly($dir))->implode('/'));
+        Blade::componentNamespace($namespace, $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__2.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__2.txt
@@ -1,11 +1,9 @@
 <?php
 
-namespace Modules\Blog\Http\Controllers;
+namespace Modules\Blog\App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class BlogController extends Controller
 {
@@ -28,7 +26,7 @@ class BlogController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request): RedirectResponse
+    public function store(Request $request)
     {
         //
     }
@@ -52,7 +50,7 @@ class BlogController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id): RedirectResponse
+    public function update(Request $request, $id)
     {
         //
     }

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__3.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__3.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\database\seeders;
+namespace Modules\Blog\Database\Seeders;
 
 use Illuminate\Database\Seeder;
 

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__4.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__4.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Providers;
+namespace Modules\Blog\App\Providers;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__1.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__1.txt
@@ -1,9 +1,10 @@
 <?php
 
-namespace Modules\Blog\Providers;
+namespace Modules\Blog\App\Providers;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 
 class BlogServiceProvider extends ServiceProvider
 {
@@ -88,8 +89,9 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
 
-        $componentNamespace = str_replace('/', '\\', config('modules.namespace').'\\'.$this->moduleName.'\\'.ltrim(config('modules.paths.generator.component-class.path'), config('modules.paths.app_folder','')));
-        Blade::componentNamespace($componentNamespace, $this->moduleNameLower);
+        $path = config('modules.namespace').'\\'.$this->moduleName.'\\'.config('modules.paths.generator.component-class.path');
+        $namespace = str_replace('/', '\\', collect(explode('/', $path))->map(fn ($dir) => Str::studly($dir))->implode('/'));
+        Blade::componentNamespace($namespace, $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__2.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__2.txt
@@ -1,11 +1,9 @@
 <?php
 
-namespace Modules\Blog\Http\Controllers;
+namespace Modules\Blog\App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class BlogController extends Controller
 {
@@ -28,7 +26,7 @@ class BlogController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request): RedirectResponse
+    public function store(Request $request)
     {
         //
     }
@@ -52,7 +50,7 @@ class BlogController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id): RedirectResponse
+    public function update(Request $request, $id)
     {
         //
     }

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__3.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__3.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\database\seeders;
+namespace Modules\Blog\Database\Seeders;
 
 use Illuminate\Database\Seeder;
 

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__4.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__4.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Providers;
+namespace Modules\Blog\App\Providers;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__1.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__1.txt
@@ -1,9 +1,10 @@
 <?php
 
-namespace Modules\Blog\Providers;
+namespace Modules\Blog\App\Providers;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 
 class BlogServiceProvider extends ServiceProvider
 {
@@ -88,8 +89,9 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
 
-        $componentNamespace = str_replace('/', '\\', config('modules.namespace').'\\'.$this->moduleName.'\\'.ltrim(config('modules.paths.generator.component-class.path'), config('modules.paths.app_folder','')));
-        Blade::componentNamespace($componentNamespace, $this->moduleNameLower);
+        $path = config('modules.namespace').'\\'.$this->moduleName.'\\'.config('modules.paths.generator.component-class.path');
+        $namespace = str_replace('/', '\\', collect(explode('/', $path))->map(fn ($dir) => Str::studly($dir))->implode('/'));
+        Blade::componentNamespace($namespace, $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__2.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__2.txt
@@ -1,11 +1,9 @@
 <?php
 
-namespace Modules\Blog\Http\Controllers;
+namespace Modules\Blog\App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class BlogController extends Controller
 {
@@ -28,7 +26,7 @@ class BlogController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request): RedirectResponse
+    public function store(Request $request)
     {
         //
     }
@@ -52,7 +50,7 @@ class BlogController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id): RedirectResponse
+    public function update(Request $request, $id)
     {
         //
     }

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__3.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__3.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\database\seeders;
+namespace Modules\Blog\Database\Seeders;
 
 use Illuminate\Database\Seeder;
 

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__4.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__4.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Providers;
+namespace Modules\Blog\App\Providers;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_route_file__1.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_route_file__1.txt
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use Modules\Blog\Http\Controllers\BlogController;
+use Modules\Blog\App\Http\Controllers\BlogController;
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generes_module_with_new_provider_location__2.txt
+++ b/tests/Commands/__snapshots__/ModuleMakeCommandTest__test_it_generes_module_with_new_provider_location__2.txt
@@ -17,7 +17,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Modules\\Blog\\": "app/",
+            "Modules\\Blog\\App\\": "app/",
             "Modules\\Blog\\Database\\Factories\\": "database/factories/",
             "Modules\\Blog\\Database\\Seeders\\": "database/seeders/"
         }

--- a/tests/Commands/__snapshots__/NotificationMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/__snapshots__/NotificationMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Notifications;
+namespace Modules\Blog\App\Notifications;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;

--- a/tests/Commands/__snapshots__/ObserverMakeCommandTest__test_it_makes_observer__1.txt
+++ b/tests/Commands/__snapshots__/ObserverMakeCommandTest__test_it_makes_observer__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Observers;
+namespace Modules\Blog\App\Observers;
 
 use Modules\Blog\app\Models\Post;
 

--- a/tests/Commands/__snapshots__/PolicyMakeCommandTest__test_it_makes_policy__1.txt
+++ b/tests/Commands/__snapshots__/PolicyMakeCommandTest__test_it_makes_policy__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Policies;
+namespace Modules\Blog\App\Policies;
 
 use Illuminate\Auth\Access\HandlesAuthorization;
 

--- a/tests/Commands/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -4,6 +4,7 @@ namespace Modules\Blog\SuperProviders;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 
 class BlogServiceProvider extends ServiceProvider
 {
@@ -88,8 +89,9 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
 
-        $componentNamespace = str_replace('/', '\\', config('modules.namespace').'\\'.$this->moduleName.'\\'.ltrim(config('modules.paths.generator.component-class.path'), config('modules.paths.app_folder','')));
-        Blade::componentNamespace($componentNamespace, $this->moduleNameLower);
+        $path = config('modules.namespace').'\\'.$this->moduleName.'\\'.config('modules.paths.generator.component-class.path');
+        $namespace = str_replace('/', '\\', collect(explode('/', $path))->map(fn ($dir) => Str::studly($dir))->implode('/'));
+        Blade::componentNamespace($namespace, $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
@@ -4,6 +4,7 @@ namespace Modules\Blog\SuperProviders;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 
 class BlogServiceProvider extends ServiceProvider
 {
@@ -88,8 +89,9 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
 
-        $componentNamespace = str_replace('/', '\\', config('modules.namespace').'\\'.$this->moduleName.'\\'.ltrim(config('modules.paths.generator.component-class.path'), config('modules.paths.app_folder','')));
-        Blade::componentNamespace($componentNamespace, $this->moduleNameLower);
+        $path = config('modules.namespace').'\\'.$this->moduleName.'\\'.config('modules.paths.generator.component-class.path');
+        $namespace = str_replace('/', '\\', collect(explode('/', $path))->map(fn ($dir) => Str::studly($dir))->implode('/'));
+        Blade::componentNamespace($namespace, $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/__snapshots__/ProviderMakeCommandTest__test_it_can_have_custom_migration_resources_location_paths__1.txt
+++ b/tests/Commands/__snapshots__/ProviderMakeCommandTest__test_it_can_have_custom_migration_resources_location_paths__1.txt
@@ -1,9 +1,10 @@
 <?php
 
-namespace Modules\Blog\Providers;
+namespace Modules\Blog\App\Providers;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 
 class BlogServiceProvider extends ServiceProvider
 {
@@ -88,8 +89,9 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
 
-        $componentNamespace = str_replace('/', '\\', config('modules.namespace').'\\'.$this->moduleName.'\\'.ltrim(config('modules.paths.generator.component-class.path'), config('modules.paths.app_folder','')));
-        Blade::componentNamespace($componentNamespace, $this->moduleNameLower);
+        $path = config('modules.namespace').'\\'.$this->moduleName.'\\'.config('modules.paths.generator.component-class.path');
+        $namespace = str_replace('/', '\\', collect(explode('/', $path))->map(fn ($dir) => Str::studly($dir))->implode('/'));
+        Blade::componentNamespace($namespace, $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/__snapshots__/ProviderMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/__snapshots__/ProviderMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Providers;
+namespace Modules\Blog\App\Providers;
 
 use Illuminate\Support\ServiceProvider;
 

--- a/tests/Commands/__snapshots__/ProviderMakeCommandTest__test_it_generates_a_master_service_provider_with_resource_loading__1.txt
+++ b/tests/Commands/__snapshots__/ProviderMakeCommandTest__test_it_generates_a_master_service_provider_with_resource_loading__1.txt
@@ -1,9 +1,10 @@
 <?php
 
-namespace Modules\Blog\Providers;
+namespace Modules\Blog\App\Providers;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 
 class BlogServiceProvider extends ServiceProvider
 {
@@ -88,8 +89,9 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
 
-        $componentNamespace = str_replace('/', '\\', config('modules.namespace').'\\'.$this->moduleName.'\\'.ltrim(config('modules.paths.generator.component-class.path'), config('modules.paths.app_folder','')));
-        Blade::componentNamespace($componentNamespace, $this->moduleNameLower);
+        $path = config('modules.namespace').'\\'.$this->moduleName.'\\'.config('modules.paths.generator.component-class.path');
+        $namespace = str_replace('/', '\\', collect(explode('/', $path))->map(fn ($dir) => Str::studly($dir))->implode('/'));
+        Blade::componentNamespace($namespace, $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/__snapshots__/RequestMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/__snapshots__/RequestMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Http\Requests;
+namespace Modules\Blog\App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/tests/Commands/__snapshots__/ResourceMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/__snapshots__/ResourceMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Http\Resources;
+namespace Modules\Blog\App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\ResourceCollection;

--- a/tests/Commands/__snapshots__/ResourceMakeCommandTest__test_it_can_generate_a_collection_resource_class__1.txt
+++ b/tests/Commands/__snapshots__/ResourceMakeCommandTest__test_it_can_generate_a_collection_resource_class__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Transformers;
+namespace Modules\Blog\App\Transformers;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\ResourceCollection;

--- a/tests/Commands/__snapshots__/ResourceMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/__snapshots__/ResourceMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Transformers;
+namespace Modules\Blog\App\Transformers;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;

--- a/tests/Commands/__snapshots__/RouteProviderMakeCommandTest__test_it_can_overwrite_file__1.txt
+++ b/tests/Commands/__snapshots__/RouteProviderMakeCommandTest__test_it_can_overwrite_file__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Providers;
+namespace Modules\Blog\App\Providers;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;

--- a/tests/Commands/__snapshots__/RouteProviderMakeCommandTest__test_it_can_overwrite_route_file_names__1.txt
+++ b/tests/Commands/__snapshots__/RouteProviderMakeCommandTest__test_it_can_overwrite_route_file_names__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Providers;
+namespace Modules\Blog\App\Providers;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;

--- a/tests/Commands/__snapshots__/RouteProviderMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/__snapshots__/RouteProviderMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Providers;
+namespace Modules\Blog\App\Providers;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;

--- a/tests/Commands/__snapshots__/RuleMakeCommandTest__test_it_makes_implicit_rule__1.txt
+++ b/tests/Commands/__snapshots__/RuleMakeCommandTest__test_it_makes_implicit_rule__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Rules;
+namespace Modules\Blog\App\Rules;
 
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/tests/Commands/__snapshots__/RuleMakeCommandTest__test_it_makes_rule__1.txt
+++ b/tests/Commands/__snapshots__/RuleMakeCommandTest__test_it_makes_rule__1.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modules\Blog\Rules;
+namespace Modules\Blog\App\Rules;
 
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;


### PR DESCRIPTION
### Issue Fix:
I have resolved the problem with namespace generation where each word wasn't capitalized properly within the paths.

### Reinstatement of app/ Path:
Acknowledging that a previous pull request removed the "App\" path. This path is essential for consistency and compliance with Laravel and PSR-4 conventions. Hence, the "App\" path has been reinstated to ensure adherence to conventions and maintain compatibility with the Laravel structure.

### Consistency and Compliance:
While the removal of the "App\" path may improve namespace aesthetics, it's crucial to maintain consistency and standards which mandate the use of the "App\" prefix for app/ path. Hence, the "App\" path has been reinstated to ensure compliance.

### Thorough Pull Request Review:
This pull request serves as a reminder of the importance of thoroughly reviewing pull requests before merging. By conducting comprehensive reviews, we can prevent the need for such customizations in the future, saving time and ensuring smoother development processes.

### Micro Commit Format:
Implemented commits in a microformat to facilitate easy readability and reviewing. Each commit focuses on a specific change, enhancing clarity and simplifying the review process.

### Clean, Readable, and Consistent Code:
Emphasizing the importance of maintaining clean, readable, and consistent code throughout the project. By adhering to coding standards and best practices, we can enhance code maintainability and collaboration among team members.

Please review the changes carefully to ensure they align with project requirements and standards before merging. Your feedback is greatly appreciated.