### PR TITLE
Update Stubs to Follow Laravel Pint Standards  

### DIFF
--- a/src/Commands/stubs/action-invoke.stub
+++ b/src/Commands/stubs/action-invoke.stub
@@ -4,8 +4,5 @@ namespace $CLASS_NAMESPACE$;
 
 class $CLASS$
 {
-    public function __invoke()
-    {
-        //
-    }
+    public function __invoke() {}
 }

--- a/src/Commands/stubs/action.stub
+++ b/src/Commands/stubs/action.stub
@@ -4,8 +4,5 @@ namespace $CLASS_NAMESPACE$;
 
 class $CLASS$
 {
-    public function handle()
-    {
-        //
-    }
+    public function handle() {}
 }

--- a/src/Commands/stubs/cast.stub
+++ b/src/Commands/stubs/cast.stub
@@ -9,8 +9,6 @@ class $CLASS$ implements CastsAttributes
 {
     /**
      * Cast the given value.
-     *
-     * @param  array<string, mixed>  $attributes
      */
     public function get(Model $model, string $key, mixed $value, array $attributes): mixed
     {
@@ -19,8 +17,6 @@ class $CLASS$ implements CastsAttributes
 
     /**
      * Prepare the given value for storage.
-     *
-     * @param  array<string, mixed>  $attributes
      */
     public function set(Model $model, string $key, mixed $value, array $attributes): mixed
     {

--- a/src/Commands/stubs/channel.stub
+++ b/src/Commands/stubs/channel.stub
@@ -4,21 +4,13 @@ namespace $NAMESPACE$;
 
 class $CLASS$
 {
-
     /**
      * Create a new channel instance.
      */
-    public function __construct()
-    {
-        //
-    }
-    
+    public function __construct() {}
+
     /**
      * Authenticate the user's access to the channel.
      */
-    public function join(Operator $user): array|bool
-    {
-        //
-    }
-   
+    public function join(Operator $user): array|bool {}
 }

--- a/src/Commands/stubs/class-invoke.stub
+++ b/src/Commands/stubs/class-invoke.stub
@@ -4,8 +4,5 @@ namespace $NAMESPACE$;
 
 class $CLASS$
 {
-    public function __invoke()
-    {
-        //
-    }
+    public function __invoke() {}
 }

--- a/src/Commands/stubs/class.stub
+++ b/src/Commands/stubs/class.stub
@@ -4,8 +4,5 @@ namespace $NAMESPACE$;
 
 class $CLASS$
 {
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 }

--- a/src/Commands/stubs/command.stub
+++ b/src/Commands/stubs/command.stub
@@ -29,10 +29,7 @@ class $CLASS$ extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
-    {
-        //
-    }
+    public function handle() {}
 
     /**
      * Get the console command arguments.

--- a/src/Commands/stubs/component-class.stub
+++ b/src/Commands/stubs/component-class.stub
@@ -10,10 +10,7 @@ class $CLASS$ extends Component
     /**
      * Create a new component instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Get the view/contents that represent the component.

--- a/src/Commands/stubs/controller-plain.stub
+++ b/src/Commands/stubs/controller-plain.stub
@@ -4,6 +4,4 @@ namespace $CLASS_NAMESPACE$;
 
 use Illuminate\Routing\Controller;
 
-class $CLASS$ extends Controller
-{
-}
+class $CLASS$ extends Controller {}

--- a/src/Commands/stubs/controller.stub
+++ b/src/Commands/stubs/controller.stub
@@ -26,10 +26,7 @@ class $CLASS$ extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
-    {
-        //
-    }
+    public function store(Request $request) {}
 
     /**
      * Show the specified resource.
@@ -50,16 +47,10 @@ class $CLASS$ extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id)
-    {
-        //
-    }
+    public function update(Request $request, $id) {}
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy($id)
-    {
-        //
-    }
+    public function destroy($id) {}
 }

--- a/src/Commands/stubs/enum.stub
+++ b/src/Commands/stubs/enum.stub
@@ -2,7 +2,4 @@
 
 namespace $CLASS_NAMESPACE$;
 
-enum $CLASS$
-{
-    //
-}
+enum $CLASS$ {}

--- a/src/Commands/stubs/event-provider.stub
+++ b/src/Commands/stubs/event-provider.stub
@@ -23,8 +23,5 @@ class $CLASS$ extends ServiceProvider
     /**
      * Configure the proper event listeners for email verification.
      */
-    protected function configureEmailVerification(): void
-    {
-        //
-    }
+    protected function configureEmailVerification(): void {}
 }

--- a/src/Commands/stubs/event.stub
+++ b/src/Commands/stubs/event.stub
@@ -17,10 +17,7 @@ class $CLASS$
     /**
      * Create a new event instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Get the channels the event should be broadcast on.

--- a/src/Commands/stubs/exception-render-report.stub
+++ b/src/Commands/stubs/exception-render-report.stub
@@ -11,16 +11,10 @@ class $CLASS$ extends Exception
     /**
      * Report the exception.
      */
-    public function report(): void
-    {
-        //
-    }
+    public function report(): void {}
 
     /**
      * Render the exception as an HTTP response.
      */
-    public function render(Request $request): Response
-    {
-        //
-    }
+    public function render(Request $request): Response {}
 }

--- a/src/Commands/stubs/exception-render.stub
+++ b/src/Commands/stubs/exception-render.stub
@@ -11,8 +11,5 @@ class $CLASS$ extends Exception
     /**
      * Render the exception as an HTTP response.
      */
-    public function render(Request $request): Response
-    {
-        //
-    }
+    public function render(Request $request): Response {}
 }

--- a/src/Commands/stubs/exception-report.stub
+++ b/src/Commands/stubs/exception-report.stub
@@ -9,8 +9,5 @@ class $CLASS$ extends Exception
     /**
      * Report the exception.
      */
-    public function report(): void
-    {
-        //
-    }
+    public function report(): void {}
 }

--- a/src/Commands/stubs/exception.stub
+++ b/src/Commands/stubs/exception.stub
@@ -4,7 +4,4 @@ namespace $CLASS_NAMESPACE$;
 
 use Exception;
 
-class $CLASS$ extends Exception
-{
-    //
-}
+class $CLASS$ extends Exception {}

--- a/src/Commands/stubs/helper-invoke.stub
+++ b/src/Commands/stubs/helper-invoke.stub
@@ -4,8 +4,5 @@ namespace $CLASS_NAMESPACE$;
 
 class $CLASS$
 {
-    public function __invoke()
-    {
-        //
-    }
+    public function __invoke() {}
 }

--- a/src/Commands/stubs/helper.stub
+++ b/src/Commands/stubs/helper.stub
@@ -4,8 +4,5 @@ namespace $CLASS_NAMESPACE$;
 
 class $CLASS$
 {
-    public function handle()
-    {
-        //
-    }
+    public function handle() {}
 }

--- a/src/Commands/stubs/interface.stub
+++ b/src/Commands/stubs/interface.stub
@@ -2,7 +2,4 @@
 
 namespace $CLASS_NAMESPACE$;
 
-interface $CLASS$
-{
-
-}
+interface $CLASS$ {}

