### PR TITLE
Add Upgrade Guide Section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ This package is a re-published, re-organised and maintained version of [pingpong
 
 With one big bonus that the original package didn't have: **tests**.
 
+## upgrade
+To upgrade to version V11 follow [Upgrade Guide](https://laravelmodules.com/docs/v11/upgrade) on official document.
+
 ## Install
 
 To install via Composer, run:


### PR DESCRIPTION
Hi,

In this pull request, I've added an `Upgrade Guide` section to the README of the module. 
@dcblogdev Additionally, I propose adding the URL of this upgrade guide to the release notes of [v11.0.0](https://github.com/nWidart/laravel-modules/releases/tag/v11.0.0). 

Many users have encountered issues recently, such as providers not working, and it's likely because they haven't consulted the upgrade guide. You can find related discussions in the following issues:
- [#1805](https://github.com/nWidart/laravel-modules/issues/1805)
- [#1797](https://github.com/nWidart/laravel-modules/issues/1797)
- [#1781](https://github.com/nWidart/laravel-modules/issues/1781)
- [#1795](https://github.com/nWidart/laravel-modules/issues/1795)