### PR TITLE
Delete cache of module_status.json

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -249,21 +249,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Caching
-    |--------------------------------------------------------------------------
-    |
-    | Here is the config for setting up the caching feature.
-    |
-    */
-    'cache' => [
-        'enabled' => env('MODULES_CACHE_ENABLED', false),
-        'driver' => env('MODULES_CACHE_DRIVER', 'file'),
-        'key' => env('MODULES_CACHE_KEY', 'laravel-modules'),
-        'lifetime' => env('MODULES_CACHE_LIFETIME', 60),
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
     | Choose what laravel-modules will register as custom namespaces.
     | Setting one to false will require you to register that part
     | in your own Service Provider class.
@@ -290,8 +275,6 @@ return [
         'file' => [
             'class' => FileActivator::class,
             'statuses-file' => base_path('modules_statuses.json'),
-            'cache-key' => 'activator.installed',
-            'cache-lifetime' => 604800,
         ],
     ],
 

--- a/src/Module.php
+++ b/src/Module.php
@@ -347,7 +347,6 @@ abstract class Module
         $this->fireEvent(ModuleEvent::DISABLING);
 
         $this->activator->disable($this);
-        $this->flushCache();
 
         $this->fireEvent(ModuleEvent::DISABLED);
     }
@@ -360,7 +359,6 @@ abstract class Module
         $this->fireEvent(ModuleEvent::ENABLING);
 
         $this->activator->enable($this);
-        $this->flushCache();
 
         $this->fireEvent(ModuleEvent::ENABLED);
     }
@@ -397,13 +395,6 @@ abstract class Module
         return config('modules.register.files', 'register') === 'boot' &&
             // force register method if option == boot && app is AsgardCms
             ! class_exists('\Modules\Core\Foundation\AsgardCms');
-    }
-
-    private function flushCache(): void
-    {
-        if (config('modules.cache.enabled')) {
-            $this->cache->store(config('modules.cache.driver'))->flush();
-        }
     }
 
     /**

--- a/src/Traits/CanClearModulesCache.php
+++ b/src/Traits/CanClearModulesCache.php
@@ -9,10 +9,6 @@ trait CanClearModulesCache
      */
     public function clearCache()
     {
-        if (config('modules.cache.enabled') === true) {
-            app('cache')->forget(config('modules.cache.key'));
-        }
-
         $this->laravel['modules']->resetModules();
     }
 }


### PR DESCRIPTION
Hi,

In this pull request, I've removed the caching mechanism for the `module_status.json` file and switched to reading it directly. The direct read operation is fast and not need cache.

Additionally, I've completely removed the cache-related code from the package and cleaned up unused keys in the config file.