--- a/src/Commands/stubs/job-queued.stub
+++ b/src/Commands/stubs/job-queued.stub
@@ -15,16 +15,10 @@ class $CLASS$ implements ShouldQueue
     /**
      * Create a new job instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Execute the job.
      */
-    public function handle(): void
-    {
-        //
-    }
+    public function handle(): void {}
 }

--- a/src/Commands/stubs/job.stub
+++ b/src/Commands/stubs/job.stub
@@ -12,16 +12,10 @@ class $CLASS$ implements ShouldQueue
     /**
      * Create a new job instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Execute the job.
      */
-    public function handle(): void
-    {
-        //
-    }
+    public function handle(): void {}
 }

--- a/src/Commands/stubs/listener-duck.stub
+++ b/src/Commands/stubs/listener-duck.stub
@@ -10,16 +10,10 @@ class $CLASS$
     /**
      * Create the event listener.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Handle the event.
      */
-    public function handle($event): void
-    {
-        //
-    }
+    public function handle($event): void {}
 }

--- a/src/Commands/stubs/listener-queued-duck.stub
+++ b/src/Commands/stubs/listener-queued-duck.stub
@@ -12,16 +12,10 @@ class $CLASS$ implements ShouldQueue
     /**
      * Create the event listener
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Handle the event.
      */
-    public function handle($event): void
-    {
-        //
-    }
+    public function handle($event): void {}
 }

--- a/src/Commands/stubs/listener-queued.stub
+++ b/src/Commands/stubs/listener-queued.stub
@@ -13,16 +13,10 @@ class $CLASS$ implements ShouldQueue
     /**
      * Create the event listener.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Handle the event.
      */
-    public function handle($SHORTEVENTNAME$ $event): void
-    {
-        //
-    }
+    public function handle($SHORTEVENTNAME$ $event): void {}
 }

--- a/src/Commands/stubs/listener.stub
+++ b/src/Commands/stubs/listener.stub
@@ -11,16 +11,10 @@ class $CLASS$
     /**
      * Create the event listener.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Handle the event.
      */
-    public function handle($SHORTEVENTNAME$ $event): void
-    {
-        //
-    }
+    public function handle($SHORTEVENTNAME$ $event): void {}
 }

--- a/src/Commands/stubs/mail.stub
+++ b/src/Commands/stubs/mail.stub
@@ -14,10 +14,7 @@ class $CLASS$ extends Mailable
     /**
      * Create a new message instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Build the message.

--- a/src/Commands/stubs/migration/plain.stub
+++ b/src/Commands/stubs/migration/plain.stub
@@ -9,16 +9,10 @@ return new class extends Migration
     /**
      * Run the migrations.
      */
-    public function up(): void
-    {
-        //
-    }
+    public function up(): void {}
 
     /**
      * Reverse the migrations.
      */
-    public function down(): void
-    {
-        //
-    }
+    public function down(): void {}
 };

--- a/src/Commands/stubs/notification.stub
+++ b/src/Commands/stubs/notification.stub
@@ -14,10 +14,7 @@ class $CLASS$ extends Notification
     /**
      * Create a new notification instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Get the notification's delivery channels.

--- a/src/Commands/stubs/observer.stub
+++ b/src/Commands/stubs/observer.stub
@@ -9,40 +9,25 @@ class $NAME$Observer
     /**
      * Handle the $NAME$ "created" event.
      */
-    public function created($NAME$ $NAME_VARIABLE$): void
-    {
-        //
-    }
+    public function created($NAME$ $NAME_VARIABLE$): void {}
 
     /**
      * Handle the $NAME$ "updated" event.
      */
-    public function updated($NAME$ $NAME_VARIABLE$): void
-    {
-        //
-    }
+    public function updated($NAME$ $NAME_VARIABLE$): void {}
 
     /**
      * Handle the $NAME$ "deleted" event.
      */
-    public function deleted($NAME$ $NAME_VARIABLE$): void
-    {
-        //
-    }
+    public function deleted($NAME$ $NAME_VARIABLE$): void {}
 
     /**
      * Handle the $NAME$ "restored" event.
      */
-    public function restored($NAME$ $NAME_VARIABLE$): void
-    {
-        //
-    }
+    public function restored($NAME$ $NAME_VARIABLE$): void {}
 
     /**
      * Handle the $NAME$ "force deleted" event.
      */
-    public function forceDeleted($NAME$ $NAME_VARIABLE$): void
-    {
-        //
-    }
+    public function forceDeleted($NAME$ $NAME_VARIABLE$): void {}
 }

--- a/src/Commands/stubs/policy.plain.stub
+++ b/src/Commands/stubs/policy.plain.stub
@@ -11,8 +11,5 @@ class $CLASS$
     /**
      * Create a new policy instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 }

--- a/src/Commands/stubs/provider.stub
+++ b/src/Commands/stubs/provider.stub
@@ -9,10 +9,7 @@ class $CLASS$ extends ServiceProvider
     /**
      * Register the service provider.
      */
-    public function register(): void
-    {
-        //
-    }
+    public function register(): void {}
 
     /**
      * Get the services provided by the provider.

--- a/src/Commands/stubs/repository-invoke.stub
+++ b/src/Commands/stubs/repository-invoke.stub
@@ -4,8 +4,5 @@ namespace $CLASS_NAMESPACE$;
 
 class $CLASS$
 {
-    public function __invoke()
-    {
-        //
-    }
+    public function __invoke() {}
 }

--- a/src/Commands/stubs/repository.stub
+++ b/src/Commands/stubs/repository.stub
@@ -4,8 +4,5 @@ namespace $CLASS_NAMESPACE$;
 
 class $CLASS$
 {
-    public function handle()
-    {
-        //
-    }
+    public function handle() {}
 }

--- a/src/Commands/stubs/request.stub
+++ b/src/Commands/stubs/request.stub
@@ -11,9 +11,7 @@ class $CLASS$ extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            //
-        ];
+        return [];
     }
 
     /**

--- a/src/Commands/stubs/route-provider.stub
+++ b/src/Commands/stubs/route-provider.stub
@@ -2,8 +2,8 @@
 
 namespace $NAMESPACE$;
 
-use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
 
 class $CLASS$ extends ServiceProvider
 {

--- a/src/Commands/stubs/routes/api.stub
+++ b/src/Commands/stubs/routes/api.stub
@@ -3,17 +3,6 @@
 use Illuminate\Support\Facades\Route;
 use $MODULE_NAMESPACE$\$STUDLY_NAME$\$CONTROLLER_NAMESPACE$\$STUDLY_NAME$Controller;
 
-/*
- *--------------------------------------------------------------------------
- * API Routes
- *--------------------------------------------------------------------------
- *
- * Here is where you can register API routes for your application. These
- * routes are loaded by the RouteServiceProvider within a group which
- * is assigned the "api" middleware group. Enjoy building your API!
- *
-*/
-
 Route::middleware(['auth:sanctum'])->prefix('v1')->group(function () {
     Route::apiResource('$LOWER_NAME$', $STUDLY_NAME$Controller::class)->names('$LOWER_NAME$');
 });

