### PR TITLE
Added missing type hinting for helpers.php

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -4,6 +4,11 @@ use Illuminate\Foundation\Vite;
 use Illuminate\Support\Facades\Vite as ViteFacade;
 
 if (! function_exists('module_path')) {
+    /**
+     * @param string $name
+     * @param string $path
+     * @return string
+     */
     function module_path($name, $path = '')
     {
         $module = app('modules')->find($name);
@@ -35,6 +40,10 @@ if (! function_exists('public_path')) {
 if (! function_exists('module_vite')) {
     /**
      * support for vite
+     * 
+     * @param string $module
+     * @param string $asset
+     * @param string|null $hotFilePath
      */
     function module_vite($module, $asset, $hotFilePath = null): Vite
     {


### PR DESCRIPTION
Upgrading to larastan 3.0, caused a lot of phpstan errors related to `module_path()` usage. 

PHPStan assumes `module_path()` returns mixed type without any typehints, causing coode below to fail:

```php
<?php

if (is_dir(module_path('my_module', 'views'))) { // Parameter #1 $filename of function is_dir expects string, mixed given. 
   // ....
}
```

Also I added parameter type hints for `module_vite()` as well.

To not introduce potential breaking change using native types, I sticked to phpdoc syntax.