### PR TITLE
Improvement: Remove Cached JSON File Reading for Faster Performance

### DIFF
--- a/src/Json.php
+++ b/src/Json.php
@@ -116,7 +116,7 @@ class Json
      */
     public function decodeContents()
     {
-        $attributes = json_decode($this->getContents(), 1);
+        $attributes = $this->filesystem->json($this->getPath());
 
         // any JSON parsing errors should throw an exception
         if (json_last_error() > 0) {
@@ -136,13 +136,7 @@ class Json
      */
     public function getAttributes()
     {
-        if (config('modules.cache.enabled') === false) {
-            return $this->decodeContents();
-        }
-
-        return app('cache')->store(config('modules.cache.driver'))->remember($this->getPath(), config('modules.cache.lifetime'), function () {
-            return $this->decodeContents();
-        });
+        return $this->decodeContents();
     }
 
     /**


### PR DESCRIPTION
Hi,

In this pull request, I propose removing the cached JSON file reading and instead reading directly from the file. This approach is significantly faster (~12x on my OS).

> Before merging, please test this on your own system.

### How to Test This

1. **Create a new fresh Laravel project and generate 150 modules.** Use the following console command:
    ```php
    use Illuminate\Support\Facades\Artisan;

    Artisan::command('create', function () {
        $module_names = collect(range(0, 150))
            ->map(function ($item) {
                return 'module' . $item;
            })
            ->toArray();

        \Illuminate\Support\Facades\Artisan::call('module:make', [
            'name' => $module_names,
        ]);
    });
    ```
    Run this command in the terminal:
    ```sh
    php artisan create
    ```

2. **Publish the module config file and set `cache.enabled` to true** or set the environment variable `MODULES_CACHE_ENABLED=true`.

3. **Create a benchmark route with this code:**
    ```php
    Route::get('/benchmark', function () {
        $base_path = base_path();

        \Illuminate\Support\Benchmark::dd([
            'directly from file' => function () use ($base_path) {
                $num = rand(0, 150);
                $path = "$base_path/Modules/Module{$num}/module.json";
                $json = \Illuminate\Support\Facades\File::json($path);
                $name = $json['name'];
            },
            'read from cache' => function () use ($base_path) {
                $num = rand(0, 150);
                $path = "$base_path/Modules/Module{$num}/module.json";
                $json = app('cache')
                    ->store(config('modules.cache.driver'))
                    ->remember($path, 100000, function () use ($path) {
                        return \Illuminate\Support\Facades\File::json($path);
                    });
                $name = $json['name'];
            },
        ], 1000);
    });
    ```

### Benchmark Results

Here are my results on `redis` cache is:
![image](https://github.com/nWidart/laravel-modules/assets/26966142/839b8c7a-f037-4dd3-a189-39956c073476)

on `file` driver and,  first run :
```
array:2 [▼ 
  "directly from file" => "0.014ms"
  "read from cache" => "0.109ms"
]
```
after 3 4 run, result improve:
```
array:2 [▼ 
  "directly from file" => "0.014ms"
  "read from cache" => "0.079ms"
]
```