### PR TITLE
module:composer-autoload command

### DIFF
--- a/src/Commands/Composer/AutoloadCommand.php
+++ b/src/Commands/Composer/AutoloadCommand.php
@@ -9,9 +9,10 @@ use Illuminate\Support\Str;
 class AutoloadCommand extends BaseCommand
 {
     /**
-     * The console command name.
+     * The name and signature of the console command.
      */
-    protected $name = 'module:composer-autoload';
+    protected $signature = 'module:composer-autoload
+        {--p|path= : Custom app path.}';
 
     /**
      * The console command description.
@@ -24,15 +25,22 @@ class AutoloadCommand extends BaseCommand
 
         $this->components->task("Updating <fg=cyan;options=bold>{$module->getName()}</>", function () use ($module) {
             $composer_file = $module->getPath() . DIRECTORY_SEPARATOR . 'composer.json';
-            $composer = json_decode(File::get($composer_file), true);
 
+            $composer = json_decode(File::get($composer_file), true);
+            if (!$composer) {
+                return false;
+            }
+
+            // Get autoload.psr-4
             $autoload_psr4 = data_get($composer, 'autoload.psr-4') ?? [];
             $autoload_dev_psr4 = data_get($composer, 'autoload-dev.psr-4') ?? [];
 
             // Get the module name.
             $name = $module->getStudlyName();
-            $app_path = trim(strlen($path = config('modules.paths.app_folder')) ? $path : 'app', '/') . '/'; // accept app_path option
-            $app_path_name = trim($app_path, '/');
+
+            $path = trim($this->option('path') ?? (strlen($p = config('modules.paths.app_folder')) ? $p : 'app'), '/') . '/';
+
+            $path_name = trim($path, '/');
 
             // Remove old app key
             $autoload_old_app_key = sprintf('Modules\\%s\\', $name);
@@ -40,28 +48,41 @@ class AutoloadCommand extends BaseCommand
                 unset($autoload_psr4[$autoload_old_app_key]);
             }
 
-            // Update autoload.psr-4
-            if (strlen($app_path_name)) {
-                $autoload_app = sprintf('Modules\\%s\\%s\\', $name, Str::studly($app_path_name));
-            } else {
-                $autoload_app = sprintf('Modules\\%s\\', $name);
-            }
-            $autoload_factories = sprintf('Modules\\%s\\Database\\Factories\\', $name);
-            $autoload_seeders = sprintf('Modules\\%s\\Database\\Seeders\\', $name);
-            $autoload_psr4 += [
-                $autoload_app => Str::lower($app_path ?? '/'),
-                $autoload_factories => 'database/factories/',
-                $autoload_seeders => 'database/seeders/',
-            ];
+            /*
+             * ---------------------
+             * Update autoload.psr-4
+             * ---------------------
+             */
+            // Set the keys
+            $psr4_app = strlen($path_name) ? sprintf('Modules\\%s\\%s\\', $name, Str::studly($path_name)) : sprintf('Modules\\%s\\', $name);
+            $psr4_factories = sprintf('Modules\\%s\\Database\\Factories\\', $name);
+            $psr4_seeders = sprintf('Modules\\%s\\Database\\Seeders\\', $name);
+
+            // Update the values
+            $autoload_psr4[$psr4_app] = Str::lower($path ?? 'app/');
+            $autoload_psr4[$psr4_factories] = 'database/factories/';
+            $autoload_psr4[$psr4_seeders] = 'database/seeders/';
+
+            // Update composer.json
             data_set($composer, 'autoload.psr-4', $autoload_psr4);
 
-            // Update autoload-dev.psr-4
-            $autoload_dev_psr4_test = sprintf('Modules\\%s\\Tests\\', $name);
-            $autoload_dev_psr4 += [
-                $autoload_dev_psr4_test => 'tests/',
-            ];
+            /*
+             * -------------------------
+             * Update autoload-dev.psr-4
+             * -------------------------
+             */
+            // Set the keys
+            $dev_psr4_test = sprintf('Modules\\%s\\Tests\\', $name);
+
+            // Update the values
+            $autoload_dev_psr4[$dev_psr4_test] = 'tests/';
+
+            // Update composer.json
             data_set($composer, 'autoload-dev.psr-4', $autoload_dev_psr4);
 
+            /*
+             * Save composer.json
+             */
             file_put_contents($composer_file, json_encode($composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
         });
     }

