### PR TITLE
Enhance Config Merging Logic to Prevent Duplicate Keys in Modules

### DIFF
--- a/src/Commands/stubs/scaffold/provider.stub
+++ b/src/Commands/stubs/scaffold/provider.stub
@@ -78,19 +78,28 @@ class $CLASS$ extends ServiceProvider
      */
     protected function registerConfig(): void
     {
-        $relativeConfigPath = config('modules.paths.generator.config.path');
-        $configPath = module_path($this->name, $relativeConfigPath);
+        $configPath = module_path($this->name, config('modules.paths.generator.config.path'));
 
         if (is_dir($configPath)) {
             $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($configPath));
 
             foreach ($iterator as $file) {
                 if ($file->isFile() && $file->getExtension() === 'php') {
-                    $relativePath = str_replace($configPath . DIRECTORY_SEPARATOR, '', $file->getPathname());
-                    $configKey = $this->nameLower . '.' . str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $relativePath);
-                    $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
+                    $config = str_replace($configPath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+                    $config_key = str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $config);
+                    $segments = explode('.', $this->nameLower.'.'.$config_key);
 
-                    $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
+                    // Remove duplicated adjacent segments
+                    $normalized = [];
+                    foreach ($segments as $segment) {
+                        if (end($normalized) !== $segment) {
+                            $normalized[] = $segment;
+                        }
+                    }
+
+                    $key = implode('.', $normalized);
+
+                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);
                 }
             }

--- a/src/Commands/stubs/scaffold/provider.stub
+++ b/src/Commands/stubs/scaffold/provider.stub
@@ -97,7 +97,7 @@ class $CLASS$ extends ServiceProvider
                         }
                     }
 
-                    $key = implode('.', $normalized);
+                    $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
                     $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_disable__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_disable__1.txt
@@ -78,19 +78,28 @@ class BlogServiceProvider extends ServiceProvider
      */
     protected function registerConfig(): void
     {
-        $relativeConfigPath = config('modules.paths.generator.config.path');
-        $configPath = module_path($this->name, $relativeConfigPath);
+        $configPath = module_path($this->name, config('modules.paths.generator.config.path'));
 
         if (is_dir($configPath)) {
             $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($configPath));
 
             foreach ($iterator as $file) {
                 if ($file->isFile() && $file->getExtension() === 'php') {
-                    $relativePath = str_replace($configPath . DIRECTORY_SEPARATOR, '', $file->getPathname());
-                    $configKey = $this->nameLower . '.' . str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $relativePath);
-                    $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
+                    $config = str_replace($configPath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+                    $config_key = str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $config);
+                    $segments = explode('.', $this->nameLower.'.'.$config_key);
 
-                    $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
+                    // Remove duplicated adjacent segments
+                    $normalized = [];
+                    foreach ($segments as $segment) {
+                        if (end($normalized) !== $segment) {
+                            $normalized[] = $segment;
+                        }
+                    }
+
+                    $key = implode('.', $normalized);
+
+                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_disable__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_disable__1.txt
@@ -97,7 +97,7 @@ class BlogServiceProvider extends ServiceProvider
                         }
                     }
 
-                    $key = implode('.', $normalized);
+                    $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
                     $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__1.txt
@@ -78,19 +78,28 @@ class BlogServiceProvider extends ServiceProvider
      */
     protected function registerConfig(): void
     {
-        $relativeConfigPath = config('modules.paths.generator.config.path');
-        $configPath = module_path($this->name, $relativeConfigPath);
+        $configPath = module_path($this->name, config('modules.paths.generator.config.path'));
 
         if (is_dir($configPath)) {
             $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($configPath));
 
             foreach ($iterator as $file) {
                 if ($file->isFile() && $file->getExtension() === 'php') {
-                    $relativePath = str_replace($configPath . DIRECTORY_SEPARATOR, '', $file->getPathname());
-                    $configKey = $this->nameLower . '.' . str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $relativePath);
-                    $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
+                    $config = str_replace($configPath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+                    $config_key = str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $config);
+                    $segments = explode('.', $this->nameLower.'.'.$config_key);
 
-                    $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
+                    // Remove duplicated adjacent segments
+                    $normalized = [];
+                    foreach ($segments as $segment) {
+                        if (end($normalized) !== $segment) {
+                            $normalized[] = $segment;
+                        }
+                    }
+
+                    $key = implode('.', $normalized);
+
+                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__1.txt
@@ -97,7 +97,7 @@ class BlogServiceProvider extends ServiceProvider
                         }
                     }
 
-                    $key = implode('.', $normalized);
+                    $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
                     $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__1.txt
