### PR TITLE
Add Event Handling and Constants for Module Actions

### DIFF
--- a/src/Constants/ModuleEvent.php
+++ b/src/Constants/ModuleEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Nwidart\Modules\Constants;
+
+class ModuleEvent
+{
+    const BOOT = 'boot';
+
+    const REGISTER = 'register';
+
+    const DISABLING = 'disabling';
+
+    const DISABLED = 'disabled';
+
+    const ENABLING = 'enabling';
+
+    const ENABLED = 'enabled';
+
+    const CREATE = 'create';
+
+    const DELETE = 'delete';
+
+    const USED = 'used';
+
+    const UNUSED = 'unused';
+}

--- a/src/Constants/ModuleEvent.php
+++ b/src/Constants/ModuleEvent.php
@@ -16,9 +16,13 @@ class ModuleEvent
 
     const ENABLED = 'enabled';
 
-    const CREATE = 'create';
+    const CREATING = 'creating';
 
-    const DELETE = 'delete';
+    const CREATED = 'created';
+
+    const DELETING = 'deleting';
+
+    const DELETED = 'deleted';
 
     const USED = 'used';
 

--- a/src/FileRepository.php
+++ b/src/FileRepository.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use Nwidart\Modules\Constants\ModuleEvent;
 use Nwidart\Modules\Contracts\RepositoryInterface;
 use Nwidart\Modules\Exceptions\InvalidAssetPath;
 use Nwidart\Modules\Exceptions\ModuleNotFoundException;
@@ -410,6 +411,8 @@ abstract class FileRepository implements Countable, RepositoryInterface
         $module = $this->findOrFail($name);
 
         $this->getFiles()->put($this->getUsedStoragePath(), $module);
