### PR TITLE
[fix] fix Error Cannot instantiate abstract class

### DIFF
--- a/src/Lumen/LumenFileRepository.php
+++ b/src/Lumen/LumenFileRepository.php
@@ -4,7 +4,6 @@ namespace Nwidart\Modules\Lumen;
 
 use Illuminate\Container\Container;
 use Nwidart\Modules\FileRepository;
-use Nwidart\Modules\Module;
 
 class LumenFileRepository extends FileRepository
 {


### PR DESCRIPTION
The class `Nwidart\Modules\Module` is abstract and cannot be instantiated directly.
The correct class to use in a Lumen is `Nwidart\Modules\Lumen\Module`, which extends `Nwidart\Modules\Module`.