### PR TITLE
added option to use kebab case

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -39,12 +39,12 @@ return [
             'package' => 'package.json',
         ],
         'replacements' => [
-            'routes/web' => ['LOWER_NAME', 'STUDLY_NAME', 'MODULE_NAMESPACE', 'CONTROLLER_NAMESPACE'],
-            'routes/api' => ['LOWER_NAME', 'STUDLY_NAME', 'MODULE_NAMESPACE', 'CONTROLLER_NAMESPACE'],
-            'vite' => ['LOWER_NAME', 'STUDLY_NAME'],
-            'json' => ['LOWER_NAME', 'STUDLY_NAME', 'MODULE_NAMESPACE', 'PROVIDER_NAMESPACE'],
+            'routes/web' => ['LOWER_NAME', 'STUDLY_NAME', 'KEBAB_NAME', 'MODULE_NAMESPACE', 'CONTROLLER_NAMESPACE'],
+            'routes/api' => ['LOWER_NAME', 'STUDLY_NAME', 'KEBAB_NAME', 'MODULE_NAMESPACE', 'CONTROLLER_NAMESPACE'],
+            'vite' => ['LOWER_NAME', 'STUDLY_NAME', 'KEBAB_NAME'],
+            'json' => ['LOWER_NAME', 'STUDLY_NAME', 'KEBAB_NAME', 'MODULE_NAMESPACE', 'PROVIDER_NAMESPACE'],
             'views/index' => ['LOWER_NAME'],
-            'views/master' => ['LOWER_NAME', 'STUDLY_NAME'],
+            'views/master' => ['LOWER_NAME', 'STUDLY_NAME', 'KEBAB_NAME',],
             'scaffold/config' => ['STUDLY_NAME'],
             'composer' => [
                 'LOWER_NAME',

--- a/src/Commands/Make/RouteProviderMakeCommand.php
+++ b/src/Commands/Make/RouteProviderMakeCommand.php
@@ -65,6 +65,7 @@ class RouteProviderMakeCommand extends GeneratorCommand
             'WEB_ROUTES_PATH' => $this->getWebRoutesPath(),
             'API_ROUTES_PATH' => $this->getApiRoutesPath(),
             'LOWER_NAME' => $module->getLowerName(),
+            'KEBAB_NAME' => $module->getKebabName(),
         ]))->render();
     }
 

--- a/src/Generators/ModuleGenerator.php
+++ b/src/Generators/ModuleGenerator.php
@@ -547,6 +547,11 @@ class ModuleGenerator extends Generator
         return strtolower($this->getName());
     }
 
+    protected function getKebabNameReplacement(): string
+    {
+        return Str::kebab($this->getName());
+    }
+
     /**
      * Get the module name in studly case.
      */

--- a/src/Module.php
+++ b/src/Module.php
@@ -126,6 +126,14 @@ abstract class Module
     }
 
     /**
+     * Get name in studly case.
+     */
+    public function getKebabName(): string
+    {
+        return Str::kebab($this->name);
+    }
+
+    /**
      * Get name in snake case.
      */
     public function getSnakeName(): string


### PR DESCRIPTION
This PR adds support to use kebab case for routes.

To enable this edit your config file and change the path location to your local stub files (publish them if you don't have them)

```php
'stubs' => [
        'enabled' => false,
        'path' => base_path('stubs/nwidart-stubs'),
```

Also add KEBAB in the replacements array:

```php
'replacements' => [
            'routes/web' => ['LOWER_NAME', 'KEBAB_NAME', 'STUDLY_NAME', 'MODULE_NAMESPACE', 'CONTROLLER_NAMESPACE'],
            'routes/api' => ['LOWER_NAME', 'STUDLY_NAME', 'MODULE_NAMESPACE', 'CONTROLLER_NAMESPACE'],
 ```
 
 Then to use in your routes stub edit /stubs/nwidart-stubs/web.stub
 
 ```php
 Route::group([], function () {
    Route::resource('$KEBAB_NAME$', $STUDLY_NAME$Controller::class)->names('$KEBAB_NAME$');
});
```

Next time a module is created it will use the KEBAB case.