@@ -78,19 +78,28 @@ class BlogServiceProvider extends ServiceProvider
      */
     protected function registerConfig(): void
     {
-        $relativeConfigPath = config('modules.paths.generator.config.path');
-        $configPath = module_path($this->name, $relativeConfigPath);
+        $configPath = module_path($this->name, config('modules.paths.generator.config.path'));
 
         if (is_dir($configPath)) {
             $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($configPath));
 
             foreach ($iterator as $file) {
                 if ($file->isFile() && $file->getExtension() === 'php') {
-                    $relativePath = str_replace($configPath . DIRECTORY_SEPARATOR, '', $file->getPathname());
-                    $configKey = $this->nameLower . '.' . str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $relativePath);
-                    $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
+                    $config = str_replace($configPath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+                    $config_key = str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $config);
+                    $segments = explode('.', $this->nameLower.'.'.$config_key);
 
-                    $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
+                    // Remove duplicated adjacent segments
+                    $normalized = [];
+                    foreach ($segments as $segment) {
+                        if (end($normalized) !== $segment) {
+                            $normalized[] = $segment;
+                        }
+                    }
+
+                    $key = implode('.', $normalized);
+
+                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__1.txt
@@ -97,7 +97,7 @@ class BlogServiceProvider extends ServiceProvider
                         }
                     }
 
-                    $key = implode('.', $normalized);
+                    $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
                     $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_namespace_using_studly_case__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_namespace_using_studly_case__1.txt
@@ -78,19 +78,28 @@ class ModuleNameServiceProvider extends ServiceProvider
      */
     protected function registerConfig(): void
     {
-        $relativeConfigPath = config('modules.paths.generator.config.path');
-        $configPath = module_path($this->name, $relativeConfigPath);
+        $configPath = module_path($this->name, config('modules.paths.generator.config.path'));
 
         if (is_dir($configPath)) {
             $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($configPath));
 
             foreach ($iterator as $file) {
                 if ($file->isFile() && $file->getExtension() === 'php') {
-                    $relativePath = str_replace($configPath . DIRECTORY_SEPARATOR, '', $file->getPathname());
-                    $configKey = $this->nameLower . '.' . str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $relativePath);
-                    $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
+                    $config = str_replace($configPath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+                    $config_key = str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $config);
+                    $segments = explode('.', $this->nameLower.'.'.$config_key);
 
-                    $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
+                    // Remove duplicated adjacent segments
+                    $normalized = [];
+                    foreach ($segments as $segment) {
+                        if (end($normalized) !== $segment) {
+                            $normalized[] = $segment;
+                        }
+                    }
+
+                    $key = implode('.', $normalized);
+
+                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_namespace_using_studly_case__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_namespace_using_studly_case__1.txt
@@ -97,7 +97,7 @@ class ModuleNameServiceProvider extends ServiceProvider
                         }
                     }
 
-                    $key = implode('.', $normalized);
+                    $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
                     $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__1.txt
@@ -78,19 +78,28 @@ class BlogServiceProvider extends ServiceProvider
      */
     protected function registerConfig(): void
     {
-        $relativeConfigPath = config('modules.paths.generator.config.path');
-        $configPath = module_path($this->name, $relativeConfigPath);
+        $configPath = module_path($this->name, config('modules.paths.generator.config.path'));
 
         if (is_dir($configPath)) {
             $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($configPath));
 
             foreach ($iterator as $file) {
                 if ($file->isFile() && $file->getExtension() === 'php') {
-                    $relativePath = str_replace($configPath . DIRECTORY_SEPARATOR, '', $file->getPathname());
-                    $configKey = $this->nameLower . '.' . str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $relativePath);
-                    $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
+                    $config = str_replace($configPath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+                    $config_key = str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $config);
+                    $segments = explode('.', $this->nameLower.'.'.$config_key);
 
-                    $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
+                    // Remove duplicated adjacent segments
+                    $normalized = [];
+                    foreach ($segments as $segment) {
+                        if (end($normalized) !== $segment) {
+                            $normalized[] = $segment;
+                        }
+                    }
+
+                    $key = implode('.', $normalized);
+
+                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__1.txt
@@ -97,7 +97,7 @@ class BlogServiceProvider extends ServiceProvider
                         }
                     }
 
-                    $key = implode('.', $normalized);
+                    $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
                     $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__1.txt
