### PR TITLE
fix: resolve Blade component namespace issue by removing redundant 'app' prefix in PSR-4 configuration. This caused components to not be recognized in Blade when variables were passed in the component's constructor.

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -116,7 +116,7 @@ return [
             'channels' => ['path' => 'app/Broadcasting', 'generate' => false],
             'class' => ['path' => 'app/Classes', 'generate' => false],
             'command' => ['path' => 'app/Console', 'generate' => false],
-            'component-class' => ['path' => 'app/View/Components', 'generate' => false],
+            'component-class' => ['path' => 'View/Components', 'generate' => false],
             'emails' => ['path' => 'app/Emails', 'generate' => false],
             'event' => ['path' => 'app/Events', 'generate' => false],
             'enums' => ['path' => 'app/Enums', 'generate' => false],

--- a/src/Commands/stubs/scaffold/provider.stub
+++ b/src/Commands/stubs/scaffold/provider.stub
@@ -109,7 +109,7 @@ class $CLASS$ extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->nameLower);
 
-        $componentNamespace = $this->module_namespace($this->name, $this->app_path(config('modules.paths.generator.component-class.path')));
+        $componentNamespace = $this->module_namespace($this->name, config('modules.paths.generator.component-class.path'));
         Blade::componentNamespace($componentNamespace, $this->nameLower);
     }
 


### PR DESCRIPTION
fix: resolve Blade component namespace issue by removing redundant 'app' prefix in PSR-4 configuration. This caused components to not be recognized in Blade when variables were passed in the component's constructor.

The issue was caused by the redundant 'app' prefix in the PSR-4 configuration, which led to Blade components not being recognized correctly. To fix this, the 'app' prefix was removed from both the service provider and the configuration. Without this fix, the component class would not be correctly linked to Blade, and variables defined in the component's constructor would not be recognized.