--- a/src/Commands/stubs/routes/web.stub
+++ b/src/Commands/stubs/routes/web.stub
@@ -3,17 +3,6 @@
 use Illuminate\Support\Facades\Route;
 use $MODULE_NAMESPACE$\$STUDLY_NAME$\$CONTROLLER_NAMESPACE$\$STUDLY_NAME$Controller;
 
-/*
-|--------------------------------------------------------------------------
-| Web Routes
-|--------------------------------------------------------------------------
-|
-| Here is where you can register web routes for your application. These
-| routes are loaded by the RouteServiceProvider within a group which
-| contains the "web" middleware group. Now create something great!
-|
-*/
-
 Route::group([], function () {
     Route::resource('$LOWER_NAME$', $STUDLY_NAME$Controller::class)->names('$LOWER_NAME$');
 });

--- a/src/Commands/stubs/routes/web.stub
+++ b/src/Commands/stubs/routes/web.stub
@@ -3,6 +3,6 @@
 use Illuminate\Support\Facades\Route;
 use $MODULE_NAMESPACE$\$STUDLY_NAME$\$CONTROLLER_NAMESPACE$\$STUDLY_NAME$Controller;
 
-Route::group([], function () {
+Route::middleware(['auth', 'verified'])->group(function () {
     Route::resource('$LOWER_NAME$', $STUDLY_NAME$Controller::class)->names('$LOWER_NAME$');
 });

--- a/src/Commands/stubs/rule.implicit.stub
+++ b/src/Commands/stubs/rule.implicit.stub
@@ -15,8 +15,5 @@ class $CLASS$ implements ValidationRule
     /**
      * Run the validation rule.
      */
-    public function validate(string $attribute, mixed $value, Closure $fail): void
-    {
-        //
-    }
+    public function validate(string $attribute, mixed $value, Closure $fail): void {}
 }

--- a/src/Commands/stubs/rule.stub
+++ b/src/Commands/stubs/rule.stub
@@ -10,8 +10,5 @@ class $CLASS$ implements ValidationRule
     /**
      * Run the validation rule.
      */
-    public function validate(string $attribute, mixed $value, Closure $fail): void
-    {
-        //
-    }
+    public function validate(string $attribute, mixed $value, Closure $fail): void {}
 }

--- a/src/Commands/stubs/scope.stub
+++ b/src/Commands/stubs/scope.stub
@@ -11,8 +11,5 @@ class $CLASS$ implements Scope
     /**
      * Apply the scope to a given Eloquent query builder.
      */
-    public function apply(Builder $builder, Model $model): void
-    {
-        //
-    }
+    public function apply(Builder $builder, Model $model): void {}
 }

--- a/src/Commands/stubs/service-invoke.stub
+++ b/src/Commands/stubs/service-invoke.stub
@@ -4,8 +4,5 @@ namespace $CLASS_NAMESPACE$;
 
 class $CLASS$
 {
-    public function __invoke()
-    {
-        //
-    }
+    public function __invoke() {}
 }

--- a/src/Commands/stubs/service.stub
+++ b/src/Commands/stubs/service.stub
@@ -4,8 +4,5 @@ namespace $CLASS_NAMESPACE$;
 
 class $CLASS$
 {
-    public function handle()
-    {
-        //
-    }
+    public function handle() {}
 }

--- a/src/Commands/stubs/trait.stub
+++ b/src/Commands/stubs/trait.stub
@@ -2,7 +2,4 @@
 
 namespace $CLASS_NAMESPACE$;
 
-trait $CLASS$
-{
-    //
-}
+trait $CLASS$ {}

--- a/src/Commands/stubs/views/index.stub
+++ b/src/Commands/stubs/views/index.stub
@@ -1,7 +1,5 @@
-@extends('$LOWER_NAME$::layouts.master')
-
-@section('content')
+<x-$LOWER_NAME$::layouts.master>
     <h1>Hello World</h1>
 
     <p>Module: {!! config('$LOWER_NAME$.name') !!}</p>
-@endsection
+</x-$LOWER_NAME$::layouts.master>

--- a/src/Commands/stubs/views/master.stub
+++ b/src/Commands/stubs/views/master.stub
@@ -1,29 +1,29 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="csrf-token" content="{{ csrf_token() }}">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <title>$STUDLY_NAME$ Module - {{ config('app.name', 'Laravel') }}</title>
+        <title>$STUDLY_NAME$ Module - {{ config('app.name', 'Laravel') }}</title>
 
-    <meta name="description" content="{{ $description ?? '' }}">
-    <meta name="keywords" content="{{ $keywords ?? '' }}">
-    <meta name="author" content="{{ $author ?? '' }}">
+        <meta name="description" content="{{ $description ?? '' }}">
+        <meta name="keywords" content="{{ $keywords ?? '' }}">
+        <meta name="author" content="{{ $author ?? '' }}">
 
-    <!-- Fonts -->
-    <link rel="preconnect" href="https://fonts.bunny.net">
-    <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
+        <!-- Fonts -->
+        <link rel="preconnect" href="https://fonts.bunny.net">
+        <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
 
-    {{-- Vite CSS --}}
-    {{-- {{ module_vite('build-$LOWER_NAME$', 'resources/assets/sass/app.scss', storage_path('vite.hot')) }} --}}
-</head>
+        {{-- Vite CSS --}}
+        {{-- {{ module_vite('build-$LOWER_NAME$', 'resources/assets/sass/app.scss') }} --}}
+    </head>
 
-<body>
-    @yield('content')
+    <body>
+        {{ $slot }}
 
-    {{-- Vite JS --}}
-    {{-- {{ module_vite('build-$LOWER_NAME$', 'resources/assets/js/app.js', storage_path('vite.hot')) }} --}}
-</body>
+        {{-- Vite JS --}}
+        {{-- {{ module_vite('build-$LOWER_NAME$', 'resources/assets/js/app.js') }} --}}
+    </body>

--- a/tests/Commands/Make/__snapshots__/ActionMakeCommandTest__test_it_can_generate_a_action_in_sub_namespace_with_correct_generated_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/ActionMakeCommandTest__test_it_can_generate_a_action_in_sub_namespace_with_correct_generated_file__1.txt
@@ -4,8 +4,5 @@ namespace Modules\Blog\Actions\Api;
 
 class MyAction
 {
-    public function handle()
-    {
-        //
-    }
+    public function handle() {}
 }

--- a/tests/Commands/Make/__snapshots__/ActionMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/ActionMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -4,8 +4,5 @@ namespace Modules\Blog\Actions;
 
 class MyAction
 {
-    public function handle()
-    {
-        //
-    }
+    public function handle() {}
 }