+
+        $module->fireEvent(ModuleEvent::USED);
     }
 
     /**

--- a/src/Generators/ModuleGenerator.php
+++ b/src/Generators/ModuleGenerator.php
@@ -336,6 +336,8 @@ class ModuleGenerator extends Generator
      */
     public function generate(): int
     {
+        $this->fireEvent(ModuleEvent::CREATING);
+
         $name = $this->getName();
 
         if ($this->module->has($name)) {
@@ -368,7 +370,7 @@ class ModuleGenerator extends Generator
 
         $this->component->info("Module [{$name}] created successfully.");
 
-        $this->fireEvent(ModuleEvent::CREATE);
+        $this->fireEvent(ModuleEvent::CREATED);
 
         return 0;
     }

--- a/src/Generators/ModuleGenerator.php
+++ b/src/Generators/ModuleGenerator.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use Nwidart\Modules\Constants\ModuleEvent;
 use Nwidart\Modules\Contracts\ActivatorInterface;
-use Nwidart\Modules\Facades\Module;
 use Nwidart\Modules\FileRepository;
 use Nwidart\Modules\Support\Config\GenerateConfigReader;
 use Nwidart\Modules\Support\Stub;
@@ -336,9 +335,9 @@ class ModuleGenerator extends Generator
      */
     public function generate(): int
     {
-        $this->fireEvent(ModuleEvent::CREATING);
-
         $name = $this->getName();
+
+        Event::dispatch(sprintf('modules.%s.%s', strtolower($name), ModuleEvent::CREATING));
 
         if ($this->module->has($name)) {
             if ($this->force) {
@@ -686,8 +685,6 @@ class ModuleGenerator extends Generator
 
     /**
      * fire the module event.
-     *
-     * @param string $event
      */
     protected function fireEvent(string $event): void
     {

--- a/src/Generators/ModuleGenerator.php
+++ b/src/Generators/ModuleGenerator.php
@@ -5,8 +5,11 @@ namespace Nwidart\Modules\Generators;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Console\Command as Console;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
+use Nwidart\Modules\Constants\ModuleEvent;
 use Nwidart\Modules\Contracts\ActivatorInterface;
+use Nwidart\Modules\Facades\Module;
 use Nwidart\Modules\FileRepository;
 use Nwidart\Modules\Support\Config\GenerateConfigReader;
 use Nwidart\Modules\Support\Stub;
@@ -365,6 +368,8 @@ class ModuleGenerator extends Generator
 
         $this->component->info("Module [{$name}] created successfully.");
 
+        $this->fireEvent(ModuleEvent::CREATE);
+
         return 0;
     }
 
@@ -675,5 +680,17 @@ class ModuleGenerator extends Generator
     protected function getProviderNamespaceReplacement(): string
     {
         return str_replace('\\', '\\\\', GenerateConfigReader::read('provider')->getNamespace());
+    }
+
+    /**
+     * fire the module event.
+     *
+     * @param string $event
+     */
+    protected function fireEvent(string $event): void
+    {
+        $module = $this->module->find($this->name);
+
+        $module->fireEvent($event);
     }
 }

--- a/src/Module.php
+++ b/src/Module.php
@@ -269,7 +269,7 @@ abstract class Module
      */
     public function fireEvent(string $event): void
     {
-        $this->app['events']->dispatch(sprintf('modules.%s.'.$event, $this->getLowerName()), [$this]);
+        $this->app['events']->dispatch(sprintf('modules.%s.%s', $this->getLowerName(), $event), [$this]);
     }
 
     /**

--- a/src/Module.php
+++ b/src/Module.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Translation\Translator;
+use Nwidart\Modules\Constants\ModuleEvent;
 use Nwidart\Modules\Contracts\ActivatorInterface;
 
 abstract class Module
@@ -192,7 +193,7 @@ abstract class Module
             $this->registerFiles();
         }
 
-        $this->fireEvent('boot');
+        $this->fireEvent(ModuleEvent::BOOT);
     }
 
     /**
@@ -260,15 +261,13 @@ abstract class Module
             $this->registerFiles();
         }
 
-        $this->fireEvent('register');
+        $this->fireEvent(ModuleEvent::REGISTER);
     }
 
     /**
-     * Register the module event.
-     *
-     * @param  string  $event
+     * fire the module event.
      */
-    protected function fireEvent($event): void
+    public function fireEvent(string $event): void
     {
         $this->app['events']->dispatch(sprintf('modules.%s.'.$event, $this->getLowerName()), [$this]);
     }
@@ -345,12 +344,12 @@ abstract class Module
      */
     public function disable(): void
     {
-        $this->fireEvent('disabling');
+        $this->fireEvent(ModuleEvent::DISABLING);
 
         $this->activator->disable($this);
         $this->flushCache();
 
-        $this->fireEvent('disabled');
+        $this->fireEvent(ModuleEvent::DISABLED);
     }
 
     /**
@@ -358,12 +357,12 @@ abstract class Module
      */
     public function enable(): void
     {
-        $this->fireEvent('enabling');
+        $this->fireEvent(ModuleEvent::ENABLING);
 
         $this->activator->enable($this);
         $this->flushCache();
 
-        $this->fireEvent('enabled');
+        $this->fireEvent(ModuleEvent::ENABLED);
     }
 
     /**
@@ -373,7 +372,11 @@ abstract class Module
     {
         $this->activator->delete($this);
 
-        return $this->json()->getFilesystem()->deleteDirectory($this->getPath());
+        $result = $this->json()->getFilesystem()->deleteDirectory($this->getPath());
+
+        $this->fireEvent(ModuleEvent::DELETE);
+
+        return $result;
     }
 
     /**

--- a/src/Module.php
+++ b/src/Module.php
@@ -370,11 +370,13 @@ abstract class Module
      */
     public function delete(): bool
     {
+        $this->fireEvent(ModuleEvent::DELETING);
+
         $this->activator->delete($this);
 
         $result = $this->json()->getFilesystem()->deleteDirectory($this->getPath());
 
-        $this->fireEvent(ModuleEvent::DELETE);
+        $this->fireEvent(ModuleEvent::DELETED);
 
         return $result;
     }

--- a/tests/Commands/Actions/ModuleDeleteCommandTest.php
+++ b/tests/Commands/Actions/ModuleDeleteCommandTest.php
@@ -2,7 +2,9 @@
 
 namespace Nwidart\Modules\Commands;
 
+use Illuminate\Support\Facades\Event;
 use Nwidart\Modules\Activators\FileActivator;
+use Nwidart\Modules\Constants\ModuleEvent;
 use Nwidart\Modules\Contracts\RepositoryInterface;
 use Nwidart\Modules\Tests\BaseTestCase;
 use Spatie\Snapshots\MatchesSnapshots;
@@ -88,5 +90,43 @@ class ModuleDeleteCommandTest extends BaseTestCase
         $code = $this->artisan('module:delete', ['module' => 'WrongModule', '--force' => true]);
         $this->assertMatchesSnapshot($this->finder->get($this->activator->getStatusesFilePath()));
         $this->assertSame(0, $code);
+    }
+
+    public function test_it_fires_events_when_module_deleted()
+    {
+        $module_name = 'Blog';
+
+        $this->createModule($module_name);
+
+        Event::fake();
+
+        $code = $this->artisan('module:delete', ['module' => [$module_name], '--force' => true]);
+
+        $this->assertSame(0, $code);
+
+        Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::DELETE, strtolower($module_name)));
+    }
+
+    public function test_it_fires_events_when_multi_module_deleted()
+    {
+        $modules = [
+            'Foo',
+            'Bar',
+            'Zoo',
+        ];
+
+        foreach ($modules as $module) {
+            $this->createModule($module);
+        }
+
+        Event::fake();
+
+        $code = $this->artisan('module:delete', ['--all' => true, '--force' => true]);
+
+        $this->assertSame(0, $code);
+
+        foreach ($modules as $module) {
+            Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::DELETE, strtolower($module)));
+        }
     }
 }

