### PR TITLE
added make-service class

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -126,6 +126,7 @@ return [
             'resource' => ['path' => 'app/Transformers', 'generate' => false],
             'rules' => ['path' => 'app/Rules', 'generate' => false],
             'component-class' => ['path' => 'app/View/Components', 'generate' => false],
+            'service' => ['path' => 'app/Services', 'generate' => false],
 
             // app/Http/
             'controller' => ['path' => 'app/Http/Controllers', 'generate' => true],

--- a/src/Commands/Make/ServiceMakeCommand.php
+++ b/src/Commands/Make/ServiceMakeCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Nwidart\Modules\Commands\Make;
+
+use Illuminate\Support\Str;
+use Nwidart\Modules\Support\Config\GenerateConfigReader;
+use Nwidart\Modules\Support\Stub;
+use Nwidart\Modules\Traits\ModuleCommandTrait;
+use Symfony\Component\Console\Input\InputArgument;
+
+class ServiceMakeCommand extends GeneratorCommand
+{
+    use ModuleCommandTrait;
+
+    protected $argumentName = 'name';
+    protected $name = 'module:make-service';
+    protected $description = 'Generate a service class for the specified module.';
+
+    public function getDestinationFilePath(): string
+    {
+        $path = $this->laravel['modules']->getModulePath($this->getModuleName());
+
+        $servicePath = GenerateConfigReader::read('service');
+
+        return $path . $servicePath->getPath() . '/' . $this->getServiceName() . '.php';
+    }
+
+    protected function getTemplateContents(): string
+    {
+        $module = $this->laravel['modules']->findOrFail($this->getModuleName());
+
+        return (new Stub($this->getStubName(), [
+            'CLASS_NAMESPACE'   => $this->getClassNamespace($module),
+            'CLASS'             => $this->getClassNameWithoutNamespace(),
+        ]))->render();
+    }
+
+    protected function getArguments(): array
+    {
+        return [
+            ['name', InputArgument::REQUIRED, 'The name of the service class.'],
+            ['module', InputArgument::OPTIONAL, 'The name of module will be used.'],
+        ];
+    }
+
+    protected function getServiceName(): array|string
+    {
+        return Str::studly($this->argument('name'));
+    }
+
+    private function getClassNameWithoutNamespace(): array|string
+    {
+        return class_basename($this->getServiceName());
+    }
+
+    public function getDefaultNamespace(): string
+    {
+        return config('modules.paths.generator.service.namespace')
+            ?? ltrim(config('modules.paths.generator.service.path', 'Services'), config('modules.paths.app_folder'));
+    }
+
+    protected function getStubName(): string
+    {
+        return '/service.stub';
+    }
+}

--- a/src/Commands/stubs/service.stub
+++ b/src/Commands/stubs/service.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace $CLASS_NAMESPACE$;
+
+class $CLASS$
+{
+    public function __invoke()
+    {
+        //
+    }
+}

--- a/src/Commands/stubs/service.stub
+++ b/src/Commands/stubs/service.stub
@@ -4,7 +4,7 @@ namespace $CLASS_NAMESPACE$;
 
 class $CLASS$
 {
-    public function __invoke()
+    public function __construct()
     {
         //
     }

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -72,6 +72,7 @@ class ConsoleServiceProvider extends ServiceProvider
             Commands\Make\RouteProviderMakeCommand::class,
             Commands\Make\RuleMakeCommand::class,
             Commands\Make\SeedMakeCommand::class,
+            Commands\Make\ServiceMakeCommand::class,
             Commands\Make\TestMakeCommand::class,
             Commands\Make\ViewMakeCommand::class,
 

--- a/tests/Commands/ServiceMakeCommandTest.php
+++ b/tests/Commands/ServiceMakeCommandTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Nwidart\Modules\Tests\Commands;
+
+use Nwidart\Modules\Contracts\RepositoryInterface;
+use Nwidart\Modules\Tests\BaseTestCase;
+use Spatie\Snapshots\MatchesSnapshots;
+
+class ServiceMakeCommandTest extends BaseTestCase
+{
+    use MatchesSnapshots;
+
+    /**
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    private $finder;
+    /**
+     * @var string
+     */
+    private $modulePath;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->finder = $this->app['files'];
+        $this->createModule();
+        $this->modulePath = $this->getModuleAppPath();
+
+    }
+
+    public function tearDown(): void
+    {
+        $this->app[RepositoryInterface::class]->delete('Blog');
+        parent::tearDown();
+    }
+
+    public function test_it_generates_a_new_service_class()
+    {
+        $code = $this->artisan('module:make-service', ['name' => 'MyService', 'module' => 'Blog']);
+
+        $this->assertTrue(is_file($this->modulePath . '/Services/MyService.php'));
+        $this->assertSame(0, $code);
+    }
+
+    public function test_it_generated_correct_file_with_content()
+    {
+        $code = $this->artisan('module:make-service', ['name' => 'MyService', 'module' => 'Blog']);
+
+        $file = $this->finder->get($this->modulePath . '/Services/MyService.php');
+
+        $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
+    }
+
+    public function test_it_can_change_the_default_namespace()
+    {
+        $this->app['config']->set('modules.paths.generator.service.path', 'Services');
+
+        $code = $this->artisan('module:make-service', ['name' => 'MyService', 'module' => 'Blog']);
+
+        $file = $this->finder->get($this->getModuleBasePath() . '/Services/MyService.php');
+
+        $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
+    }
+
+    public function test_it_can_generate_a_service_in_sub_namespace_in_correct_folder()
+    {
+        $code = $this->artisan('module:make-service', ['name' => 'Api\\MyService', 'module' => 'Blog']);
+
+        $this->assertTrue(is_file($this->modulePath . '/Services/Api/MyService.php'));
+        $this->assertSame(0, $code);
+    }
+
+    public function test_it_can_generate_a_service_in_sub_namespace_with_correct_generated_file()
+    {
+        $code = $this->artisan('module:make-service', ['name' => 'Api\\MyService', 'module' => 'Blog']);
+
+        $file = $this->finder->get($this->modulePath . '/Services/Api/MyService.php');
+
+        $this->assertMatchesSnapshot($file);
+        $this->assertSame(0, $code);
+    }
+}

--- a/tests/Commands/__snapshots__/ServiceMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/__snapshots__/ServiceMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -4,7 +4,7 @@ namespace Modules\Blog\Services;
 
 class MyService
 {
-    public function __invoke()
+    public function __construct()
     {
         //
     }

--- a/tests/Commands/__snapshots__/ServiceMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/__snapshots__/ServiceMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -1,0 +1,11 @@
+<?php
+
+namespace Modules\Blog\Services;
+
+class MyService
+{
+    public function __invoke()
+    {
+        //
+    }
+}

--- a/tests/Commands/__snapshots__/ServiceMakeCommandTest__test_it_can_generate_a_service_in_sub_namespace_with_correct_generated_file__1.txt
+++ b/tests/Commands/__snapshots__/ServiceMakeCommandTest__test_it_can_generate_a_service_in_sub_namespace_with_correct_generated_file__1.txt
@@ -4,7 +4,7 @@ namespace Modules\Blog\Services\Api;
 
 class MyService
 {
-    public function __invoke()
+    public function __construct()
     {
         //
     }

--- a/tests/Commands/__snapshots__/ServiceMakeCommandTest__test_it_can_generate_a_service_in_sub_namespace_with_correct_generated_file__1.txt
+++ b/tests/Commands/__snapshots__/ServiceMakeCommandTest__test_it_can_generate_a_service_in_sub_namespace_with_correct_generated_file__1.txt
@@ -1,0 +1,11 @@
+<?php
+
+namespace Modules\Blog\Services\Api;
+
+class MyService
+{
+    public function __invoke()
+    {
+        //
+    }
+}

--- a/tests/Commands/__snapshots__/ServiceMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/__snapshots__/ServiceMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -4,7 +4,7 @@ namespace Modules\Blog\Services;
 
 class MyService
 {
-    public function __invoke()
+    public function __construct()
     {
         //
     }

--- a/tests/Commands/__snapshots__/ServiceMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/__snapshots__/ServiceMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -1,0 +1,11 @@
+<?php
+
+namespace Modules\Blog\Services;
+
+class MyService
+{
+    public function __invoke()
+    {
+        //
+    }
+}


### PR DESCRIPTION
This PR adds the ability to generate service classes using `php artisan module:make-service ServiceName ModuleName`

Added service generator
Added Tests
Added Stub

This does require the application config file to add a service to the generator paths:

```php
'service' => ['path' => 'app/Services', 'generate' => false],
```