### PR TITLE
Add Confirmation Option for Command Execution

### DIFF
--- a/src/Commands/Actions/ModuleDeleteCommand.php
+++ b/src/Commands/Actions/ModuleDeleteCommand.php
@@ -3,8 +3,9 @@
 namespace Nwidart\Modules\Commands\Actions;
 
 use Nwidart\Modules\Commands\BaseCommand;
+use Nwidart\Modules\Contracts\ConfirmableCommandInterface;
 
-class ModuleDeleteCommand extends BaseCommand
+class ModuleDeleteCommand extends BaseCommand implements ConfirmableCommandInterface
 {
     protected $name        = 'module:delete';
     protected $description = 'Delete a module from the application';
@@ -22,4 +23,8 @@ class ModuleDeleteCommand extends BaseCommand
         return 'deleting module ...';
     }
 
+    public function getConfirmLabel(): string
+    {
+        return 'Do you want delete module?';
+    }
 }

--- a/src/Contracts/ConfirmableCommandInterface.php
+++ b/src/Contracts/ConfirmableCommandInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Nwidart\Modules\Contracts;
+
+interface ConfirmableCommandInterface
+{
+    public function getConfirmLabel();
+
+}

--- a/src/Exceptions/CancelCommandException.php
+++ b/src/Exceptions/CancelCommandException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Nwidart\Modules\Exceptions;
+
+class CancelCommandException extends \Exception
+{
+}

--- a/tests/Commands/ModuleDeleteCommandTest.php
+++ b/tests/Commands/ModuleDeleteCommandTest.php
@@ -32,7 +32,7 @@ class ModuleDeleteCommandTest extends BaseTestCase
         $this->artisan('module:make', ['name' => ['WrongModule']]);
         $this->assertDirectoryExists(base_path('modules/WrongModule'));
 
-        $code = $this->artisan('module:delete', ['module' => 'WrongModule']);
+        $code = $this->artisan('module:delete', ['module' => 'WrongModule','--force' => true]);
         $this->assertFileDoesNotExist(base_path('modules/WrongModule'));
         $this->assertSame(0, $code);
     }
@@ -50,7 +50,7 @@ class ModuleDeleteCommandTest extends BaseTestCase
             $this->assertDirectoryExists($this->getModuleBasePath($module));
         }
 
-        $code = $this->artisan('module:delete', ['module' => ['Foo', 'Bar']]);
+        $code = $this->artisan('module:delete', ['module' => ['Foo', 'Bar'], '--force' => true]);
         $this->assertSame(0, $code);
         $this->assertFileDoesNotExist($this->getModuleBasePath('Foo'));
         $this->assertFileDoesNotExist($this->getModuleBasePath('Bar'));
@@ -72,7 +72,7 @@ class ModuleDeleteCommandTest extends BaseTestCase
             $this->assertDirectoryExists($this->getModuleBasePath($module));
         }
 
-        $code = $this->artisan('module:delete', ['--all' => true]);
+        $code = $this->artisan('module:delete', ['--all' => true, '--force' => true]);
         $this->assertSame(0, $code);
         $this->assertFileDoesNotExist($this->getModuleBasePath('Foo'));
         $this->assertFileDoesNotExist($this->getModuleBasePath('Bar'));
@@ -84,7 +84,7 @@ class ModuleDeleteCommandTest extends BaseTestCase
         $this->artisan('module:make', ['name' => ['WrongModule']]);
         $this->assertMatchesSnapshot($this->finder->get($this->activator->getStatusesFilePath()));
 
-        $code = $this->artisan('module:delete', ['module' => 'WrongModule']);
+        $code = $this->artisan('module:delete', ['module' => 'WrongModule', '--force' => true]);
         $this->assertMatchesSnapshot($this->finder->get($this->activator->getStatusesFilePath()));
         $this->assertSame(0, $code);
     }


### PR DESCRIPTION
Hi,

In this pull request, I have added an option for confirmation before executing certain commands. Previously, the delete command ran without confirmation, which could lead to accidental and irreversible data loss.

I have also added an option to pass `--force` to delete without confirmation, allowing for the previous behavior when needed.

```sh
php artisan module:delete Foo --force
```

This change addresses issue #1859.

<img width="573" alt="image" src="https://github.com/nWidart/laravel-modules/assets/26966142/b13a12a2-a4ba-4625-b5c5-e9558f31215b">

Thank you for reviewing this pull request.