--- a/tests/Commands/Actions/ModuleDeleteCommandTest.php
+++ b/tests/Commands/Actions/ModuleDeleteCommandTest.php
@@ -104,7 +104,8 @@ class ModuleDeleteCommandTest extends BaseTestCase
 
         $this->assertSame(0, $code);
 
-        Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::DELETE, strtolower($module_name)));
+        Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::DELETING, strtolower($module_name)));
+        Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::DELETED, strtolower($module_name)));
     }
 
     public function test_it_fires_events_when_multi_module_deleted()
@@ -126,7 +127,8 @@ class ModuleDeleteCommandTest extends BaseTestCase
         $this->assertSame(0, $code);
 
         foreach ($modules as $module) {
-            Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::DELETE, strtolower($module)));
+            Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::DELETING, strtolower($module)));
+            Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::DELETED, strtolower($module)));
         }
     }
 }

--- a/tests/Commands/Make/ModuleMakeCommandTest.php
+++ b/tests/Commands/Make/ModuleMakeCommandTest.php
@@ -3,7 +3,9 @@
 namespace Nwidart\Modules\Tests\Commands\Make;
 
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
+use Nwidart\Modules\Constants\ModuleEvent;
 use Nwidart\Modules\Contracts\ActivatorInterface;
 use Nwidart\Modules\Contracts\RepositoryInterface;
 use Nwidart\Modules\Tests\BaseTestCase;
@@ -482,5 +484,37 @@ class ModuleMakeCommandTest extends BaseTestCase
         $this->assertStringContainsString('JoeBlogs', $content);
 
         $this->assertSame(0, $code);
+    }
+
+    public function test_it_fires_events_when_module_created()
+    {
+        $module_name = 'Blog';
+        Event::fake();
+
+        $code = $this->createModule($module_name);
+
+        $this->assertSame(0, $code);
+
+        Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::CREATE, strtolower($module_name)));
+    }
+
+    public function test_it_fires_events_when_multi_module_created()
+    {
+        Event::fake();
+
+        $modules = [
+            'Foo',
+            'Bar',
+            'Zoo',
+        ];
+
+        $code = $this->artisan('module:make', ['name' => $modules]);
+
+        $this->assertSame(0, $code);
+
+        foreach ($modules as $module) {
+            Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::CREATE, strtolower($module)));
+        }
+
     }
 }

--- a/tests/Commands/Make/ModuleMakeCommandTest.php
+++ b/tests/Commands/Make/ModuleMakeCommandTest.php
@@ -495,7 +495,8 @@ class ModuleMakeCommandTest extends BaseTestCase
 
         $this->assertSame(0, $code);
 
-        Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::CREATE, strtolower($module_name)));
+        Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::CREATING, strtolower($module_name)));
+        Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::CREATED, strtolower($module_name)));
     }
 
     public function test_it_fires_events_when_multi_module_created()
@@ -513,7 +514,8 @@ class ModuleMakeCommandTest extends BaseTestCase
         $this->assertSame(0, $code);
 
         foreach ($modules as $module) {
-            Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::CREATE, strtolower($module)));
+            Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::CREATING, strtolower($module)));
+            Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::CREATED, strtolower($module)));
         }
 
     }

