### PR TITLE
Synchronize `module:model-show` Command with `model:show` Command in Laravel Framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "mockery/mockery": "^1.6",
     "orchestra/testbench": "^v9.0",
     "friendsofphp/php-cs-fixer": "^v3.52",
-    "laravel/framework": "^v11.0",
+    "laravel/framework": "^v11.33",
     "laravel/pint": "^1.16",
     "spatie/phpunit-snapshot-assertions": "^5.0",
     "phpstan/phpstan": "^1.4"


### PR DESCRIPTION
Hi,  

This pull request updates the `module:model-show` command to align its functionality with the `model:show` command of the Laravel framework. For additional details, you can refer to the related [Laravel Framework Pull Request](https://github.com/laravel/framework/pull/53541).  

The `qualifyModel` method has been removed from the framework. I have implemented the `promptForMissingArgumentsUsing` method from Laravel's console prompt system to handle model resolution interactively.  

fixes #1989.  