--- a/tests/Commands/Make/__snapshots__/CastMakeCommandTest__test_it_can_generate_a_cast_in_sub_namespace_with_correct_generated_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/CastMakeCommandTest__test_it_can_generate_a_cast_in_sub_namespace_with_correct_generated_file__1.txt
@@ -9,8 +9,6 @@ class MyCast implements CastsAttributes
 {
     /**
      * Cast the given value.
-     *
-     * @param  array<string, mixed>  $attributes
      */
     public function get(Model $model, string $key, mixed $value, array $attributes): mixed
     {
@@ -19,8 +17,6 @@ class MyCast implements CastsAttributes
 
     /**
      * Prepare the given value for storage.
-     *
-     * @param  array<string, mixed>  $attributes
      */
     public function set(Model $model, string $key, mixed $value, array $attributes): mixed
     {

--- a/tests/Commands/Make/__snapshots__/CastMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/CastMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -9,8 +9,6 @@ class MyCast implements CastsAttributes
 {
     /**
      * Cast the given value.
-     *
-     * @param  array<string, mixed>  $attributes
      */
     public function get(Model $model, string $key, mixed $value, array $attributes): mixed
     {
@@ -19,8 +17,6 @@ class MyCast implements CastsAttributes
 
     /**
      * Prepare the given value for storage.
-     *
-     * @param  array<string, mixed>  $attributes
      */
     public function set(Model $model, string $key, mixed $value, array $attributes): mixed
     {

--- a/tests/Commands/Make/__snapshots__/ChannelMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/ChannelMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -4,21 +4,13 @@ namespace Modules\Blog\SuperChannel;
 
 class WelcomeChannel
 {
-
     /**
      * Create a new channel instance.
      */
-    public function __construct()
-    {
-        //
-    }
-    
+    public function __construct() {}
+
     /**
      * Authenticate the user's access to the channel.
      */
-    public function join(Operator $user): array|bool
-    {
-        //
-    }
-   
+    public function join(Operator $user): array|bool {}
 }

--- a/tests/Commands/Make/__snapshots__/ChannelMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/Make/__snapshots__/ChannelMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
@@ -4,21 +4,13 @@ namespace Modules\Blog\SuperChannel;
 
 class WelcomeChannel
 {
-
     /**
      * Create a new channel instance.
      */
-    public function __construct()
-    {
-        //
-    }
-    
+    public function __construct() {}
+
     /**
      * Authenticate the user's access to the channel.
      */
-    public function join(Operator $user): array|bool
-    {
-        //
-    }
-   
+    public function join(Operator $user): array|bool {}
 }

--- a/tests/Commands/Make/__snapshots__/ChannelMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/ChannelMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -4,21 +4,13 @@ namespace Modules\Blog\Broadcasting;
 
 class WelcomeChannel
 {
-
     /**
      * Create a new channel instance.
      */
-    public function __construct()
-    {
-        //
-    }
-    
+    public function __construct() {}
+
     /**
      * Authenticate the user's access to the channel.
      */
-    public function join(Operator $user): array|bool
-    {
-        //
-    }
-   
+    public function join(Operator $user): array|bool {}
 }

--- a/tests/Commands/Make/__snapshots__/ClassMakeCommandTest__test_it_can_generate_a_class_in_sub_namespace_with_correct_generated_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/ClassMakeCommandTest__test_it_can_generate_a_class_in_sub_namespace_with_correct_generated_file__1.txt
@@ -4,8 +4,5 @@ namespace Modules\Blog\Classes\Api;
 
 class Api\Demo
 {
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 }

--- a/tests/Commands/Make/__snapshots__/ClassMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/ClassMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -4,8 +4,5 @@ namespace Modules\Blog\Classes;
 
 class Demo
 {
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 }

--- a/tests/Commands/Make/__snapshots__/CommandMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/CommandMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -29,10 +29,7 @@ class AwesomeCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
-    {
-        //
-    }
+    public function handle() {}
 
     /**
      * Get the console command arguments.

--- a/tests/Commands/Make/__snapshots__/CommandMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/Make/__snapshots__/CommandMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
@@ -29,10 +29,7 @@ class AwesomeCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
-    {
-        //
-    }
+    public function handle() {}
 
     /**
      * Get the console command arguments.

--- a/tests/Commands/Make/__snapshots__/CommandMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/CommandMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -29,10 +29,7 @@ class MyAwesomeCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
-    {
-        //
-    }
+    public function handle() {}
 
     /**
      * Get the console command arguments.

--- a/tests/Commands/Make/__snapshots__/CommandMakeCommandTest__test_it_uses_set_command_name_in_class__1.txt
+++ b/tests/Commands/Make/__snapshots__/CommandMakeCommandTest__test_it_uses_set_command_name_in_class__1.txt
@@ -29,10 +29,7 @@ class MyAwesomeCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
-    {
-        //
-    }
+    public function handle() {}
 
     /**
      * Get the console command arguments.

--- a/tests/Commands/Make/__snapshots__/ComponentClassMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/ComponentClassMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -10,10 +10,7 @@ class Blog extends Component
     /**
      * Create a new component instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Get the view/contents that represent the component.

--- a/tests/Commands/Make/__snapshots__/ComponentClassMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/ComponentClassMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -10,10 +10,7 @@ class Blog extends Component
     /**
      * Create a new component instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Get the view/contents that represent the component.

--- a/tests/Commands/Make/__snapshots__/ControllerMakeCommandTest__test_it_appends_controller_to_class_name_if_not_present__1.txt
+++ b/tests/Commands/Make/__snapshots__/ControllerMakeCommandTest__test_it_appends_controller_to_class_name_if_not_present__1.txt
@@ -26,10 +26,7 @@ class MyController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
-    {
-        //
-    }
+    public function store(Request $request) {}
 
     /**
      * Show the specified resource.
@@ -50,16 +47,10 @@ class MyController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id)
-    {
-        //
-    }
+    public function update(Request $request, $id) {}
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy($id)
-    {
-        //
-    }
+    public function destroy($id) {}
 }

--- a/tests/Commands/Make/__snapshots__/ControllerMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/ControllerMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -26,10 +26,7 @@ class MyController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
-    {
-        //
-    }
+    public function store(Request $request) {}
 
     /**
      * Show the specified resource.
@@ -50,16 +47,10 @@ class MyController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id)
-    {
-        //
-    }
+    public function update(Request $request, $id) {}
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy($id)
-    {
-        //
-    }
+    public function destroy($id) {}
 }

--- a/tests/Commands/Make/__snapshots__/ControllerMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/Make/__snapshots__/ControllerMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
@@ -26,10 +26,7 @@ class MyController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
-    {
-        //
-    }
+    public function store(Request $request) {}
 
     /**
      * Show the specified resource.
@@ -50,16 +47,10 @@ class MyController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id)
-    {
-        //
-    }
+    public function update(Request $request, $id) {}
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy($id)
-    {
-        //
-    }
+    public function destroy($id) {}
 }

--- a/tests/Commands/Make/__snapshots__/ControllerMakeCommandTest__test_it_can_generate_a_controller_in_sub_namespace_with_correct_generated_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/ControllerMakeCommandTest__test_it_can_generate_a_controller_in_sub_namespace_with_correct_generated_file__1.txt
@@ -26,10 +26,7 @@ class MyController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
-    {
-        //
-    }
+    public function store(Request $request) {}
 
     /**
      * Show the specified resource.
@@ -50,16 +47,10 @@ class MyController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id)
-    {
-        //
-    }
+    public function update(Request $request, $id) {}
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy($id)
-    {
-        //
-    }
+    public function destroy($id) {}
 }

--- a/tests/Commands/Make/__snapshots__/ControllerMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/ControllerMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -26,10 +26,7 @@ class MyController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
-    {
-        //
-    }
+    public function store(Request $request) {}
 
     /**
      * Show the specified resource.
@@ -50,16 +47,10 @@ class MyController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id)
-    {
-        //
-    }
+    public function update(Request $request, $id) {}
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy($id)
-    {
-        //
-    }
+    public function destroy($id) {}
 }

--- a/tests/Commands/Make/__snapshots__/ControllerMakeCommandTest__test_it_generates_a_plain_controller__1.txt
+++ b/tests/Commands/Make/__snapshots__/ControllerMakeCommandTest__test_it_generates_a_plain_controller__1.txt
@@ -4,6 +4,4 @@ namespace Modules\Blog\Http\Controllers;
 
 use Illuminate\Routing\Controller;
 
-class MyController extends Controller
-{
-}
+class MyController extends Controller {}

--- a/tests/Commands/Make/__snapshots__/EnumMakeCommandTest__test_it_can_generate_a_enum_in_sub_namespace_with_correct_generated_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/EnumMakeCommandTest__test_it_can_generate_a_enum_in_sub_namespace_with_correct_generated_file__1.txt
@@ -2,7 +2,4 @@
 
 namespace Modules\Blog\Enums\Api;
 
-enum MyEnum
-{
-    //
-}
+enum MyEnum {}

--- a/tests/Commands/Make/__snapshots__/EnumMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/EnumMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -2,7 +2,4 @@
 
 namespace Modules\Blog\Enums;
 
-enum MyEnum
-{
-    //
-}
+enum MyEnum {}

--- a/tests/Commands/Make/__snapshots__/EventMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/EventMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -17,10 +17,7 @@ class PostWasCreated
     /**
      * Create a new event instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Get the channels the event should be broadcast on.

--- a/tests/Commands/Make/__snapshots__/EventMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/Make/__snapshots__/EventMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
@@ -17,10 +17,7 @@ class PostWasCreated
     /**
      * Create a new event instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Get the channels the event should be broadcast on.

--- a/tests/Commands/Make/__snapshots__/EventMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/EventMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -17,10 +17,7 @@ class PostWasCreated
     /**
      * Create a new event instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Get the channels the event should be broadcast on.

--- a/tests/Commands/Make/__snapshots__/EventProviderMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/EventProviderMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -23,8 +23,5 @@ class EventServiceProvider extends ServiceProvider
     /**
      * Configure the proper event listeners for email verification.
      */
-    protected function configureEmailVerification(): void
-    {
-        //
-    }
+    protected function configureEmailVerification(): void {}
 }

--- a/tests/Commands/Make/__snapshots__/ExceptionMakeCommandTest__test_it_can_generate_a_exception_in_sub_namespace_with_correct_generated_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/ExceptionMakeCommandTest__test_it_can_generate_a_exception_in_sub_namespace_with_correct_generated_file__1.txt
@@ -4,7 +4,4 @@ namespace Modules\Blog\Exceptions\Api;
 
 use Exception;
 
-class MyException extends Exception
-{
-    //
-}
+class MyException extends Exception {}

--- a/tests/Commands/Make/__snapshots__/ExceptionMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/ExceptionMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -4,7 +4,4 @@ namespace Modules\Blog\Exceptions;
 
 use Exception;
 
-class MyException extends Exception
-{
-    //
-}
+class MyException extends Exception {}

--- a/tests/Commands/Make/__snapshots__/HelperMakeCommandTest__test_it_can_generate_a_helper_in_sub_namespace_with_correct_generated_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/HelperMakeCommandTest__test_it_can_generate_a_helper_in_sub_namespace_with_correct_generated_file__1.txt
@@ -4,8 +4,5 @@ namespace Modules\Blog\Helpers\Api;
 
 class MyHelper
 {
-    public function handle()
-    {
-        //
-    }
+    public function handle() {}
 }

--- a/tests/Commands/Make/__snapshots__/HelperMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/HelperMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -4,8 +4,5 @@ namespace Modules\Blog\Helpers;
 
 class MyHelper
 {
-    public function handle()
-    {
-        //
-    }
+    public function handle() {}
 }

--- a/tests/Commands/Make/__snapshots__/InterfaceMakeCommandTest__test_it_can_generate_a_interface_in_sub_namespace_with_correct_generated_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/InterfaceMakeCommandTest__test_it_can_generate_a_interface_in_sub_namespace_with_correct_generated_file__1.txt
@@ -2,7 +2,4 @@
 
 namespace Modules\Blog\Interfaces\Api;
 
-interface MyInterface
-{
-
-}
+interface MyInterface {}

--- a/tests/Commands/Make/__snapshots__/InterfaceMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/InterfaceMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -2,7 +2,4 @@
 
 namespace Modules\Blog\Interfaces;
 
-interface MyInterface
-{
-
-}
+interface MyInterface {}

--- a/tests/Commands/Make/__snapshots__/JobMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/JobMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -15,16 +15,10 @@ class SomeJob implements ShouldQueue
     /**
      * Create a new job instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Execute the job.
      */
-    public function handle(): void
-    {
-        //
-    }
+    public function handle(): void {}
 }

--- a/tests/Commands/Make/__snapshots__/JobMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/Make/__snapshots__/JobMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
@@ -15,16 +15,10 @@ class SomeJob implements ShouldQueue
     /**
      * Create a new job instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Execute the job.
      */
-    public function handle(): void
-    {
-        //
-    }
+    public function handle(): void {}
 }

--- a/tests/Commands/Make/__snapshots__/JobMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/JobMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -15,16 +15,10 @@ class SomeJob implements ShouldQueue
     /**
      * Create a new job instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Execute the job.
      */
-    public function handle(): void
-    {
-        //
-    }
+    public function handle(): void {}
 }

--- a/tests/Commands/Make/__snapshots__/JobMakeCommandTest__test_it_generated_correct_sync_job_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/JobMakeCommandTest__test_it_generated_correct_sync_job_file_with_content__1.txt
@@ -12,16 +12,10 @@ class SomeJob implements ShouldQueue
     /**
      * Create a new job instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Execute the job.
      */
-    public function handle(): void
-    {
-        //
-    }
+    public function handle(): void {}
 }

--- a/tests/Commands/Make/__snapshots__/ListenerMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/ListenerMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -10,16 +10,10 @@ class NotifyUsersOfANewPost
     /**
      * Create the event listener.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Handle the event.
      */
-    public function handle($event): void
-    {
-        //
-    }
+    public function handle($event): void {}
 }

