### PR TITLE
[new feature] Module plural names

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -39,8 +39,8 @@ return [
             'package' => 'package.json',
         ],
         'replacements' => [
-            'routes/web' => ['LOWER_NAME', 'STUDLY_NAME', 'KEBAB_NAME', 'MODULE_NAMESPACE', 'CONTROLLER_NAMESPACE'],
-            'routes/api' => ['LOWER_NAME', 'STUDLY_NAME', 'KEBAB_NAME', 'MODULE_NAMESPACE', 'CONTROLLER_NAMESPACE'],
+            'routes/web' => ['LOWER_NAME', 'STUDLY_NAME', 'PLURAL_LOWER_NAME', 'KEBAB_NAME', 'MODULE_NAMESPACE', 'CONTROLLER_NAMESPACE'],
+            'routes/api' => ['LOWER_NAME', 'STUDLY_NAME', 'PLURAL_LOWER_NAME', 'KEBAB_NAME', 'MODULE_NAMESPACE', 'CONTROLLER_NAMESPACE'],
             'vite' => ['LOWER_NAME', 'STUDLY_NAME', 'KEBAB_NAME'],
             'json' => ['LOWER_NAME', 'STUDLY_NAME', 'KEBAB_NAME', 'MODULE_NAMESPACE', 'PROVIDER_NAMESPACE'],
             'views/index' => ['LOWER_NAME'],

--- a/src/Generators/ModuleGenerator.php
+++ b/src/Generators/ModuleGenerator.php
@@ -485,6 +485,7 @@ class ModuleGenerator extends Generator
                 $keys[] = 'PROVIDER_NAMESPACE';
             }
         }
+
         foreach ($keys as $key) {
             if (method_exists($this, $method = 'get'.ucfirst(Str::studly(strtolower($key))).'Replacement')) {
                 $replace = $this->$method();
@@ -494,7 +495,6 @@ class ModuleGenerator extends Generator
                 }
 
                 $replaces[$key] = $replace;
-
             } else {
                 $replaces[$key] = null;
             }
@@ -546,6 +546,14 @@ class ModuleGenerator extends Generator
         return strtolower($this->getName());
     }
 
+    /**
+     * Get the module name in lowercase plural form.
+     */
+    protected function getPluralLowerNameReplacement(): string
+    {
+        return Str::of($this->getName())->lower()->plural();
+    }
+
     protected function getKebabNameReplacement(): string
     {
         return Str::kebab($this->getName());
@@ -557,6 +565,14 @@ class ModuleGenerator extends Generator
     protected function getStudlyNameReplacement(): string
     {
         return $this->getName();
+    }
+
+    /**
+     * Get the module name in plural studly case.
+     */
+    protected function getPluralStudlyNameReplacement(): string
+    {
+        return Str::of($this->getName())->pluralStudly();
     }
 
     /**


### PR DESCRIPTION
Based on: https://github.com/nWidart/laravel-modules/issues/949
Ref: https://github.com/nWidart/laravel-modules/pull/1908

Added two new replacements: PLURAL_LOWER_NAME and PLURAL_STUDLY_NAME

This feature is necessary for many functionalities, such as the route path and name.

This will no longer break any existing setup as it's not implemented in any stub. Dev are expected to implement it at their choice.