@@ -78,19 +78,28 @@ class BlogServiceProvider extends ServiceProvider
      */
     protected function registerConfig(): void
     {
-        $relativeConfigPath = config('modules.paths.generator.config.path');
-        $configPath = module_path($this->name, $relativeConfigPath);
+        $configPath = module_path($this->name, config('modules.paths.generator.config.path'));
 
         if (is_dir($configPath)) {
             $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($configPath));
 
             foreach ($iterator as $file) {
                 if ($file->isFile() && $file->getExtension() === 'php') {
-                    $relativePath = str_replace($configPath . DIRECTORY_SEPARATOR, '', $file->getPathname());
-                    $configKey = $this->nameLower . '.' . str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $relativePath);
-                    $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
+                    $config = str_replace($configPath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+                    $config_key = str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $config);
+                    $segments = explode('.', $this->nameLower.'.'.$config_key);
 
-                    $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
+                    // Remove duplicated adjacent segments
+                    $normalized = [];
+                    foreach ($segments as $segment) {
+                        if (end($normalized) !== $segment) {
+                            $normalized[] = $segment;
+                        }
+                    }
+
+                    $key = implode('.', $normalized);
+
+                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__1.txt
@@ -97,7 +97,7 @@ class BlogServiceProvider extends ServiceProvider
                         }
                     }
 
-                    $key = implode('.', $normalized);
+                    $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
                     $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__1.txt
@@ -78,19 +78,28 @@ class BlogServiceProvider extends ServiceProvider
      */
     protected function registerConfig(): void
     {
-        $relativeConfigPath = config('modules.paths.generator.config.path');
-        $configPath = module_path($this->name, $relativeConfigPath);
+        $configPath = module_path($this->name, config('modules.paths.generator.config.path'));
 
         if (is_dir($configPath)) {
             $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($configPath));
 
             foreach ($iterator as $file) {
                 if ($file->isFile() && $file->getExtension() === 'php') {
-                    $relativePath = str_replace($configPath . DIRECTORY_SEPARATOR, '', $file->getPathname());
-                    $configKey = $this->nameLower . '.' . str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $relativePath);
-                    $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
+                    $config = str_replace($configPath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+                    $config_key = str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $config);
+                    $segments = explode('.', $this->nameLower.'.'.$config_key);
 
-                    $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
+                    // Remove duplicated adjacent segments
+                    $normalized = [];
+                    foreach ($segments as $segment) {
+                        if (end($normalized) !== $segment) {
+                            $normalized[] = $segment;
+                        }
+                    }
+
+                    $key = implode('.', $normalized);
+
+                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__1.txt
@@ -97,7 +97,7 @@ class BlogServiceProvider extends ServiceProvider
                         }
                     }
 
-                    $key = implode('.', $normalized);
+                    $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
                     $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -78,19 +78,28 @@ class BlogServiceProvider extends ServiceProvider
      */
     protected function registerConfig(): void
     {
-        $relativeConfigPath = config('modules.paths.generator.config.path');
-        $configPath = module_path($this->name, $relativeConfigPath);
+        $configPath = module_path($this->name, config('modules.paths.generator.config.path'));
 
         if (is_dir($configPath)) {
             $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($configPath));
 
             foreach ($iterator as $file) {
                 if ($file->isFile() && $file->getExtension() === 'php') {
-                    $relativePath = str_replace($configPath . DIRECTORY_SEPARATOR, '', $file->getPathname());
-                    $configKey = $this->nameLower . '.' . str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $relativePath);
-                    $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
+                    $config = str_replace($configPath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+                    $config_key = str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $config);
+                    $segments = explode('.', $this->nameLower.'.'.$config_key);
 
-                    $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
+                    // Remove duplicated adjacent segments
+                    $normalized = [];
+                    foreach ($segments as $segment) {
+                        if (end($normalized) !== $segment) {
+                            $normalized[] = $segment;
+                        }
+                    }
+
+                    $key = implode('.', $normalized);
+
+                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -97,7 +97,7 @@ class BlogServiceProvider extends ServiceProvider
                         }
                     }
 
-                    $key = implode('.', $normalized);
+                    $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
                     $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
@@ -78,19 +78,28 @@ class BlogServiceProvider extends ServiceProvider
      */
     protected function registerConfig(): void
     {
-        $relativeConfigPath = config('modules.paths.generator.config.path');
-        $configPath = module_path($this->name, $relativeConfigPath);
+        $configPath = module_path($this->name, config('modules.paths.generator.config.path'));
 
         if (is_dir($configPath)) {
             $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($configPath));
 
             foreach ($iterator as $file) {
                 if ($file->isFile() && $file->getExtension() === 'php') {
-                    $relativePath = str_replace($configPath . DIRECTORY_SEPARATOR, '', $file->getPathname());
-                    $configKey = $this->nameLower . '.' . str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $relativePath);
-                    $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
+                    $config = str_replace($configPath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+                    $config_key = str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $config);
+                    $segments = explode('.', $this->nameLower.'.'.$config_key);
 
-                    $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
+                    // Remove duplicated adjacent segments
+                    $normalized = [];
+                    foreach ($segments as $segment) {
+                        if (end($normalized) !== $segment) {
+                            $normalized[] = $segment;
+                        }
+                    }
+
+                    $key = implode('.', $normalized);
+
+                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
@@ -97,7 +97,7 @@ class BlogServiceProvider extends ServiceProvider
                         }
                     }
 