--- a/src/Commands/Composer/AutoloadCommand.php
+++ b/src/Commands/Composer/AutoloadCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Nwidart\Modules\Commands\Composer;
+
+use Illuminate\Support\Facades\File;
+use Nwidart\Modules\Commands\BaseCommand;
+use Illuminate\Support\Str;
+
+class AutoloadCommand extends BaseCommand
+{
+    /**
+     * The console command name.
+     */
+    protected $name = 'module:composer-autoload';
+
+    /**
+     * The console command description.
+     */
+    protected $description = 'Update composer.json autoloads';
+
+    public function executeAction($name): void
+    {
+        $module = $this->getModuleModel($name);
+
+        $this->components->task("Updating <fg=cyan;options=bold>{$module->getName()}</>", function () use ($module) {
+            $composer_file = $module->getPath() . DIRECTORY_SEPARATOR . 'composer.json';
+            $composer = json_decode(File::get($composer_file), true);
+
+            $autoload_psr4 = data_get($composer, 'autoload.psr-4') ?? [];
+            $autoload_dev_psr4 = data_get($composer, 'autoload-dev.psr-4') ?? [];
+
+            // Get the module name.
+            $name = $module->getStudlyName();
+            $app_path = trim(strlen($path = config('modules.paths.app_folder')) ? $path : 'app', '/') . '/'; // accept app_path option
+            $app_path_name = trim($app_path, '/');
+
+            // Remove old app key
+            $autoload_old_app_key = sprintf('Modules\\%s\\', $name);
+            if (array_key_exists($autoload_old_app_key, $autoload_psr4)) {
+                unset($autoload_psr4[$autoload_old_app_key]);
+            }
+
+            // Update autoload.psr-4
+            if (strlen($app_path_name)) {
+                $autoload_app = sprintf('Modules\\%s\\%s\\', $name, Str::studly($app_path_name));
+            } else {
+                $autoload_app = sprintf('Modules\\%s\\', $name);
+            }
+            $autoload_factories = sprintf('Modules\\%s\\Database\\Factories\\', $name);
+            $autoload_seeders = sprintf('Modules\\%s\\Database\\Seeders\\', $name);
+            $autoload_psr4 += [
+                $autoload_app => Str::lower($app_path ?? '/'),
+                $autoload_factories => 'database/factories/',
+                $autoload_seeders => 'database/seeders/',
+            ];
+            data_set($composer, 'autoload.psr-4', $autoload_psr4);
+
+            // Update autoload-dev.psr-4
+            $autoload_dev_psr4_test = sprintf('Modules\\%s\\Tests\\', $name);
+            $autoload_dev_psr4 += [
+                $autoload_dev_psr4_test => 'tests/',
+            ];
+            data_set($composer, 'autoload-dev.psr-4', $autoload_dev_psr4);
+
+            file_put_contents($composer_file, json_encode($composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        });
+    }
+
+    public function getInfo(): string
+    {
+        return 'Updating modules composer.json autoloads ...';
+    }
+}

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -92,8 +92,11 @@ class ConsoleServiceProvider extends ServiceProvider
             Commands\Publish\PublishMigrationCommand::class,
             Commands\Publish\PublishTranslationCommand::class,
 
-            // Other Commands
+            // Composer Commands
+            Commands\Composer\AutoloadCommand::class,
             Commands\ComposerUpdateCommand::class,
+
+            // Other Commands
             Commands\LaravelModulesV6Migrator::class,
             Commands\SetupCommand::class,
 


### PR DESCRIPTION
This PR focuses on adding the new autoload.psr-4 and autoload-dev.psr-4 data to modules composer.json file.

### Usage
Updates the autoload data in the composer.json file for all modules.
```
php artisan module:composer-autoload --all
```

Updates the autoload data in the composer.json file of a specific module.
```
php artisan module:composer-autoload Blog
```

### App path
Uses the value from `modules.paths.app_folder`.