### PR TITLE
Lavavel Pint as a dev-dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
   "require": {
     "php": ">=8.2",
     "ext-json": "*",
-    "wikimedia/composer-merge-plugin": "^2.1",
-    "laravel/pint": "^1.16"
+    "wikimedia/composer-merge-plugin": "^2.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^11.0",
@@ -29,6 +28,7 @@
     "orchestra/testbench": "^v9.0",
     "friendsofphp/php-cs-fixer": "^v3.52",
     "laravel/framework": "^v11.0",
+    "laravel/pint": "^1.16",
     "spatie/phpunit-snapshot-assertions": "^5.0",
     "phpstan/phpstan": "^1.4"
   },


### PR DESCRIPTION
#1872 introduced Laravel pint but incorrectly marked it a dependency instead of as a dev-dependency. 

The result of this is that Laravel pint gets installed in production