### PR TITLE
Feature/pluralize module route paths

### DIFF
--- a/src/Commands/stubs/routes/api.stub
+++ b/src/Commands/stubs/routes/api.stub
@@ -4,5 +4,5 @@ use Illuminate\Support\Facades\Route;
 use $MODULE_NAMESPACE$\$STUDLY_NAME$\$CONTROLLER_NAMESPACE$\$STUDLY_NAME$Controller;
 
 Route::middleware(['auth:sanctum'])->prefix('v1')->group(function () {
-    Route::apiResource('$LOWER_NAME$', $STUDLY_NAME$Controller::class)->names('$LOWER_NAME$');
+    Route::apiResource('$PLURAL_LOWER_NAME$', $STUDLY_NAME$Controller::class)->names('$LOWER_NAME$');
 });

--- a/src/Commands/stubs/routes/web.stub
+++ b/src/Commands/stubs/routes/web.stub
@@ -4,5 +4,5 @@ use Illuminate\Support\Facades\Route;
 use $MODULE_NAMESPACE$\$STUDLY_NAME$\$CONTROLLER_NAMESPACE$\$STUDLY_NAME$Controller;
 
 Route::middleware(['auth', 'verified'])->group(function () {
-    Route::resource('$LOWER_NAME$', $STUDLY_NAME$Controller::class)->names('$LOWER_NAME$');
+    Route::resource('$PLURAL_LOWER_NAME$', $STUDLY_NAME$Controller::class)->names('$LOWER_NAME$');
 });

--- a/src/Generators/ModuleGenerator.php
+++ b/src/Generators/ModuleGenerator.php
@@ -468,8 +468,15 @@ class ModuleGenerator extends Generator
     {
         $replacements = $this->module->config('stubs.replacements');
 
+        // Temporarily check if the replacements are defined; remove in the next major version.
         if (! isset($replacements['composer']['APP_FOLDER_NAME'])) {
             $replacements['composer'][] = 'APP_FOLDER_NAME';
+        }
+        if (! isset($replacements['routes/web']['PLURAL_LOWER_NAME'])) {
+            $replacements['routes/web'][] = 'PLURAL_LOWER_NAME';
+        }
+        if (! isset($replacements['routes/api']['PLURAL_LOWER_NAME'])) {
+            $replacements['routes/api'][] = 'PLURAL_LOWER_NAME';
         }
 
         if (! isset($replacements[$stub])) {

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_route_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_route_file__1.txt
@@ -4,5 +4,5 @@ use Illuminate\Support\Facades\Route;
 use Modules\Blog\Http\Controllers\BlogController;
 
 Route::middleware(['auth:sanctum'])->prefix('v1')->group(function () {
-    Route::apiResource('blog', BlogController::class)->names('blog');
+    Route::apiResource('blogs', BlogController::class)->names('blog');
 });

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_route_file_with_multi_segment_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_route_file_with_multi_segment_default_namespace__1.txt
@@ -4,5 +4,5 @@ use Illuminate\Support\Facades\Route;
 use Custom\Modules\Blog\Http\Controllers\BlogController;
 
 Route::middleware(['auth:sanctum'])->prefix('v1')->group(function () {
-    Route::apiResource('blog', BlogController::class)->names('blog');
+    Route::apiResource('blogs', BlogController::class)->names('blog');
 });

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_route_file__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_route_file__1.txt
@@ -4,5 +4,5 @@ use Illuminate\Support\Facades\Route;
 use Modules\Blog\Http\Controllers\BlogController;
 
 Route::middleware(['auth', 'verified'])->group(function () {
-    Route::resource('blog', BlogController::class)->names('blog');
+    Route::resource('blogs', BlogController::class)->names('blog');
 });

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_route_file_with_multi_segment_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_route_file_with_multi_segment_default_namespace__1.txt
@@ -4,5 +4,5 @@ use Illuminate\Support\Facades\Route;
 use Custom\Modules\Blog\Http\Controllers\BlogController;
 
 Route::middleware(['auth', 'verified'])->group(function () {
-    Route::resource('blog', BlogController::class)->names('blog');
+    Route::resource('blogs', BlogController::class)->names('blog');
 });


### PR DESCRIPTION
- Introduced a feature to normalize module route base paths to use plural names. E.g. /blog -> /blogs
- Ensures consistency across module routing structure.
- Provides backward compatibility with existing module routes.
- Updated documentation and configuration to reflect the changes.