### PR TITLE
Change `Multiselect` to `Multisearch` in BaseCommand

### DIFF
--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -111,7 +111,7 @@ abstract class BaseCommand extends Command implements PromptsForMissingInput
                     ...$modules,
                 ])->when(strlen($search_value) > 0, function (Collection &$modules) use ($search_value) {
                     return $modules->filter(fn ($item) => str_contains(strtolower($item), strtolower($search_value)));
-                })->toArray();
+                })->values()->toArray();
             },
             required: 'You must select at least one module',
         );

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -30,18 +30,22 @@ abstract class BaseCommand extends Command implements PromptsForMissingInput
     public function __construct()
     {
         parent::__construct();
-        $this->getDefinition()->addOption(new InputOption(
-            strtolower(self::ALL),
-            'a',
-            InputOption::VALUE_NONE,
-            'Check all Modules',
-        ));
+        $this->getDefinition()->addOption(
+            option: new InputOption(
+                name: strtolower(self::ALL),
+                shortcut: 'a',
+                mode: InputOption::VALUE_NONE,
+                description: 'Check all Modules',
+            )
+        );
 
-        $this->getDefinition()->addArgument(new InputArgument(
-            'module',
-            InputArgument::IS_ARRAY,
-            'The name of module will be used.',
-        ));
+        $this->getDefinition()->addArgument(
+            argument: new InputArgument(
+                name: 'module',
+                mode: InputArgument::IS_ARRAY,
+                description: 'The name of module will be used.',
+            )
+        );
 
         if ($this instanceof ConfirmableCommand) {
             $this->configureConfirmable();
@@ -130,11 +134,13 @@ abstract class BaseCommand extends Command implements PromptsForMissingInput
     private function configureConfirmable(): void
     {
         $this->getDefinition()
-            ->addOption(new InputOption(
-                'force',
-                null,
-                InputOption::VALUE_NONE,
-                'Force the operation to run without confirmation.',
-            ));
+            ->addOption(
+                option: new InputOption(
+                    name: 'force',
+                    shortcut: null,
+                    mode: InputOption::VALUE_NONE,
+                    description: 'Force the operation to run without confirmation.',
+                )
+            );
     }
 }


### PR DESCRIPTION
Hi,

In this pull request, I have changed `multiselect` to `multisearch` in the Laravel prompt. This modification allows for faster searching and selection of modules, which is especially useful when the module list is loaded with priority, such as in the migrate command.

This improvement enhances the efficiency of managing projects with many modules.

Thanks.