### PR TITLE
Reset Static Variable for Module Creation

### DIFF
--- a/src/Generators/ModuleGenerator.php
+++ b/src/Generators/ModuleGenerator.php
@@ -298,6 +298,7 @@ class ModuleGenerator extends Generator
 
         if ($this->type !== 'plain') {
             $this->generateFiles();
+            $this->module->resetModules();
             $this->generateResources();
         }
 


### PR DESCRIPTION
Hi,

In this pull request, I address an issue that occurs when creating a new module (not the first module). Since the list of modules is stored in a static variable during execution, the newly created module’s files are not immediately recognized. This creates problems when subsequent commands are called, such as:
- module:make-seed
- module:make-event-provider
- module:route-provider
- module:make-controller

To resolve this, I reset the static variable used for storing the module list. This ensures the module paths are re-scanned, allowing the new module to be fully recognized and enabling the commands to work correctly.

Fixes #1956
