### PR TITLE
[fix] check command has direction option, load module with 'priority'

### DIFF
--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -63,7 +63,9 @@ abstract class BaseCommand extends Command implements PromptsForMissingInput
 
     protected function promptForMissingArguments(InputInterface $input, OutputInterface $output): void
     {
-        $modules = array_keys($this->laravel['modules']->all());
+        $modules = $this->hasOption('direction')
+            ? array_keys($this->laravel['modules']->getOrdered($input->hasOption('direction')))
+            : array_keys($this->laravel['modules']->all());
 
         if ($input->getOption(strtolower(self::ALL))) {
             $input->setArgument('module', $modules);


### PR DESCRIPTION
hi,

if command has option 'direction', load module list with 'priority'.

fix #1816 