### PR TITLE
Add `prohibitDestructiveCommands` Method to Prevent Running Destructive Commands in Production

### DIFF
--- a/src/Commands/Actions/ModuleDeleteCommand.php
+++ b/src/Commands/Actions/ModuleDeleteCommand.php
@@ -28,4 +28,9 @@ class ModuleDeleteCommand extends BaseCommand implements ConfirmableCommand
     {
         return 'Warning: Do you want to remove the module?';
     }
+
+    public function getConfirmableCallback(): \Closure|bool|null
+    {
+        return true;
+    }
 }

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -61,7 +61,12 @@ abstract class BaseCommand extends Command implements PromptsForMissingInput
 
     public function getConfirmableLabel(): ?string
     {
-        return 'Warning';
+        return 'Application In Production';
+    }
+
+    public function getConfirmableCallback(): \Closure|bool|null
+    {
+        return null;
     }
 
     /**
@@ -71,8 +76,8 @@ abstract class BaseCommand extends Command implements PromptsForMissingInput
     {
         if ($this instanceof ConfirmableCommand) {
             if ($this->isProhibited() ||
-                ! $this->confirmToProceed($this->getConfirmableLabel(), fn () => true)) {
-                return 1;
+                ! $this->confirmToProceed($this->getConfirmableLabel(), $this->getConfirmableCallback())) {
+                return Command::FAILURE;
             }
         }
 

--- a/src/Commands/Database/MigrateFreshCommand.php
+++ b/src/Commands/Database/MigrateFreshCommand.php
@@ -5,9 +5,10 @@ namespace Nwidart\Modules\Commands\Database;
 use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Support\Collection;
 use Nwidart\Modules\Commands\BaseCommand;
+use Nwidart\Modules\Contracts\ConfirmableCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-class MigrateFreshCommand extends BaseCommand
+class MigrateFreshCommand extends BaseCommand implements ConfirmableCommand
 {
     /**
      * The console command name.

--- a/src/Commands/Database/MigrateRefreshCommand.php
+++ b/src/Commands/Database/MigrateRefreshCommand.php
@@ -3,9 +3,10 @@
 namespace Nwidart\Modules\Commands\Database;
 
 use Nwidart\Modules\Commands\BaseCommand;
+use Nwidart\Modules\Contracts\ConfirmableCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-class MigrateRefreshCommand extends BaseCommand
+class MigrateRefreshCommand extends BaseCommand implements ConfirmableCommand
 {
     /**
      * The console command name.

--- a/src/Commands/Database/MigrateResetCommand.php
+++ b/src/Commands/Database/MigrateResetCommand.php
@@ -3,11 +3,12 @@
 namespace Nwidart\Modules\Commands\Database;
 
 use Nwidart\Modules\Commands\BaseCommand;
+use Nwidart\Modules\Contracts\ConfirmableCommand;
 use Nwidart\Modules\Migrations\Migrator;
 use Nwidart\Modules\Traits\MigrationLoaderTrait;
 use Symfony\Component\Console\Input\InputOption;
 
-class MigrateResetCommand extends BaseCommand
+class MigrateResetCommand extends BaseCommand implements ConfirmableCommand
 {
     use MigrationLoaderTrait;
 

--- a/src/Facades/Module.php
+++ b/src/Facades/Module.php
@@ -3,6 +3,9 @@
 namespace Nwidart\Modules\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use Nwidart\Modules\Commands\Database\MigrateFreshCommand;
+use Nwidart\Modules\Commands\Database\MigrateRefreshCommand;
+use Nwidart\Modules\Commands\Database\MigrateResetCommand;
 
 /**
  * @method static array all()
@@ -19,7 +22,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Nwidart\Modules\Module findOrFail(string $name)
  * @method static string getModulePath($moduleName)
  * @method static \Illuminate\Filesystem\Filesystem getFiles()
- * @method static mixed config(string $key, $default = NULL)
+ * @method static mixed config(string $key, $default = null)
  * @method static string getPath()
  * @method static void boot()
  * @method static void register(): void
@@ -30,6 +33,21 @@ use Illuminate\Support\Facades\Facade;
  */
 class Module extends Facade
 {
+    /**
+     * Indicate if destructive Artisan commands should be prohibited.
+     *
+     * Prohibits: module:migrate-fresh, module:migrate-refresh, and module:migrate-reset
+     *
+     * @param  bool  $prohibit
+     * @return void
+     */
+    public static function prohibitDestructiveCommands(bool $prohibit = true): void
+    {
+        MigrateFreshCommand::prohibit($prohibit);
+        MigrateRefreshCommand::prohibit($prohibit);
+        MigrateResetCommand::prohibit($prohibit);
+    }
+
     protected static function getFacadeAccessor(): string
     {
         return 'modules';


### PR DESCRIPTION
Hi,

In this pull request, I’ve added a `prohibitDestructiveCommands` method to the Module facade. This method allows you to indicate whether destructive Artisan commands should be prohibited, especially in production environments.

The commands affected are:
- `module:migrate-fresh`  
- `module:migrate-refresh`  
- `module:migrate-reset`  

### Usage:  

To enable this feature, add the following line to your service provider:
```php
Module::prohibitDestructiveCommands($this->app->isProduction());
```

This ensures that these potentially harmful commands are disabled when running in a production environment, adding an extra layer of safety for your application.

Additionally, this PR updates the confirmable messages to provide clearer communication to users when running these commands.

Thanks.