### PR TITLE
Add Issue Template for Improved Support

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.md
@@ -1,0 +1,23 @@
+---
+name: "🐛 Bug Report"
+about: 'Report a general bug.'
+labels: bug
+
+---
+
+### Versions:
+- laravel-modules Version: #.#.#
+- Laravel Version: #.#.#
+- PHP Version: #.#.#
+
+### Description:
+
+<!--
+Please describe in detail the nature of the bug, code samples, etc.
+
+The more, the better.
+-->
+
+### Steps To Reproduce:
+
+- …

--- a/.github/ISSUE_TEMPLATE/2_Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2_Feature_request.md
@@ -1,0 +1,12 @@
+---
+name: "✨ Feature request"
+about: 'Suggest a new feature or other improvements.'
+labels: "feature request"
+
+---
+
+### Summary
+
+<!--
+Describe in detail what you propose, show (preferable) code examples and also signal if you're willing to work on it!
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+    - name: 🙋🏼‍♂️ Support Questions & Other
+      url: https://github.com/nWidart/laravel-modules/discussions/new
+      about: 'I need assistance or clarification on usage of this library.'


### PR DESCRIPTION
Hi,

This pull request adds an issue template that prompts users to provide the Laravel and package version before creating an issue. This aims to improve the response process by ensuring that essential information is available from the start.

Here’s a preview:
<img width="929" alt="image" src="https://github.com/user-attachments/assets/030cb559-edf8-4022-a381-a72be6053bff">

Thanks!