### PR TITLE
fix: update component namespace generation in module make command tests

### DIFF
--- a/src/Commands/stubs/scaffold/provider.stub
+++ b/src/Commands/stubs/scaffold/provider.stub
@@ -118,8 +118,7 @@ class $CLASS$ extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->nameLower);
 
-        $componentNamespace = $this->module_namespace($this->name, $this->app_path(config('modules.paths.generator.component-class.path')));
-        Blade::componentNamespace($componentNamespace, $this->nameLower);
+        Blade::componentNamespace(config('modules.namespace').'\\' . $this->moduleName . '\\View\\Components', $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_disable__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_disable__1.txt
@@ -118,8 +118,7 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->nameLower);
 
-        $componentNamespace = $this->module_namespace($this->name, $this->app_path(config('modules.paths.generator.component-class.path')));
-        Blade::componentNamespace($componentNamespace, $this->nameLower);
+        Blade::componentNamespace(config('modules.namespace').'\\' . $this->moduleName . '\\View\\Components', $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__1.txt
@@ -118,8 +118,7 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->nameLower);
 
-        $componentNamespace = $this->module_namespace($this->name, $this->app_path(config('modules.paths.generator.component-class.path')));
-        Blade::componentNamespace($componentNamespace, $this->nameLower);
+        Blade::componentNamespace(config('modules.namespace').'\\' . $this->moduleName . '\\View\\Components', $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__1.txt
@@ -118,8 +118,7 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->nameLower);
 
-        $componentNamespace = $this->module_namespace($this->name, $this->app_path(config('modules.paths.generator.component-class.path')));
-        Blade::componentNamespace($componentNamespace, $this->nameLower);
+        Blade::componentNamespace(config('modules.namespace').'\\' . $this->moduleName . '\\View\\Components', $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_namespace_using_studly_case__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_namespace_using_studly_case__1.txt
@@ -118,8 +118,7 @@ class ModuleNameServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->nameLower);
 
-        $componentNamespace = $this->module_namespace($this->name, $this->app_path(config('modules.paths.generator.component-class.path')));
-        Blade::componentNamespace($componentNamespace, $this->nameLower);
+        Blade::componentNamespace(config('modules.namespace').'\\' . $this->moduleName . '\\View\\Components', $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__1.txt
@@ -118,8 +118,7 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->nameLower);
 
-        $componentNamespace = $this->module_namespace($this->name, $this->app_path(config('modules.paths.generator.component-class.path')));
-        Blade::componentNamespace($componentNamespace, $this->nameLower);
+        Blade::componentNamespace(config('modules.namespace').'\\' . $this->moduleName . '\\View\\Components', $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__1.txt
@@ -118,8 +118,7 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->nameLower);
 
-        $componentNamespace = $this->module_namespace($this->name, $this->app_path(config('modules.paths.generator.component-class.path')));
-        Blade::componentNamespace($componentNamespace, $this->nameLower);
+        Blade::componentNamespace(config('modules.namespace').'\\' . $this->moduleName . '\\View\\Components', $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__1.txt
@@ -118,8 +118,7 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->nameLower);
 
-        $componentNamespace = $this->module_namespace($this->name, $this->app_path(config('modules.paths.generator.component-class.path')));
-        Blade::componentNamespace($componentNamespace, $this->nameLower);
+        Blade::componentNamespace(config('modules.namespace').'\\' . $this->moduleName . '\\View\\Components', $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -118,8 +118,7 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->nameLower);
 
-        $componentNamespace = $this->module_namespace($this->name, $this->app_path(config('modules.paths.generator.component-class.path')));
-        Blade::componentNamespace($componentNamespace, $this->nameLower);
+        Blade::componentNamespace(config('modules.namespace').'\\' . $this->moduleName . '\\View\\Components', $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
@@ -118,8 +118,7 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->nameLower);
 
-        $componentNamespace = $this->module_namespace($this->name, $this->app_path(config('modules.paths.generator.component-class.path')));
-        Blade::componentNamespace($componentNamespace, $this->nameLower);
+        Blade::componentNamespace(config('modules.namespace').'\\' . $this->moduleName . '\\View\\Components', $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_have_custom_migration_resources_location_paths__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_have_custom_migration_resources_location_paths__1.txt
@@ -118,8 +118,7 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->nameLower);
 
-        $componentNamespace = $this->module_namespace($this->name, $this->app_path(config('modules.paths.generator.component-class.path')));
-        Blade::componentNamespace($componentNamespace, $this->nameLower);
+        Blade::componentNamespace(config('modules.namespace').'\\' . $this->moduleName . '\\View\\Components', $this->moduleNameLower);
     }
 
     /**

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_generates_a_master_service_provider_with_resource_loading__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_generates_a_master_service_provider_with_resource_loading__1.txt
@@ -118,8 +118,7 @@ class BlogServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->nameLower);
 
-        $componentNamespace = $this->module_namespace($this->name, $this->app_path(config('modules.paths.generator.component-class.path')));
-        Blade::componentNamespace($componentNamespace, $this->nameLower);
+        Blade::componentNamespace(config('modules.namespace').'\\' . $this->moduleName . '\\View\\Components', $this->moduleNameLower);
     }
 
     /**


### PR DESCRIPTION
Fixed path for class based components replaces

```php
$componentNamespace = str_replace('/', '\\', config('modules.namespace').'\\'.$this->moduleName.'\\'.config('modules.paths.generator.component-class.path'));
        Blade::componentNamespace($componentNamespace, $this->moduleNameLower);
```

with

```php
Blade::componentNamespace(config('modules.namespace').'\\' . $this->moduleName . '\\View\\Components', $this->moduleNameLower);
```