### PR TITLE
Auto-Register Module Language Files

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -188,6 +188,16 @@ return [
         */
         'migrations' => true,
 
+        /*
+        |--------------------------------------------------------------------------
+        | Translations
+        |--------------------------------------------------------------------------
+        |
+        | This option for register lang file automatically.
+        |
+        */
+        'translations' => false,
+
     ],
 
     /*

--- a/src/LaravelModulesServiceProvider.php
+++ b/src/LaravelModulesServiceProvider.php
@@ -3,11 +3,13 @@
 namespace Nwidart\Modules;
 
 use Composer\InstalledVersions;
+use Illuminate\Contracts\Translation\Translator as TranslatorContract;
 use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Translation\Translator;
 use Nwidart\Modules\Constants\ModuleEvent;
 use Nwidart\Modules\Contracts\RepositoryInterface;
 use Nwidart\Modules\Exceptions\InvalidActivatorClass;
@@ -51,6 +53,7 @@ class LaravelModulesServiceProvider extends ModulesServiceProvider
         $this->registerProviders();
 
         $this->registerMigrations();
+        $this->registerTransactions();
 
         $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'modules');
     }
@@ -115,6 +118,34 @@ class LaravelModulesServiceProvider extends ModulesServiceProvider
                 });
         });
     }
+
+    protected function registerTransactions(): void
+    {
+        if (! $this->app['config']->get('modules.auto-discover.translations', true)) {
+            return;
+        }
+
+        $this->callAfterResolving('translator', function (TranslatorContract $translator) {
+            if (! $translator instanceof Translator) {
+                return;
+            }
+
+            $path = implode(DIRECTORY_SEPARATOR, [
+                $this->app['config']->get('modules.paths.modules'),
+                '*',
+                'lang',
+            ]);
+
+            collect(glob($path, GLOB_ONLYDIR))
+                ->each(function (string $path) use ($translator) {
+                    preg_match('/Modules\/([^\/]+)/', $path, $matches);
+
+                    $translator->addNamespace(strtolower($matches[1]), $path);
+                    $translator->addJsonPath($path);
+                });
+        });
+    }
+
 
     private function registerEvents(): void
     {


### PR DESCRIPTION
Hi,

This Pull Request introduces a method to automatically register language files for modules. By default, this option is enabled, but it can be managed by the client based on their needs from config.

When automatic registration of translations is enabled, the following section can be removed from all modules:  🚀
```php
public function registerTranslations(): void
{
    $langPath = resource_path('lang/modules/'.$this->moduleNameLower);

    if (is_dir($langPath)) {
        $this->loadTranslationsFrom($langPath, $this->moduleNameLower);
        $this->loadJsonTranslationsFrom($langPath);
    } else {
        $this->loadTranslationsFrom(module_path($this->moduleName, 'lang'), $this->moduleNameLower);
        $this->loadJsonTranslationsFrom(module_path($this->moduleName, 'lang'));
    }
}
```

After this pull request is merged, I will create another pull request to update the stubs for service providers and perform some cleanup to prevent the registration of duplicate processes.

Please note that this update does not support language files located at `resource_path('lang/modules/'.$this->moduleNameLower)`. Clients will need to register this path manually if needed. 

Please review and provide your feedback.