### PR TITLE
Remove Cached Module Providers Manifest to Improve Dynamic Module Detection  

### DIFF
--- a/src/Commands/ModuleClearCompiledCommand.php
+++ b/src/Commands/ModuleClearCompiledCommand.php
@@ -5,6 +5,9 @@ namespace Nwidart\Modules\Commands;
 use Illuminate\Console\Command;
 use Nwidart\Modules\ModuleManifest;
 
+/**
+ * @deprecated This command is deprecated and will be removed in the next major version.
+ */
 class ModuleClearCompiledCommand extends Command
 {
     /**
@@ -27,6 +30,6 @@ class ModuleClearCompiledCommand extends Command
             @unlink($manifest->manifestPath);
         }
 
-        $this->components->info('Compiled module files removed successfully.');
+        $this->components->warn('You may stop calling the `module:clear-compiled` command.');
     }
 }

--- a/src/Commands/ModuleDiscoverCommand.php
+++ b/src/Commands/ModuleDiscoverCommand.php
@@ -5,6 +5,9 @@ namespace Nwidart\Modules\Commands;
 use Illuminate\Console\Command;
 use Nwidart\Modules\ModuleManifest;
 
+/**
+ * @deprecated This command is deprecated and will be removed in the next major version.
+ */
 class ModuleDiscoverCommand extends Command
 {
     /**
@@ -23,14 +26,6 @@ class ModuleDiscoverCommand extends Command
 
     public function handle(ModuleManifest $manifest): void
     {
-        $this->components->info('Discovering modules');
-
-        $manifest->build();
-
-        collect($manifest->providersArray())
-            ->map(fn ($provider) => preg_match('/Modules\\\\(.*?)\\\\/', $provider, $matches) ? $matches[1] : null)
-            ->unique()
-            ->each(fn ($description) => $this->components->task($description))
-            ->whenNotEmpty(fn () => $this->newLine());
+        $this->components->warn('You may stop calling the `module:discover` command.');
     }
 }

--- a/src/ModuleManifest.php
+++ b/src/ModuleManifest.php
@@ -63,8 +63,6 @@ class ModuleManifest
 
     /**
      * Get the current package manifest.
-     *
-     * @return array
      */
     public function getManifest(): array
     {
@@ -77,8 +75,6 @@ class ModuleManifest
 
     /**
      * Build the manifest and write it to disk.
-     *
-     * @return array
      */
     public function build(): array
     {
@@ -91,7 +87,7 @@ class ModuleManifest
 
     public function registerFiles(): void
     {
-        //todo check this section store on module.php or not?
+        // todo check this section store on module.php or not?
         $this->getModulesData()
             ->each(function (array $manifest) {
                 if (empty($manifest['files'])) {

--- a/src/ModuleManifest.php
+++ b/src/ModuleManifest.php
@@ -64,7 +64,7 @@ class ModuleManifest
     /**
      * Get the current package manifest.
      */
-    public function getManifest(): array
+    public function getProviders(): array
     {
         if (! is_null($this->manifest)) {
             return $this->manifest;

--- a/src/ModulesServiceProvider.php
+++ b/src/ModulesServiceProvider.php
@@ -31,7 +31,7 @@ abstract class ModulesServiceProvider extends ServiceProvider
         $manifest = app()->make(ModuleManifest::class);
 
         (new ProviderRepository($this->app, new Filesystem, $this->getCachedModulePath()))
-            ->load($manifest->providersArray());
+            ->load($manifest->getManifest());
 
         $manifest->registerFiles();
 

--- a/src/ModulesServiceProvider.php
+++ b/src/ModulesServiceProvider.php
@@ -31,7 +31,7 @@ abstract class ModulesServiceProvider extends ServiceProvider
         $manifest = app()->make(ModuleManifest::class);
 
         (new ProviderRepository($this->app, new Filesystem, $this->getCachedModulePath()))
-            ->load($manifest->getManifest());
+            ->load($manifest->getProviders());
 
         $manifest->registerFiles();
 

--- a/tests/Commands/Actions/ClearCompiledCommandTest.php
+++ b/tests/Commands/Actions/ClearCompiledCommandTest.php
@@ -7,6 +7,9 @@ use Nwidart\Modules\Contracts\RepositoryInterface;
 use Nwidart\Modules\ModuleManifest;
 use Nwidart\Modules\Tests\BaseTestCase;
 
+/**
+ * @deprecated This Test File is deprecated and will be removed in the next major version.
+ */
 class ClearCompiledCommandTest extends BaseTestCase
 {
     private RepositoryInterface $repository;
@@ -36,47 +39,5 @@ class ClearCompiledCommandTest extends BaseTestCase
 
         $this->assertFileDoesNotExist($this->manifestPath);
         $this->assertSame(0, $code);
-    }
-
-    public function test_manifest_file_clear_when_create_module()
-    {
-        $this->assertFileExists($this->manifestPath);
-
-        $this->createModule('Foo');
-
-        $this->assertFileDoesNotExist($this->manifestPath);
-    }
-
-    public function test_manifest_file_clear_when_delete_module()
-    {
-        $this->assertFileExists($this->manifestPath);
-
-        $this->createModule('Foo');
-
-        $this->artisan('module:delete', ['module' => 'Foo', '--force' => true]);
-
-        $this->assertFileDoesNotExist($this->manifestPath);
-    }
-
-    public function test_manifest_file_clear_when_disable_module()
-    {
-        $this->assertFileExists($this->manifestPath);
-
-        $this->createModule('Foo');
-
-        $this->artisan('module:disable', ['module' => 'Foo']);
-
-        $this->assertFileDoesNotExist($this->manifestPath);
-    }
-
-    public function test_manifest_file_clear_when_enable_module()
-    {
-        $this->assertFileExists($this->manifestPath);
-
-        $this->createModule('Foo');
-
-        $this->artisan('module:enable', ['module' => 'Foo']);
-
-        $this->assertFileDoesNotExist($this->manifestPath);
     }
 }

--- a/tests/Commands/Actions/ModuleDiscoverCommandTest.php
+++ b/tests/Commands/Actions/ModuleDiscoverCommandTest.php
@@ -7,6 +7,9 @@ use Nwidart\Modules\Contracts\RepositoryInterface;
 use Nwidart\Modules\ModuleManifest;
 use Nwidart\Modules\Tests\BaseTestCase;
 
+/**
+ * @deprecated This Test File is deprecated and will be removed in the next major version.
+ */
 class ModuleDiscoverCommandTest extends BaseTestCase
 {
     private RepositoryInterface $repository;
@@ -37,48 +40,4 @@ class ModuleDiscoverCommandTest extends BaseTestCase
 
         $this->assertSame(0, $code);
     }
-
-    public function test_manifest_file_contain_new_module_provider()
-    {
-        $this->createModule('Foo');
-
-        $path = base_path('modules/Foo').'/module.json';
-        $provider = json_decode($this->finder->get($path))->providers[0];
-
-        $code = $this->artisan('module:discover');
-        $this->assertSame(0, $code);
-
-        $manifest = require $this->manifestPath;
-
-        $this->assertContains($provider, $manifest['providers'], 'provider not found in manifest file');
-        $this->assertContains($provider, $manifest['eager'], 'provider not found in manifest file');
-    }
-
-    public function test_manifest_file_contain_multi_module_provider()
-    {
-        $modules = [
-            'Foo',
-            'Bar',
-            'Baz',
-        ];
-
-        foreach ($modules as $module) {
-            $this->createModule($module);
-        }
-
-        $code = $this->artisan('module:discover');
-        $this->assertSame(0, $code);
-
-        $manifest = require $this->manifestPath;
-
-        foreach ($modules as $module) {
-            $path = module_path($module).'/module.json';
-            $provider = json_decode($this->finder->get($path))->providers[0];
-
-            $this->assertContains($provider, $manifest['providers'], 'provider not found in manifest file');
-            $this->assertContains($provider, $manifest['eager'], 'provider not found in manifest file');
-        }
-    }
-
-
 }


### PR DESCRIPTION
Hi,  

In this pull request, I have removed the caching of provider data in the `bootstrap/cache/module.php` file. Storing this cache causes several issues:  

1. Changes in `module_status.json` are not detected until `module:discover` or `module:delete-compile` is executed.  
2. When copying a module directly into the `Modules` folder, Laravel does not detect it until the command is run.  
3. Switching between branches with different module statuses leads to inconsistencies (#2020).  

Since this file is only used once during Laravel's booting process, we can safely remove its caching mechanism.  

Additionally, this pull request updates the messages for `module:discover` and `module:delete-compile`, clarifying their removal in the next major version. Tests related to these commands have been marked as `@deprecated` and will be removed accordingly.  

Thanks!

fixes #2020 