### PR TITLE
Module route plural paths & names

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -39,8 +39,8 @@ return [
             'package' => 'package.json',
         ],
         'replacements' => [
-            'routes/web' => ['LOWER_NAME', 'STUDLY_NAME', 'MODULE_NAMESPACE', 'CONTROLLER_NAMESPACE'],
-            'routes/api' => ['LOWER_NAME', 'STUDLY_NAME', 'MODULE_NAMESPACE', 'CONTROLLER_NAMESPACE'],
+            'routes/web' => ['LOWER_NAME', 'PLURAL_LOWER_NAME', 'STUDLY_NAME', 'MODULE_NAMESPACE', 'CONTROLLER_NAMESPACE'],
+            'routes/api' => ['LOWER_NAME', 'PLURAL_LOWER_NAME', 'STUDLY_NAME', 'MODULE_NAMESPACE', 'CONTROLLER_NAMESPACE'],
             'vite' => ['LOWER_NAME', 'STUDLY_NAME'],
             'json' => ['LOWER_NAME', 'STUDLY_NAME', 'MODULE_NAMESPACE', 'PROVIDER_NAMESPACE'],
             'views/index' => ['LOWER_NAME'],

--- a/src/Commands/stubs/routes/api.stub
+++ b/src/Commands/stubs/routes/api.stub
@@ -3,17 +3,6 @@
 use Illuminate\Support\Facades\Route;
 use $MODULE_NAMESPACE$\$STUDLY_NAME$\$CONTROLLER_NAMESPACE$\$STUDLY_NAME$Controller;
 
-/*
- *--------------------------------------------------------------------------
- * API Routes
- *--------------------------------------------------------------------------
- *
- * Here is where you can register API routes for your application. These
- * routes are loaded by the RouteServiceProvider within a group which
- * is assigned the "api" middleware group. Enjoy building your API!
- *
-*/
-
 Route::middleware(['auth:sanctum'])->prefix('v1')->group(function () {
-    Route::apiResource('$LOWER_NAME$', $STUDLY_NAME$Controller::class)->names('$LOWER_NAME$');
+    Route::apiResource('$PLURAL_LOWER_NAME$', $STUDLY_NAME$Controller::class);
 });

--- a/src/Commands/stubs/routes/api.stub
+++ b/src/Commands/stubs/routes/api.stub
@@ -4,5 +4,5 @@ use Illuminate\Support\Facades\Route;
 use $MODULE_NAMESPACE$\$STUDLY_NAME$\$CONTROLLER_NAMESPACE$\$STUDLY_NAME$Controller;
 
 Route::middleware(['auth:sanctum'])->prefix('v1')->group(function () {
-    Route::apiResource('$PLURAL_LOWER_NAME$', $STUDLY_NAME$Controller::class);
+    Route::apiResource('$PLURAL_LOWER_NAME$', $STUDLY_NAME$Controller::class)->names('$PLURAL_LOWER_NAME$');
 });

--- a/src/Commands/stubs/routes/web.stub
+++ b/src/Commands/stubs/routes/web.stub
@@ -3,6 +3,6 @@
 use Illuminate\Support\Facades\Route;
 use $MODULE_NAMESPACE$\$STUDLY_NAME$\$CONTROLLER_NAMESPACE$\$STUDLY_NAME$Controller;
 
-Route::group([], function () {
-    Route::resource('$PLURAL_LOWER_NAME$', $STUDLY_NAME$Controller::class);
+Route::middleware(['auth', 'verified'])->group(function () {
+    Route::resource('$PLURAL_LOWER_NAME$', $STUDLY_NAME$Controller::class)->names('$PLURAL_LOWER_NAME$');
 });

--- a/src/Commands/stubs/routes/web.stub
+++ b/src/Commands/stubs/routes/web.stub
@@ -3,17 +3,6 @@
 use Illuminate\Support\Facades\Route;
 use $MODULE_NAMESPACE$\$STUDLY_NAME$\$CONTROLLER_NAMESPACE$\$STUDLY_NAME$Controller;
 
-/*
-|--------------------------------------------------------------------------
-| Web Routes
-|--------------------------------------------------------------------------
-|
-| Here is where you can register web routes for your application. These
-| routes are loaded by the RouteServiceProvider within a group which
-| contains the "web" middleware group. Now create something great!
-|
-*/
-
 Route::group([], function () {
-    Route::resource('$LOWER_NAME$', $STUDLY_NAME$Controller::class)->names('$LOWER_NAME$');
+    Route::resource('$PLURAL_LOWER_NAME$', $STUDLY_NAME$Controller::class);
 });

--- a/src/Generators/ModuleGenerator.php
+++ b/src/Generators/ModuleGenerator.php
@@ -483,6 +483,7 @@ class ModuleGenerator extends Generator
                 $keys[] = 'PROVIDER_NAMESPACE';
             }
         }
+
         foreach ($keys as $key) {
             if (method_exists($this, $method = 'get'.ucfirst(Str::studly(strtolower($key))).'Replacement')) {
                 $replaces[$key] = $this->$method();
@@ -534,7 +535,15 @@ class ModuleGenerator extends Generator
      */
     protected function getLowerNameReplacement(): string
     {
-        return strtolower($this->getName());
+        return Str::of($this->getName())->lower();
+    }
+
+    /**
+     * Get the module name in plural lower case.
+     */
+    protected function getPluralLowerNameReplacement(): string
+    {
+        return Str::of($this->getName())->lower()->plural();
     }
 
     /**
@@ -543,6 +552,14 @@ class ModuleGenerator extends Generator
     protected function getStudlyNameReplacement(): string
     {
         return $this->getName();
+    }
+
+    /**
+     * Get the module name in plural studly case.
+     */
+    protected function getPluralStudlyNameReplacement(): string
+    {
+        return Str::of($this->getName())->pluralStudly();
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_route_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_route_file__1.txt
@@ -4,5 +4,5 @@ use Illuminate\Support\Facades\Route;
 use Modules\Blog\Http\Controllers\BlogController;
 
 Route::middleware(['auth:sanctum'])->prefix('v1')->group(function () {
-    Route::apiResource('blogs', BlogController::class);
+    Route::apiResource('blogs', BlogController::class)->names('$PLURAL_LOWER_NAME$');
 });

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_route_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_route_file__1.txt
@@ -3,17 +3,6 @@
 use Illuminate\Support\Facades\Route;
 use Modules\Blog\Http\Controllers\BlogController;
 
-/*
- *--------------------------------------------------------------------------
- * API Routes
- *--------------------------------------------------------------------------
- *
- * Here is where you can register API routes for your application. These
- * routes are loaded by the RouteServiceProvider within a group which
- * is assigned the "api" middleware group. Enjoy building your API!
- *
-*/
-
 Route::middleware(['auth:sanctum'])->prefix('v1')->group(function () {
-    Route::apiResource('blog', BlogController::class)->names('blog');
+    Route::apiResource('blogs', BlogController::class);
 });

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_route_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_route_file__1.txt
@@ -4,5 +4,5 @@ use Illuminate\Support\Facades\Route;
 use Modules\Blog\Http\Controllers\BlogController;
 
 Route::middleware(['auth:sanctum'])->prefix('v1')->group(function () {
-    Route::apiResource('blogs', BlogController::class)->names('$PLURAL_LOWER_NAME$');
+    Route::apiResource('blogs', BlogController::class)->names('blogs');
 });

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_route_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_route_file__1.txt
@@ -3,17 +3,6 @@
 use Illuminate\Support\Facades\Route;
 use Modules\Blog\Http\Controllers\BlogController;
 
-/*
-|--------------------------------------------------------------------------
-| Web Routes
-|--------------------------------------------------------------------------
-|
-| Here is where you can register web routes for your application. These
-| routes are loaded by the RouteServiceProvider within a group which
-| contains the "web" middleware group. Now create something great!
-|
-*/
-
 Route::group([], function () {
-    Route::resource('blog', BlogController::class)->names('blog');
+    Route::resource('blogs', BlogController::class);
 });

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_route_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_route_file__1.txt
@@ -3,6 +3,6 @@
 use Illuminate\Support\Facades\Route;
 use Modules\Blog\Http\Controllers\BlogController;
 
-Route::group([], function () {
-    Route::resource('blogs', BlogController::class);
+Route::middleware(['auth', 'verified'])->group(function () {
+    Route::resource('blogs', BlogController::class)->names('blogs');
 });


### PR DESCRIPTION
Based on https://github.com/nWidart/laravel-modules/issues/949

- Added two new replacements - PLURAL_LOWER_NAME and PLURAL_STUDLY_NAME
- Generate modules route path in a plural name (e.g. `/users`, `/posts`, etc.)
- Allow the route resource to auto-generate its name from the path.
- Added the a new replacement to the config file