### PR TITLE
Update controller, service, helper, and action methods

### DIFF
--- a/src/Commands/stubs/helper-invoke.stub
+++ b/src/Commands/stubs/helper-invoke.stub
@@ -4,7 +4,7 @@ namespace $CLASS_NAMESPACE$;
 
 class $CLASS$
 {
-    public function __invokable()
+    public function __invoke()
     {
         //
     }

--- a/src/Commands/stubs/helper.stub
+++ b/src/Commands/stubs/helper.stub
@@ -4,7 +4,7 @@ namespace $CLASS_NAMESPACE$;
 
 class $CLASS$
 {
-    public function __construct()
+    public function handle()
     {
         //
     }

--- a/tests/Commands/__snapshots__/ActionMakeCommandTest__test_it_can_generate_a_action_in_sub_namespace_with_correct_generated_file__1.txt
+++ b/tests/Commands/__snapshots__/ActionMakeCommandTest__test_it_can_generate_a_action_in_sub_namespace_with_correct_generated_file__1.txt
@@ -4,7 +4,7 @@ namespace Modules\Blog\Actions\Api;
 
 class MyAction
 {
-    public function __construct()
+    public function handle()
     {
         //
     }

--- a/tests/Commands/__snapshots__/ActionMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/__snapshots__/ActionMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -4,7 +4,7 @@ namespace Modules\Blog\Actions;
 
 class MyAction
 {
-    public function __construct()
+    public function handle()
     {
         //
     }

--- a/tests/Commands/__snapshots__/ControllerMakeCommandTest__test_it_generates_an_invokable_controller__1.txt
+++ b/tests/Commands/__snapshots__/ControllerMakeCommandTest__test_it_generates_an_invokable_controller__1.txt
@@ -1,0 +1,18 @@
+<?php
+
+namespace {{ namespace }};
+
+namespace Modules\Blog\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+
+class MyController extends Controller
+{
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(Request $request)
+    {
+        //
+    }
+}

--- a/tests/Commands/__snapshots__/HelperMakeCommandTest__test_it_can_generate_a_helper_in_sub_namespace_with_correct_generated_file__1.txt
+++ b/tests/Commands/__snapshots__/HelperMakeCommandTest__test_it_can_generate_a_helper_in_sub_namespace_with_correct_generated_file__1.txt
@@ -4,7 +4,7 @@ namespace Modules\Blog\Helpers\Api;
 
 class MyHelper
 {
-    public function __construct()
+    public function handle()
     {
         //
     }

--- a/tests/Commands/__snapshots__/HelperMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/__snapshots__/HelperMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -4,7 +4,7 @@ namespace Modules\Blog\Helpers;
 
 class MyHelper
 {
-    public function __construct()
+    public function handle()
     {
         //
     }

--- a/tests/Commands/__snapshots__/ServiceMakeCommandTest__test_it_can_generate_a_service_in_sub_namespace_with_correct_generated_file__1.txt
+++ b/tests/Commands/__snapshots__/ServiceMakeCommandTest__test_it_can_generate_a_service_in_sub_namespace_with_correct_generated_file__1.txt
@@ -4,7 +4,7 @@ namespace Modules\Blog\Services\Api;
 
 class MyService
 {
-    public function __construct()
+    public function handle()
     {
         //
     }

--- a/tests/Commands/__snapshots__/ServiceMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/__snapshots__/ServiceMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -4,7 +4,7 @@ namespace Modules\Blog\Services;
 
 class MyService
 {
-    public function __construct()
+    public function handle()
     {
         //
     }


### PR DESCRIPTION
This commit replaces the `__construct()` method in generated controller, service, helper, and action classes with `handle()`. 

Also, it changes `__invokable()` in the helper-invoke.stub to `__invoke()`. This makes them more immediately useful for handling requests or other actions.