--- a/tests/Commands/Make/__snapshots__/ListenerMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/Make/__snapshots__/ListenerMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
@@ -10,16 +10,10 @@ class NotifyUsersOfANewPost
     /**
      * Create the event listener.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Handle the event.
      */
-    public function handle($event): void
-    {
-        //
-    }
+    public function handle($event): void {}
 }

--- a/tests/Commands/Make/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_queued_duck_event_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_queued_duck_event_with_content__1.txt
@@ -12,16 +12,10 @@ class NotifyUsersOfANewPost implements ShouldQueue
     /**
      * Create the event listener
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Handle the event.
      */
-    public function handle($event): void
-    {
-        //
-    }
+    public function handle($event): void {}
 }

--- a/tests/Commands/Make/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_queued_event_in_a_subdirectory_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_queued_event_in_a_subdirectory_with_content__1.txt
@@ -13,16 +13,10 @@ class NotifyUsersOfANewPost implements ShouldQueue
     /**
      * Create the event listener.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Handle the event.
      */
-    public function handle(WasCreated $event): void
-    {
-        //
-    }
+    public function handle(WasCreated $event): void {}
 }

--- a/tests/Commands/Make/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_queued_event_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_queued_event_with_content__1.txt
@@ -13,16 +13,10 @@ class NotifyUsersOfANewPost implements ShouldQueue
     /**
      * Create the event listener.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Handle the event.
      */
