### PR TITLE
Add Support for Closures in Stub Variable Replacement

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -55,7 +55,6 @@ return [
              *
              * Note: Keys should be in UPPERCASE.
              */
-
             'routes/web' => ['LOWER_NAME', 'STUDLY_NAME', 'PLURAL_LOWER_NAME', 'KEBAB_NAME', 'MODULE_NAMESPACE', 'CONTROLLER_NAMESPACE'],
             'routes/api' => ['LOWER_NAME', 'STUDLY_NAME', 'PLURAL_LOWER_NAME', 'KEBAB_NAME', 'MODULE_NAMESPACE', 'CONTROLLER_NAMESPACE'],
             'vite' => ['LOWER_NAME', 'STUDLY_NAME', 'KEBAB_NAME'],

--- a/config/config.php
+++ b/config/config.php
@@ -39,6 +39,23 @@ return [
             'package' => 'package.json',
         ],
         'replacements' => [
+            /**
+             * Define custom replacements for each section.
+             * You can specify a closure for dynamic values.
+             *
+             * Example:
+             *
+             * 'composer' => [
+             *      'CUSTOM_KEY' => fn (\Nwidart\Modules\Generators\ModuleGenerator $generator) => $generator->getModule()->getLowerName() . '-module',
+             *      'CUSTOM_KEY2' => fn () => 'custom text',
+             *      'LOWER_NAME',
+             *      'STUDLY_NAME',
+             *      // ...
+             * ],
+             *
+             * Note: Keys should be in UPPERCASE.
+             */
+
             'routes/web' => ['LOWER_NAME', 'STUDLY_NAME', 'PLURAL_LOWER_NAME', 'KEBAB_NAME', 'MODULE_NAMESPACE', 'CONTROLLER_NAMESPACE'],
             'routes/api' => ['LOWER_NAME', 'STUDLY_NAME', 'PLURAL_LOWER_NAME', 'KEBAB_NAME', 'MODULE_NAMESPACE', 'CONTROLLER_NAMESPACE'],
             'vite' => ['LOWER_NAME', 'STUDLY_NAME', 'KEBAB_NAME'],

--- a/src/Generators/ModuleGenerator.php
+++ b/src/Generators/ModuleGenerator.php
@@ -486,17 +486,19 @@ class ModuleGenerator extends Generator
             }
         }
 
-        foreach ($keys as $key) {
-            if (method_exists($this, $method = 'get'.ucfirst(Str::studly(strtolower($key))).'Replacement')) {
+        foreach ($keys as $key => $value) {
+            if ($value instanceof \Closure) {
+                $replaces[strtoupper($key)] = $value($this);
+            } elseif (method_exists($this, $method = 'get'.ucfirst(Str::studly(strtolower($value))).'Replacement')) {
                 $replace = $this->$method();
 
                 if ($stub === 'routes/web' || $stub === 'routes/api') {
                     $replace = str_replace('\\\\', '\\', $replace);
                 }
 
-                $replaces[$key] = $replace;
+                $replaces[$value] = $replace;
             } else {
-                $replaces[$key] = null;
+                $replaces[$value] = null;
             }
         }
 


### PR DESCRIPTION
Hi,  

This pull request adds support for **closures in stub variable replacements**, allowing dynamic values to be set in published configuration files.  

### **Usage:**  
In the `module.php` file, under the `stubs/replacements` section, you can now define variables as closures:  

```php
'composer' => [
    'CUSTOM_KEY' => fn (\Nwidart\Modules\Generators\ModuleGenerator $generator) => $generator->getName() . '-module',
    'CUSTOM_KEY1' => fn () => 'custom text',
    'LOWER_NAME',
    'STUDLY_NAME',
    'VENDOR',
    'AUTHOR_NAME',
    'AUTHOR_EMAIL',
    'MODULE_NAMESPACE',
    'PROVIDER_NAMESPACE',
    'APP_FOLDER_NAME',
],
```

In stub files, use the defined variables as placeholders:  

```json
{
    "name": "$VENDOR$/$LOWER_NAME$",
    "description": "$CUSTOM_KEY$ $CUSTOM_KEY1$",
    "authors": [
        {
            "name": "$AUTHOR_NAME$",
            "email": "$AUTHOR_EMAIL$"
        }
    ]
}
```
> [!IMPORTANT]  
> in stub file Variables should be define UPPERCASE

result:
```json
{
    "name": "LaraSSN/k12",
    "description": "K12-module custom text",
    "authors": [
        {
            "name": "Ali SSN",
            "email": "alisasani15@gmail.com"
        }
    ],
}

```

This enhancement provides **greater flexibility** in generating module configurations dynamically.  
