### PR TITLE
Fixed public path for octane setup

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -83,8 +83,8 @@ abstract class Module
     {
         $paths = [];
 
-        if (file_exists('build/manifest.json')) {
-            $files = json_decode(file_get_contents('build/manifest.json'), true);
+        if (file_exists(public_path('build/manifest.json'))) {
+            $files = json_decode(file_get_contents(public_path('build/manifest.json')), true);
 
             if (is_array($files)) {
                 foreach ($files as $file) {


### PR DESCRIPTION
The path to `build/manifest.json` is relative, which works if the executing PHP file is in the public folder. If you use Laravel Octane the executing script is the `artisan` script which is in the working directory, and so the paths are incorrect.

I fixed this by using the `public_path` function.