-    public function handle(UserWasCreated $event): void
-    {
-        //
-    }
+    public function handle(UserWasCreated $event): void {}
 }

--- a/tests/Commands/Make/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_sync_duck_event_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_sync_duck_event_with_content__1.txt
@@ -10,16 +10,10 @@ class NotifyUsersOfANewPost
     /**
      * Create the event listener.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Handle the event.
      */
-    public function handle($event): void
-    {
-        //
-    }
+    public function handle($event): void {}
 }

--- a/tests/Commands/Make/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_sync_event_in_a_subdirectory_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_sync_event_in_a_subdirectory_with_content__1.txt
@@ -11,16 +11,10 @@ class NotifyUsersOfANewPost
     /**
      * Create the event listener.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Handle the event.
      */
-    public function handle(WasCreated $event): void
-    {
-        //
-    }
+    public function handle(WasCreated $event): void {}
 }

--- a/tests/Commands/Make/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_sync_event_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/ListenerMakeCommandTest__test_it_generated_correct_sync_event_with_content__1.txt
@@ -11,16 +11,10 @@ class NotifyUsersOfANewPost
     /**
      * Create the event listener.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Handle the event.
      */
-    public function handle(UserWasCreated $event): void
-    {
-        //
-    }
+    public function handle(UserWasCreated $event): void {}
 }

--- a/tests/Commands/Make/__snapshots__/MailMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/MailMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -14,10 +14,7 @@ class SomeMail extends Mailable
     /**
      * Create a new message instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Build the message.

--- a/tests/Commands/Make/__snapshots__/MailMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/Make/__snapshots__/MailMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
@@ -14,10 +14,7 @@ class SomeMail extends Mailable
     /**
      * Create a new message instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Build the message.

--- a/tests/Commands/Make/__snapshots__/MailMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/MailMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -14,10 +14,7 @@ class SomeMail extends Mailable
     /**
      * Create a new message instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Build the message.

--- a/tests/Commands/Make/__snapshots__/MigrationMakeCommandTest__test_it_generates_correct_default_migration_file_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/MigrationMakeCommandTest__test_it_generates_correct_default_migration_file_content__1.txt
@@ -9,16 +9,10 @@ return new class extends Migration
     /**
      * Run the migrations.
      */
-    public function up(): void
-    {
-        //
-    }
+    public function up(): void {}
 
     /**
      * Reverse the migrations.
      */
-    public function down(): void
-    {
-        //
-    }
+    public function down(): void {}
 };

--- a/tests/Commands/Make/__snapshots__/ModelMakeCommandTest__test_it_generates_controller_and_migration_when_both_flags_are_present__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModelMakeCommandTest__test_it_generates_controller_and_migration_when_both_flags_are_present__1.txt
@@ -26,10 +26,7 @@ class PostController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
-    {
-        //
-    }
+    public function store(Request $request) {}
 
     /**
      * Show the specified resource.
@@ -50,16 +47,10 @@ class PostController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id)
-    {
-        //
-    }
+    public function update(Request $request, $id) {}
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy($id)
-    {
-        //
-    }
+    public function destroy($id) {}
 }

--- a/tests/Commands/Make/__snapshots__/ModelMakeCommandTest__test_it_generates_controller_file_with_model__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModelMakeCommandTest__test_it_generates_controller_file_with_model__1.txt
@@ -26,10 +26,7 @@ class PostController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
-    {
-        //
-    }
+    public function store(Request $request) {}
 
     /**
      * Show the specified resource.
@@ -50,16 +47,10 @@ class PostController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id)
-    {
-        //
-    }
+    public function update(Request $request, $id) {}
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy($id)
-    {
-        //
-    }
+    public function destroy($id) {}
 }

--- a/tests/Commands/Make/__snapshots__/ModelMakeCommandTest__test_it_generates_controller_file_with_model_using_shortcut_option__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModelMakeCommandTest__test_it_generates_controller_file_with_model_using_shortcut_option__1.txt
@@ -26,10 +26,7 @@ class PostController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
-    {
-        //
-    }
+    public function store(Request $request) {}
 
     /**
      * Show the specified resource.
@@ -50,16 +47,10 @@ class PostController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id)
-    {
-        //
-    }
+    public function update(Request $request, $id) {}
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy($id)
-    {
-        //
-    }
+    public function destroy($id) {}
 }

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__2.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__2.txt
@@ -2,8 +2,8 @@
 
 namespace Modules\Blog\Providers;
 
-use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
 
 class RouteServiceProvider extends ServiceProvider
 {

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__4.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__4.txt
@@ -2,8 +2,8 @@
 
 namespace Modules\Blog\Providers;
 
-use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
 
 class RouteServiceProvider extends ServiceProvider
 {

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_route_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_route_file__1.txt
@@ -3,17 +3,6 @@
 use Illuminate\Support\Facades\Route;
 use Modules\Blog\Http\Controllers\BlogController;
 
-/*
- *--------------------------------------------------------------------------
- * API Routes
- *--------------------------------------------------------------------------
- *
- * Here is where you can register API routes for your application. These
- * routes are loaded by the RouteServiceProvider within a group which
- * is assigned the "api" middleware group. Enjoy building your API!
- *
-*/
-
 Route::middleware(['auth:sanctum'])->prefix('v1')->group(function () {
     Route::apiResource('blog', BlogController::class)->names('blog');
 });

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_route_file_with_multi_segment_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_route_file_with_multi_segment_default_namespace__1.txt
@@ -3,17 +3,6 @@
 use Illuminate\Support\Facades\Route;
 use Custom\Modules\Blog\Http\Controllers\BlogController;
 
-/*
- *--------------------------------------------------------------------------
- * API Routes
- *--------------------------------------------------------------------------
- *
- * Here is where you can register API routes for your application. These
- * routes are loaded by the RouteServiceProvider within a group which
- * is assigned the "api" middleware group. Enjoy building your API!
- *
-*/
-
 Route::middleware(['auth:sanctum'])->prefix('v1')->group(function () {
     Route::apiResource('blog', BlogController::class)->names('blog');
 });

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__2.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__2.txt
@@ -23,8 +23,5 @@ class EventServiceProvider extends ServiceProvider
     /**
      * Configure the proper event listeners for email verification.
      */
