### PR TITLE
Allow Module Configs to Override Root Application Configs

### DIFF
--- a/src/Commands/stubs/scaffold/provider.stub
+++ b/src/Commands/stubs/scaffold/provider.stub
@@ -91,10 +91,21 @@ class $CLASS$ extends ServiceProvider
                     $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
 
                     $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
-                    $this->mergeConfigFrom($file->getPathname(), $key);
+                    $this->merge_config_from($file->getPathname(), $key);
                 }
             }
         }
+    }
+
+    /**
+     * Merge config from the given path recursively.
+     */
+    protected function merge_config_from(string $path, string $key): void
+    {
+        $existing = config($key, []);
+        $module_config = require $path;
+
+        config([$key => array_replace_recursive($existing, $module_config)]);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_disable__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_disable__1.txt
@@ -91,10 +91,21 @@ class BlogServiceProvider extends ServiceProvider
                     $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
 
                     $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
-                    $this->mergeConfigFrom($file->getPathname(), $key);
+                    $this->merge_config_from($file->getPathname(), $key);
                 }
             }
         }
+    }
+
+    /**
+     * Merge config from the given path recursively.
+     */
+    protected function merge_config_from(string $path, string $key): void
+    {
+        $existing = config($key, []);
+        $module_config = require $path;
+
+        config([$key => array_replace_recursive($existing, $module_config)]);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__1.txt
@@ -91,10 +91,21 @@ class BlogServiceProvider extends ServiceProvider
                     $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
 
                     $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
-                    $this->mergeConfigFrom($file->getPathname(), $key);
+                    $this->merge_config_from($file->getPathname(), $key);
                 }
             }
         }
+    }
+
+    /**
+     * Merge config from the given path recursively.
+     */
+    protected function merge_config_from(string $path, string $key): void
+    {
+        $existing = config($key, []);
+        $module_config = require $path;
+
+        config([$key => array_replace_recursive($existing, $module_config)]);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__1.txt
@@ -91,10 +91,21 @@ class BlogServiceProvider extends ServiceProvider
                     $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
 
                     $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
-                    $this->mergeConfigFrom($file->getPathname(), $key);
+                    $this->merge_config_from($file->getPathname(), $key);
                 }
             }
         }
+    }
+
+    /**
+     * Merge config from the given path recursively.
+     */
+    protected function merge_config_from(string $path, string $key): void
+    {
+        $existing = config($key, []);
+        $module_config = require $path;
+
+        config([$key => array_replace_recursive($existing, $module_config)]);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_namespace_using_studly_case__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_namespace_using_studly_case__1.txt
@@ -91,10 +91,21 @@ class ModuleNameServiceProvider extends ServiceProvider
                     $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
 
                     $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
-                    $this->mergeConfigFrom($file->getPathname(), $key);
+                    $this->merge_config_from($file->getPathname(), $key);
                 }
             }
         }
+    }
+
+    /**
+     * Merge config from the given path recursively.
+     */
+    protected function merge_config_from(string $path, string $key): void
+    {
+        $existing = config($key, []);
+        $module_config = require $path;
+
+        config([$key => array_replace_recursive($existing, $module_config)]);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__1.txt
@@ -91,10 +91,21 @@ class BlogServiceProvider extends ServiceProvider
                     $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
 
                     $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
-                    $this->mergeConfigFrom($file->getPathname(), $key);
+                    $this->merge_config_from($file->getPathname(), $key);
                 }
             }
         }
+    }
+
+    /**
+     * Merge config from the given path recursively.
+     */
+    protected function merge_config_from(string $path, string $key): void
+    {
+        $existing = config($key, []);
+        $module_config = require $path;
+
+        config([$key => array_replace_recursive($existing, $module_config)]);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__1.txt
@@ -91,10 +91,21 @@ class BlogServiceProvider extends ServiceProvider
                     $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
 
                     $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
-                    $this->mergeConfigFrom($file->getPathname(), $key);
+                    $this->merge_config_from($file->getPathname(), $key);
                 }
             }
         }