--- a/tests/LaravelFileRepositoryTest.php
+++ b/tests/LaravelFileRepositoryTest.php
@@ -32,6 +32,7 @@ class LaravelFileRepositoryTest extends BaseTestCase
     public function tearDown(): void
     {
         $this->activator->reset();
+        $this->artisan('module:delete', ['--all' => true, '--force' => true]);
         parent::tearDown();
     }
 

--- a/tests/LaravelModuleTest.php
+++ b/tests/LaravelModuleTest.php
@@ -5,6 +5,7 @@ namespace Nwidart\Modules\Tests;
 use Illuminate\Support\Facades\Event;
 use Modules\Recipe\Providers\DeferredServiceProvider;
 use Modules\Recipe\Providers\RecipeServiceProvider;
+use Nwidart\Modules\Constants\ModuleEvent;
 use Nwidart\Modules\Contracts\ActivatorInterface;
 use Nwidart\Modules\Json;
 
@@ -147,8 +148,8 @@ class LaravelModuleTest extends BaseTestCase
 
         $this->module->enable();
 
-        Event::assertDispatched(sprintf('modules.%s.enabling', $this->module->getLowerName()));
-        Event::assertDispatched(sprintf('modules.%s.enabled', $this->module->getLowerName()));
+        Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::ENABLING, $this->module->getLowerName()));
+        Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::ENABLED, $this->module->getLowerName()));
     }
 
     public function test_it_fires_events_when_module_is_disabled()
@@ -157,8 +158,8 @@ class LaravelModuleTest extends BaseTestCase
 
         $this->module->disable();
 
-        Event::assertDispatched(sprintf('modules.%s.disabling', $this->module->getLowerName()));
-        Event::assertDispatched(sprintf('modules.%s.disabled', $this->module->getLowerName()));
+        Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::DISABLING, $this->module->getLowerName()));
+        Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::DISABLED, $this->module->getLowerName()));
     }
 
     public function test_it_has_a_good_providers_manifest_path()

--- a/tests/LumenModuleTest.php
+++ b/tests/LumenModuleTest.php
@@ -3,6 +3,7 @@
 namespace Nwidart\Modules\Tests;
 
 use Illuminate\Support\Facades\Event;
+use Nwidart\Modules\Constants\ModuleEvent;
 use Nwidart\Modules\Contracts\ActivatorInterface;
 use Nwidart\Modules\Json;
 
@@ -114,8 +115,8 @@ class LumenModuleTest extends BaseTestCase
 
         $this->module->enable();
 
-        Event::assertDispatched(sprintf('modules.%s.enabling', $this->module->getLowerName()));
-        Event::assertDispatched(sprintf('modules.%s.enabled', $this->module->getLowerName()));
+        Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::ENABLING, $this->module->getLowerName()));
+        Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::ENABLED, $this->module->getLowerName()));
     }
 
     public function test_it_fires_events_when_module_is_disabled()
@@ -124,8 +125,8 @@ class LumenModuleTest extends BaseTestCase
 
         $this->module->disable();
 
-        Event::assertDispatched(sprintf('modules.%s.disabling', $this->module->getLowerName()));
-        Event::assertDispatched(sprintf('modules.%s.disabled', $this->module->getLowerName()));
+        Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::DISABLING, $this->module->getLowerName()));
+        Event::assertDispatched(sprintf('modules.%s.'.ModuleEvent::DISABLED, $this->module->getLowerName()));
     }
 
     public function test_it_has_a_good_providers_manifest_path()
@@ -137,6 +138,4 @@ class LumenModuleTest extends BaseTestCase
     }
 }
 
-class LumenTestingModule extends \Nwidart\Modules\Lumen\Module
-{
-}
+class LumenTestingModule extends \Nwidart\Modules\Lumen\Module {}


### PR DESCRIPTION
Hi,

In this pull request, I have added events for various actions and created a constant `ModuleEvent` to manage event names.

- New events added: `creating`, `created`, `deleting`, `deleted`, `used`, `unused`
- Existing events updated for usage: `boot`, `register`, `disabling`, `disabled`, `enabling`, `enabled`

This pull request depends on #1879, as provider files are registered with a single file. It's important to add a listener to clear the manifest file after certain actions.

Thanks.