-    protected function configureEmailVerification(): void
-    {
-        //
-    }
+    protected function configureEmailVerification(): void {}
 }

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__3.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__3.txt
@@ -2,8 +2,8 @@
 
 namespace Modules\Blog\Providers;
 
-use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
 
 class RouteServiceProvider extends ServiceProvider
 {

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__4.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__4.txt
@@ -26,10 +26,7 @@ class BlogController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
-    {
-        //
-    }
+    public function store(Request $request) {}
 
     /**
      * Show the specified resource.
@@ -50,16 +47,10 @@ class BlogController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id)
-    {
-        //
-    }
+    public function update(Request $request, $id) {}
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy($id)
-    {
-        //
-    }
+    public function destroy($id) {}
 }

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__2.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__2.txt
@@ -26,10 +26,7 @@ class BlogController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
-    {
-        //
-    }
+    public function store(Request $request) {}
 
     /**
      * Show the specified resource.
@@ -50,16 +47,10 @@ class BlogController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id)
-    {
-        //
-    }
+    public function update(Request $request, $id) {}
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy($id)
-    {
-        //
-    }
+    public function destroy($id) {}
 }

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__4.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__4.txt
@@ -2,8 +2,8 @@
 
 namespace Modules\Blog\Providers;
 
-use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
 
 class RouteServiceProvider extends ServiceProvider
 {

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__2.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__2.txt
@@ -26,10 +26,7 @@ class BlogController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
-    {
-        //
-    }
+    public function store(Request $request) {}
 
     /**
      * Show the specified resource.
@@ -50,16 +47,10 @@ class BlogController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, $id)
-    {
-        //
-    }
+    public function update(Request $request, $id) {}
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy($id)
-    {
-        //
-    }
+    public function destroy($id) {}
 }

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__4.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__4.txt
@@ -2,8 +2,8 @@
 
 namespace Modules\Blog\Providers;
 
-use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
 
 class RouteServiceProvider extends ServiceProvider
 {

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_route_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_route_file__1.txt
@@ -3,17 +3,6 @@
 use Illuminate\Support\Facades\Route;
 use Modules\Blog\Http\Controllers\BlogController;
 
-/*
-|--------------------------------------------------------------------------
-| Web Routes
-|--------------------------------------------------------------------------
-|
-| Here is where you can register web routes for your application. These
-| routes are loaded by the RouteServiceProvider within a group which
-| contains the "web" middleware group. Now create something great!
-|
-*/
-
-Route::group([], function () {
+Route::middleware(['auth', 'verified'])->group(function () {
     Route::resource('blog', BlogController::class)->names('blog');
 });

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_route_file_with_multi_segment_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_route_file_with_multi_segment_default_namespace__1.txt
@@ -3,17 +3,6 @@
 use Illuminate\Support\Facades\Route;
 use Custom\Modules\Blog\Http\Controllers\BlogController;
 
-/*
-|--------------------------------------------------------------------------
-| Web Routes
-|--------------------------------------------------------------------------
-|
-| Here is where you can register web routes for your application. These
-| routes are loaded by the RouteServiceProvider within a group which
-| contains the "web" middleware group. Now create something great!
-|
-*/
-
-Route::group([], function () {
+Route::middleware(['auth', 'verified'])->group(function () {
     Route::resource('blog', BlogController::class)->names('blog');
 });

--- a/tests/Commands/Make/__snapshots__/NotificationMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/NotificationMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -14,10 +14,7 @@ class WelcomeNotification extends Notification
     /**
      * Create a new notification instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Get the notification's delivery channels.

--- a/tests/Commands/Make/__snapshots__/NotificationMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/Make/__snapshots__/NotificationMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
@@ -14,10 +14,7 @@ class WelcomeNotification extends Notification
     /**
      * Create a new notification instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Get the notification's delivery channels.

--- a/tests/Commands/Make/__snapshots__/NotificationMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/NotificationMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -14,10 +14,7 @@ class WelcomeNotification extends Notification
     /**
      * Create a new notification instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Get the notification's delivery channels.

--- a/tests/Commands/Make/__snapshots__/ObserverMakeCommandTest__test_it_makes_observer__1.txt
+++ b/tests/Commands/Make/__snapshots__/ObserverMakeCommandTest__test_it_makes_observer__1.txt
@@ -9,40 +9,25 @@ class PostObserver
     /**
      * Handle the Post "created" event.
      */
-    public function created(Post $post): void
-    {
-        //
-    }
+    public function created(Post $post): void {}
 
     /**
      * Handle the Post "updated" event.
      */
-    public function updated(Post $post): void
-    {
-        //
-    }
+    public function updated(Post $post): void {}
 
     /**
      * Handle the Post "deleted" event.
      */
-    public function deleted(Post $post): void
-    {
-        //
-    }
+    public function deleted(Post $post): void {}
 
     /**
      * Handle the Post "restored" event.
      */
-    public function restored(Post $post): void
-    {
-        //
-    }
+    public function restored(Post $post): void {}
 
     /**
      * Handle the Post "force deleted" event.
      */
-    public function forceDeleted(Post $post): void
-    {
-        //
-    }
+    public function forceDeleted(Post $post): void {}
 }

--- a/tests/Commands/Make/__snapshots__/PolicyMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/PolicyMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -11,8 +11,5 @@ class PostPolicy
     /**
      * Create a new policy instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 }

--- a/tests/Commands/Make/__snapshots__/PolicyMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/Make/__snapshots__/PolicyMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
@@ -11,8 +11,5 @@ class PostPolicy
     /**
      * Create a new policy instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 }

--- a/tests/Commands/Make/__snapshots__/PolicyMakeCommandTest__test_it_makes_policy__1.txt
+++ b/tests/Commands/Make/__snapshots__/PolicyMakeCommandTest__test_it_makes_policy__1.txt
@@ -11,8 +11,5 @@ class PostPolicy
     /**
      * Create a new policy instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 }

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -9,10 +9,7 @@ class MyBlogServiceProvider extends ServiceProvider
     /**
      * Register the service provider.
      */
-    public function register(): void
-    {
-        //
-    }
+    public function register(): void {}
 
     /**
      * Get the services provided by the provider.

--- a/tests/Commands/Make/__snapshots__/RepositoryMakeCommandTest__test_it_can_generate_a_repository_in_sub_namespace_with_correct_generated_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/RepositoryMakeCommandTest__test_it_can_generate_a_repository_in_sub_namespace_with_correct_generated_file__1.txt
@@ -4,8 +4,5 @@ namespace Modules\Blog\Repositories\Api;
 
 class MyRepository
 {
-    public function handle()
-    {
-        //
-    }
+    public function handle() {}
 }

--- a/tests/Commands/Make/__snapshots__/RepositoryMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/RepositoryMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -4,8 +4,5 @@ namespace Modules\Blog\Repositories;
 
 class MyRepository
 {
-    public function handle()
-    {
-        //
-    }
+    public function handle() {}
 }

--- a/tests/Commands/Make/__snapshots__/RequestMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/RequestMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -11,9 +11,7 @@ class CreateBlogPostRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            //
-        ];
+        return [];
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/RequestMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/Make/__snapshots__/RequestMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
@@ -11,9 +11,7 @@ class CreateBlogPostRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            //
-        ];
+        return [];
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/RequestMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/RequestMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -11,9 +11,7 @@ class CreateBlogPostRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            //
-        ];
+        return [];
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/RouteProviderMakeCommandTest__test_it_can_change_the_custom_controller_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/RouteProviderMakeCommandTest__test_it_can_change_the_custom_controller_namespace__1.txt
@@ -2,8 +2,8 @@
 
 namespace Modules\Blog\Base\Providers;
 
-use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
 
 class RouteServiceProvider extends ServiceProvider
 {

--- a/tests/Commands/Make/__snapshots__/RouteProviderMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/RouteProviderMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -2,8 +2,8 @@
 
 namespace Modules\Blog\SuperProviders;
 
-use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
 
 class RouteServiceProvider extends ServiceProvider
 {

--- a/tests/Commands/Make/__snapshots__/RouteProviderMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/Make/__snapshots__/RouteProviderMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
@@ -2,8 +2,8 @@
 
 namespace Modules\Blog\SuperProviders;
 
-use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
 
 class RouteServiceProvider extends ServiceProvider
 {

--- a/tests/Commands/Make/__snapshots__/RouteProviderMakeCommandTest__test_it_can_overwrite_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/RouteProviderMakeCommandTest__test_it_can_overwrite_file__1.txt
@@ -2,8 +2,8 @@
 
 namespace Modules\Blog\Providers;
 
-use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
 
 class RouteServiceProvider extends ServiceProvider
 {

--- a/tests/Commands/Make/__snapshots__/RouteProviderMakeCommandTest__test_it_can_overwrite_route_file_names__1.txt
+++ b/tests/Commands/Make/__snapshots__/RouteProviderMakeCommandTest__test_it_can_overwrite_route_file_names__1.txt
@@ -2,8 +2,8 @@
 
 namespace Modules\Blog\Providers;
 
-use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
 
 class RouteServiceProvider extends ServiceProvider
 {

--- a/tests/Commands/Make/__snapshots__/RouteProviderMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/RouteProviderMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -2,8 +2,8 @@
 
 namespace Modules\Blog\Providers;
 
-use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
 
 class RouteServiceProvider extends ServiceProvider
 {

--- a/tests/Commands/Make/__snapshots__/RuleMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/RuleMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -10,8 +10,5 @@ class UniqueRule implements ValidationRule
     /**
      * Run the validation rule.
      */
-    public function validate(string $attribute, mixed $value, Closure $fail): void
-    {
-        //
-    }
+    public function validate(string $attribute, mixed $value, Closure $fail): void {}
 }

--- a/tests/Commands/Make/__snapshots__/RuleMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/Make/__snapshots__/RuleMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
@@ -10,8 +10,5 @@ class UniqueRule implements ValidationRule
     /**
      * Run the validation rule.
      */
-    public function validate(string $attribute, mixed $value, Closure $fail): void
-    {
-        //
-    }
+    public function validate(string $attribute, mixed $value, Closure $fail): void {}
 }

--- a/tests/Commands/Make/__snapshots__/RuleMakeCommandTest__test_it_makes_implicit_rule__1.txt
+++ b/tests/Commands/Make/__snapshots__/RuleMakeCommandTest__test_it_makes_implicit_rule__1.txt
@@ -15,8 +15,5 @@ class ImplicitUniqueRule implements ValidationRule
     /**
      * Run the validation rule.
      */
-    public function validate(string $attribute, mixed $value, Closure $fail): void
-    {
-        //
-    }
+    public function validate(string $attribute, mixed $value, Closure $fail): void {}
 }

--- a/tests/Commands/Make/__snapshots__/RuleMakeCommandTest__test_it_makes_rule__1.txt
+++ b/tests/Commands/Make/__snapshots__/RuleMakeCommandTest__test_it_makes_rule__1.txt
@@ -10,8 +10,5 @@ class UniqueRule implements ValidationRule
     /**
      * Run the validation rule.
      */
-    public function validate(string $attribute, mixed $value, Closure $fail): void
-    {
-        //
-    }
+    public function validate(string $attribute, mixed $value, Closure $fail): void {}
 }

