### PR TITLE
Fix for Running Root Migrations Before Module Migrations

### DIFF
--- a/src/Commands/Database/MigrateFreshCommand.php
+++ b/src/Commands/Database/MigrateFreshCommand.php
@@ -55,6 +55,7 @@ class MigrateFreshCommand extends BaseCommand
 
         // run migration of root
         $root_paths = $this->migration_paths
+            ->push($this->laravel->databasePath().DIRECTORY_SEPARATOR.'migrations')
             ->reject(fn (string $path) => str_starts_with($path, config('modules.paths.modules')));
 
         if ($root_paths->count() > 0) {


### PR DESCRIPTION

Hi,

While testing the `module:migrate-fresh` command, I discovered that root migrations were not being executed before the module migrations.

This issue occurs because, in the Laravel framework's `migrate` command, the default migration paths are merged when the method is called, but they are not registered by default. You can see the relevant code here: [Laravel Framework Migration Command](https://github.com/laravel/framework/blob/6ce800fdafdb0ed17ae62c65a78f8ced9b10003d/src/Illuminate/Database/Console/Migrations/BaseCommand.php#L27-L29).

```php
return array_merge(
    $this->migrator->paths(), [$this->getMigrationPath()]
);
```

This pull request addresses and fixes this issue, ensuring that root migrations are executed before module migrations.