+    }
+
+    /**
+     * Merge config from the given path recursively.
+     */
+    protected function merge_config_from(string $path, string $key): void
+    {
+        $existing = config($key, []);
+        $module_config = require $path;
+
+        config([$key => array_replace_recursive($existing, $module_config)]);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__1.txt
@@ -91,10 +91,21 @@ class BlogServiceProvider extends ServiceProvider
                     $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
 
                     $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
-                    $this->mergeConfigFrom($file->getPathname(), $key);
+                    $this->merge_config_from($file->getPathname(), $key);
                 }
             }
         }
+    }
+
+    /**
+     * Merge config from the given path recursively.
+     */
+    protected function merge_config_from(string $path, string $key): void
+    {
+        $existing = config($key, []);
+        $module_config = require $path;
+
+        config([$key => array_replace_recursive($existing, $module_config)]);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -91,10 +91,21 @@ class BlogServiceProvider extends ServiceProvider
                     $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
 
                     $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
-                    $this->mergeConfigFrom($file->getPathname(), $key);
+                    $this->merge_config_from($file->getPathname(), $key);
                 }
             }
         }
+    }
+
+    /**
+     * Merge config from the given path recursively.
+     */
+    protected function merge_config_from(string $path, string $key): void
+    {
+        $existing = config($key, []);
+        $module_config = require $path;
+
+        config([$key => array_replace_recursive($existing, $module_config)]);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
@@ -91,10 +91,21 @@ class BlogServiceProvider extends ServiceProvider
                     $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
 
                     $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
-                    $this->mergeConfigFrom($file->getPathname(), $key);
+                    $this->merge_config_from($file->getPathname(), $key);
                 }
             }
         }
+    }
+
+    /**
+     * Merge config from the given path recursively.
+     */
+    protected function merge_config_from(string $path, string $key): void
+    {
+        $existing = config($key, []);
+        $module_config = require $path;
+
+        config([$key => array_replace_recursive($existing, $module_config)]);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_have_custom_migration_resources_location_paths__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_have_custom_migration_resources_location_paths__1.txt
@@ -91,10 +91,21 @@ class BlogServiceProvider extends ServiceProvider
                     $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
 
                     $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
-                    $this->mergeConfigFrom($file->getPathname(), $key);
+                    $this->merge_config_from($file->getPathname(), $key);
                 }
             }
         }
+    }
+
+    /**
+     * Merge config from the given path recursively.
+     */
+    protected function merge_config_from(string $path, string $key): void
+    {
+        $existing = config($key, []);
+        $module_config = require $path;
+
+        config([$key => array_replace_recursive($existing, $module_config)]);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_generates_a_master_service_provider_with_resource_loading__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_generates_a_master_service_provider_with_resource_loading__1.txt
@@ -91,10 +91,21 @@ class BlogServiceProvider extends ServiceProvider
                     $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
 
                     $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
-                    $this->mergeConfigFrom($file->getPathname(), $key);
+                    $this->merge_config_from($file->getPathname(), $key);
                 }
             }
         }
+    }
+
+    /**
+     * Merge config from the given path recursively.
+     */
+    protected function merge_config_from(string $path, string $key): void
+    {
+        $existing = config($key, []);
+        $module_config = require $path;
+
+        config([$key => array_replace_recursive($existing, $module_config)]);
     }
 
     /**


### PR DESCRIPTION
#### Summary:
This PR introduces a core enhancement to the `registerConfig()` logic. It ensures that configuration files within a module (e.g., `modules/Blog/config/config.php` or `modules/Blog/config/blog.php`) override Laravel's root application configs (e.g., `config/blog.php`) during registration.

#### Why This is Necessary:
The modular architecture encourages encapsulation of logic and behavior per domain (module). However, Laravel’s default `mergeConfigFrom()` merges shallowly and always prioritizes existing config values, meaning module-defined values are ignored if a root config already exists.

This directly contradicts the core idea of modularity - that a module should define and control its behavior without being limited by app-level configs.

By allowing module configs to override root configs, developers get:
- Predictable behavior across all modules.
- Clean overrides and centralization of domain logic.
- Better separation of concerns between global app config and module logic.

#### Before:
```php
// config/blog.php
return [
    'comments' => false,
];

// Modules/Blog/config/blog.php
return [
    'comments' => true,
];

// config('blog.comments') === false
```

#### After:
```php
// config('blog.comments') === true
```

Module config values now correctly override root config values.