--- a/tests/Commands/Make/__snapshots__/ScopeMakeCommandTest__test_it_can_generate_a_scope_in_sub_namespace_with_correct_generated_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/ScopeMakeCommandTest__test_it_can_generate_a_scope_in_sub_namespace_with_correct_generated_file__1.txt
@@ -11,8 +11,5 @@ class MyScope implements Scope
     /**
      * Apply the scope to a given Eloquent query builder.
      */
-    public function apply(Builder $builder, Model $model): void
-    {
-        //
-    }
+    public function apply(Builder $builder, Model $model): void {}
 }

--- a/tests/Commands/Make/__snapshots__/ScopeMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/ScopeMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -11,8 +11,5 @@ class MyScope implements Scope
     /**
      * Apply the scope to a given Eloquent query builder.
      */
-    public function apply(Builder $builder, Model $model): void
-    {
-        //
-    }
+    public function apply(Builder $builder, Model $model): void {}
 }

--- a/tests/Commands/Make/__snapshots__/ServiceMakeCommandTest__test_it_can_generate_a_service_in_sub_namespace_with_correct_generated_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/ServiceMakeCommandTest__test_it_can_generate_a_service_in_sub_namespace_with_correct_generated_file__1.txt
@@ -4,8 +4,5 @@ namespace Modules\Blog\Services\Api;
 
 class MyService
 {
-    public function handle()
-    {
-        //
-    }
+    public function handle() {}
 }

--- a/tests/Commands/Make/__snapshots__/ServiceMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/ServiceMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -4,8 +4,5 @@ namespace Modules\Blog\Services;
 
 class MyService
 {
-    public function handle()
-    {
-        //
-    }
+    public function handle() {}
 }

--- a/tests/Commands/Make/__snapshots__/TraitMakeCommandTest__test_it_can_generate_a_trait_in_sub_namespace_with_correct_generated_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/TraitMakeCommandTest__test_it_can_generate_a_trait_in_sub_namespace_with_correct_generated_file__1.txt
@@ -2,7 +2,4 @@
 
 namespace Modules\Blog\Traits\Api;
 
-trait MyTrait
-{
-    //
-}
+trait MyTrait {}

--- a/tests/Commands/Make/__snapshots__/TraitMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
+++ b/tests/Commands/Make/__snapshots__/TraitMakeCommandTest__test_it_generated_correct_file_with_content__1.txt
@@ -2,7 +2,4 @@
 
 namespace Modules\Blog\Traits;
 
-trait MyTrait
-{
-    //
-}
+trait MyTrait {}


### PR DESCRIPTION
Updated module stubs to follow the Laravel Pint coding standards.
Updated stub files to maintain consistency, readability, and best practices in formatting and structure.

**Acceptance Criteria**
- Apply Laravel Pint formatting to all stub files.
- Ensure that indentation, spacing, and syntax follow Laravel standards.
- Validate that generated files from stubs match expected formatting.
- Test stub-based scaffolding to confirm no functional issues.