### PR TITLE
Add Confirmation Option for Command Execution

### DIFF
--- a/src/Commands/Actions/ModuleDeleteCommand.php
+++ b/src/Commands/Actions/ModuleDeleteCommand.php
@@ -2,12 +2,27 @@
 
 namespace Nwidart\Modules\Commands\Actions;
 
+use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Console\Prohibitable;
 use Nwidart\Modules\Commands\BaseCommand;
+use Nwidart\Modules\Contracts\ConfirmableCommand;
 
-class ModuleDeleteCommand extends BaseCommand
+class ModuleDeleteCommand extends BaseCommand implements ConfirmableCommand
 {
+    use ConfirmableTrait, Prohibitable;
+
     protected $name        = 'module:delete';
     protected $description = 'Delete a module from the application';
+
+    public function handle()
+    {
+        if ($this->isProhibited() ||
+            ! $this->confirmToProceed('Warning: Do you want to remove the module?', fn () => TRUE)) {
+            return 1;
+        }
+
+        parent::handle();
+    }
 
     public function executeAction($name): void
     {

--- a/src/Commands/Actions/ModuleDeleteCommand.php
+++ b/src/Commands/Actions/ModuleDeleteCommand.php
@@ -2,27 +2,13 @@
 
 namespace Nwidart\Modules\Commands\Actions;
 
-use Illuminate\Console\ConfirmableTrait;
-use Illuminate\Console\Prohibitable;
 use Nwidart\Modules\Commands\BaseCommand;
 use Nwidart\Modules\Contracts\ConfirmableCommand;
 
 class ModuleDeleteCommand extends BaseCommand implements ConfirmableCommand
 {
-    use ConfirmableTrait, Prohibitable;
-
     protected $name        = 'module:delete';
     protected $description = 'Delete a module from the application';
-
-    public function handle()
-    {
-        if ($this->isProhibited() ||
-            ! $this->confirmToProceed('Warning: Do you want to remove the module?', fn () => TRUE)) {
-            return 1;
-        }
-
-        parent::handle();
-    }
 
     public function executeAction($name): void
     {
@@ -37,4 +23,8 @@ class ModuleDeleteCommand extends BaseCommand implements ConfirmableCommand
         return 'deleting module ...';
     }
 
+    public function getConfirmableLabel(): string
+    {
+        return 'Warning: Do you want to remove the module?';
+    }
 }

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Console\PromptsForMissingInput;
 
 use function Laravel\Prompts\multiselect;
 
+use Nwidart\Modules\Contracts\ConfirmableCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -36,6 +37,10 @@ abstract class BaseCommand extends Command implements PromptsForMissingInput
             InputArgument::IS_ARRAY,
             'The name of module will be used.',
         ));
+
+        if ($this instanceof ConfirmableCommand) {
+            $this->configureConfirmable();
+        }
     }
 
     abstract public function executeAction($name);
@@ -99,6 +104,17 @@ abstract class BaseCommand extends Command implements PromptsForMissingInput
         return $name instanceof \Nwidart\Modules\Module
             ? $name
             : $this->laravel['modules']->findOrFail($name);
+    }
+
+    private function configureConfirmable(): void
+    {
+        $this->getDefinition()
+            ->addOption(new InputOption(
+                'force',
+                null,
+                InputOption::VALUE_NONE,
+                'Force the operation to run without confirmation.',
+            ));
     }
 
 }

--- a/src/Contracts/ConfirmableCommand.php
+++ b/src/Contracts/ConfirmableCommand.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Nwidart\Modules\Contracts;
+
+interface ConfirmableCommand
+{
+}

--- a/tests/Commands/ModuleDeleteCommandTest.php
+++ b/tests/Commands/ModuleDeleteCommandTest.php
@@ -32,7 +32,7 @@ class ModuleDeleteCommandTest extends BaseTestCase
         $this->artisan('module:make', ['name' => ['WrongModule']]);
         $this->assertDirectoryExists(base_path('modules/WrongModule'));
 
-        $code = $this->artisan('module:delete', ['module' => 'WrongModule']);
+        $code = $this->artisan('module:delete', ['module' => 'WrongModule','--force' => true]);
         $this->assertFileDoesNotExist(base_path('modules/WrongModule'));
         $this->assertSame(0, $code);
     }
@@ -50,7 +50,7 @@ class ModuleDeleteCommandTest extends BaseTestCase
             $this->assertDirectoryExists($this->getModuleBasePath($module));
         }
 
-        $code = $this->artisan('module:delete', ['module' => ['Foo', 'Bar']]);
+        $code = $this->artisan('module:delete', ['module' => ['Foo', 'Bar'], '--force' => true]);
         $this->assertSame(0, $code);
         $this->assertFileDoesNotExist($this->getModuleBasePath('Foo'));
         $this->assertFileDoesNotExist($this->getModuleBasePath('Bar'));
@@ -72,7 +72,7 @@ class ModuleDeleteCommandTest extends BaseTestCase
             $this->assertDirectoryExists($this->getModuleBasePath($module));
         }
 
-        $code = $this->artisan('module:delete', ['--all' => true]);
+        $code = $this->artisan('module:delete', ['--all' => true, '--force' => true]);
         $this->assertSame(0, $code);
         $this->assertFileDoesNotExist($this->getModuleBasePath('Foo'));
         $this->assertFileDoesNotExist($this->getModuleBasePath('Bar'));
@@ -84,7 +84,7 @@ class ModuleDeleteCommandTest extends BaseTestCase
         $this->artisan('module:make', ['name' => ['WrongModule']]);
         $this->assertMatchesSnapshot($this->finder->get($this->activator->getStatusesFilePath()));
 
-        $code = $this->artisan('module:delete', ['module' => 'WrongModule']);
+        $code = $this->artisan('module:delete', ['module' => 'WrongModule', '--force' => true]);
         $this->assertMatchesSnapshot($this->finder->get($this->activator->getStatusesFilePath()));
         $this->assertSame(0, $code);
     }


### PR DESCRIPTION
Hi,

In this pull request, I have added an option for confirmation before executing certain commands. Previously, the delete command ran without confirmation, which could lead to accidental and irreversible data loss.

I have also added an option to pass `--force` to delete without confirmation, allowing for the previous behavior when needed.

```sh
php artisan module:delete Foo --force
```

This change addresses issue #1859.

<img width="631" alt="image" src="https://github.com/nWidart/laravel-modules/assets/26966142/149a3f5b-0eaa-4d48-9220-2866453a8890">

Thank you for reviewing this pull request.

