### PR TITLE
Blazing Fast Module Loading 🚀😎

### DIFF
--- a/src/Contracts/RepositoryInterface.php
+++ b/src/Contracts/RepositoryInterface.php
@@ -15,13 +15,6 @@ interface RepositoryInterface
     public function all();
 
     /**
-     * Get cached modules.
-     *
-     * @return array
-     */
-    public function getCached();
-
-    /**
      * Scan & get all available modules.
      *
      * @return array

--- a/src/FileRepository.php
+++ b/src/FileRepository.php
@@ -173,46 +173,7 @@ abstract class FileRepository implements Countable, RepositoryInterface
      */
     public function all(): array
     {
-        if (! $this->config('cache.enabled')) {
-            return $this->scan();
-        }
-
-        return $this->formatCached($this->getCached());
-    }
-
-    /**
-     * Format the cached data as array of modules.
-     *
-     * @param  array  $cached
-     * @return array
-     */
-    protected function formatCached($cached)
-    {
-        $modules = [];
-
-        foreach ($cached as $name => $module) {
-            $path = $module['path'];
-
-            $modules[$name] = $this->createModule($this->app, $name, $path);
-        }
-
-        return $modules;
-    }
-
-    /**
-     * Get cached modules.
-     *
-     * @return array
-     */
-    public function getCached()
-    {
-        return $this->cache->store($this->config->get('modules.cache.driver'))->remember(
-            key: $this->config('cache.key'),
-            ttl: $this->config('cache.lifetime'),
-            callback: function () {
-                return $this->toCollection()->toArray();
-            }
-        );
+        return $this->scan();
     }
 
     /**

--- a/src/Generators/ModuleGenerator.php
+++ b/src/Generators/ModuleGenerator.php
@@ -278,8 +278,6 @@ class ModuleGenerator extends Generator
     {
         $name = $this->getName();
 
-        Event::dispatch(sprintf('modules.%s.%s', strtolower($name), ModuleEvent::CREATING));
-
         if ($this->module->has($name)) {
             if ($this->force) {
                 $this->module->delete($name);
@@ -289,6 +287,9 @@ class ModuleGenerator extends Generator
                 return E_ERROR;
             }
         }
+
+        Event::dispatch(sprintf('modules.%s.%s', strtolower($name), ModuleEvent::CREATING));
+
         $this->component->info("Creating module: [$name]");
 
         $this->generateFolders();

--- a/src/Json.php
+++ b/src/Json.php
@@ -136,7 +136,7 @@ class Json
      */
     public function getAttributes()
     {
-        return $this->decodeContents();
+        return $this->attributes ?? $this->decodeContents();
     }
 
     /**

--- a/src/Traits/CanClearModulesCache.php
+++ b/src/Traits/CanClearModulesCache.php
@@ -12,5 +12,7 @@ trait CanClearModulesCache
         if (config('modules.cache.enabled') === true) {
             app('cache')->forget(config('modules.cache.key'));
         }
+
+        $this->laravel['modules']->resetModules();
     }
 }

--- a/tests/Commands/Actions/ModuleDeleteCommandTest.php
+++ b/tests/Commands/Actions/ModuleDeleteCommandTest.php
@@ -30,6 +30,14 @@ class ModuleDeleteCommandTest extends BaseTestCase
         $this->activator = new FileActivator($this->app);
     }
 
+    public function tearDown(): void
+    {
+        $this->artisan('module:delete', ['--all' => true, '--force' => true]);
+
+        $this->activator->reset();
+        parent::tearDown();
+    }
+
     public function test_it_can_delete_a_module_from_disk(): void
     {
         $this->artisan('module:make', ['name' => ['WrongModule']]);


### PR DESCRIPTION
Hi,

In this pull request, I've updated the logic of the `FileRepository` to significantly speed up the load time of modules by storing the result of the `scan` method in a static variable.

### Benchmarking
To test this improvement, I created 166 modules and benchmarked the `isEnabled()` method of the package.

**Benchmark Code:**
```php
    $modules = [
        "A1"        => "A1",
        "A2"        => "A2",
        "Ali"       => "Ali",
        "Auth"      => "Auth",
        "Module0"   => "Module0",
        "Module1"   => "Module1",
        "Module10"  => "Module10",
        // other modules name
        "Module98"  => "Module98",
        "Module99"  => "Module99",
        "Profile"   => "Profile",
    ];

    \Illuminate\Support\Benchmark::dd([
        'check1' => function () use ($modules) {
            $module = array_rand($modules);
            $a      = \Nwidart\Modules\Facades\Module::isEnabled($module);
        },
    ], 30);
```

**Results:**

*Before:*
<img width="615" alt="image" src="https://github.com/user-attachments/assets/1f67b314-e56a-4d94-b374-d2afed558779">

*After:*
<img width="589" alt="image" src="https://github.com/user-attachments/assets/45beb5d9-34dd-45ce-9649-500afd09cc25">

also check with [laravel-debugbar](https://github.com/barryvdh/laravel-debugbar):
*Before:*
![telegram-cloud-photo-size-4-5904411011077751978-y](https://github.com/user-attachments/assets/3d55ca54-b235-464c-9042-58dd9828bf59)
*After:*
![telegram-cloud-photo-size-4-5904411011077751977-y](https://github.com/user-attachments/assets/170c7243-608d-43b7-9d87-3be705eda090)

As you can see, the results are impressive! 🚀🚀🚀😎

### Additional Improvements:
I've also optimized the logic for finding modules. Previously, the module search was done inside a loop with a complexity of O(n):

```php
 foreach ($this->all() as $module) {
    if ($module->getLowerName() === strtolower($name)) {
        return $module;
    }
}
```

Now, I've changed the storage keys to lowercase when storing, and I check for module existence with an array key, reducing the complexity to O(1):

```php
   return $this->all()[strtolower($name)] ?? null;
```

This change further enhances performance and efficiency.  and can solve #1745 

Please review the changes and let me know your thoughts!