-                    $key = implode('.', $normalized);
+                    $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
                     $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_have_custom_migration_resources_location_paths__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_have_custom_migration_resources_location_paths__1.txt
@@ -78,19 +78,28 @@ class BlogServiceProvider extends ServiceProvider
      */
     protected function registerConfig(): void
     {
-        $relativeConfigPath = config('modules.paths.generator.config.path');
-        $configPath = module_path($this->name, $relativeConfigPath);
+        $configPath = module_path($this->name, config('modules.paths.generator.config.path'));
 
         if (is_dir($configPath)) {
             $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($configPath));
 
             foreach ($iterator as $file) {
                 if ($file->isFile() && $file->getExtension() === 'php') {
-                    $relativePath = str_replace($configPath . DIRECTORY_SEPARATOR, '', $file->getPathname());
-                    $configKey = $this->nameLower . '.' . str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $relativePath);
-                    $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
+                    $config = str_replace($configPath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+                    $config_key = str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $config);
+                    $segments = explode('.', $this->nameLower.'.'.$config_key);
 
-                    $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
+                    // Remove duplicated adjacent segments
+                    $normalized = [];
+                    foreach ($segments as $segment) {
+                        if (end($normalized) !== $segment) {
+                            $normalized[] = $segment;
+                        }
+                    }
+
+                    $key = implode('.', $normalized);
+
+                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_have_custom_migration_resources_location_paths__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_have_custom_migration_resources_location_paths__1.txt
@@ -97,7 +97,7 @@ class BlogServiceProvider extends ServiceProvider
                         }
                     }
 
-                    $key = implode('.', $normalized);
+                    $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
                     $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_generates_a_master_service_provider_with_resource_loading__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_generates_a_master_service_provider_with_resource_loading__1.txt
@@ -78,19 +78,28 @@ class BlogServiceProvider extends ServiceProvider
      */
     protected function registerConfig(): void
     {
-        $relativeConfigPath = config('modules.paths.generator.config.path');
-        $configPath = module_path($this->name, $relativeConfigPath);
+        $configPath = module_path($this->name, config('modules.paths.generator.config.path'));
 
         if (is_dir($configPath)) {
             $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($configPath));
 
             foreach ($iterator as $file) {
                 if ($file->isFile() && $file->getExtension() === 'php') {
-                    $relativePath = str_replace($configPath . DIRECTORY_SEPARATOR, '', $file->getPathname());
-                    $configKey = $this->nameLower . '.' . str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $relativePath);
-                    $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
+                    $config = str_replace($configPath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+                    $config_key = str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $config);
+                    $segments = explode('.', $this->nameLower.'.'.$config_key);
 
-                    $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
+                    // Remove duplicated adjacent segments
+                    $normalized = [];
+                    foreach ($segments as $segment) {
+                        if (end($normalized) !== $segment) {
+                            $normalized[] = $segment;
+                        }
+                    }
+
+                    $key = implode('.', $normalized);
+
+                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_generates_a_master_service_provider_with_resource_loading__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_generates_a_master_service_provider_with_resource_loading__1.txt
@@ -97,7 +97,7 @@ class BlogServiceProvider extends ServiceProvider
                         }
                     }
 
-                    $key = implode('.', $normalized);
+                    $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
                     $this->publishes([$file->getPathname() => config_path($config)], 'config');
                     $this->mergeConfigFrom($file->getPathname(), $key);


### PR DESCRIPTION
This PR improves the configuration merging logic within module service providers by eliminating adjacent duplicate segments in config keys. This ensures cleaner and more predictable keys, such as `tenancy.tenant_model` instead of `tenancy.tenancy.tenant_model`.

#### ✅ What's Changed:
- Updated `registerConfig()` to normalize config keys by removing consecutive duplicate segments.
- Prevents redundant nesting like `tenancy.tenancy`.
- Helps avoid configuration resolution issues in packages expecting standard key formats.

#### 🧪 Example:

**Before:**
```php
$this->nameLower = 'tenancy'
$relativePath = 'tenancy.php'

Merged key => tenancy.tenancy
Resolved: config('tenancy.tenancy.tenant_model')
```

**After:**
```php
$this->nameLower = 'tenancy'
$relativePath = 'tenancy.php'

Normalized key => tenancy
Resolved: config('tenancy.tenant_model')
```

This change makes module-based configuration fully compatible with third-party packages expecting standard key formats, such as `stancl/tenancy`.