### PR TITLE
Refactor `module` helper, improve code clarity, and handle exceptions

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,9 +1,10 @@
 <?php
 
 use Illuminate\Foundation\Vite;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Vite as ViteFacade;
-use Nwidart\Modules\Laravel\Module;
+use Nwidart\Modules\Exceptions\ModuleNotFoundException;
+use Nwidart\Modules\FileRepository;
+use Nwidart\Modules\Module;
 
 if (! function_exists('module')) {
     /**
@@ -15,14 +16,16 @@ if (! function_exists('module')) {
      */
     function module(string $name, bool $instance = false): bool|Module
     {
-        $modules = app('modules');
-        if (! $modules->has($name)) {
-            Log::error("Module '$name' not found.");
+        /** @var FileRepository $repository */
+        $repository = app('modules');
 
+        try {
+            $module = $repository->findOrFail($name);
+
+            return $instance ? $module : $module->isEnabled();
+        } catch (ModuleNotFoundException $exception) {
             return false;
         }
-
-        return $instance ? $modules->find($name) : $modules->isEnabled($name);
     }
 }
 

--- a/tests/ModuleHelperTest.php
+++ b/tests/ModuleHelperTest.php
@@ -4,9 +4,8 @@ namespace Nwidart\Modules\Tests;
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Blade;
-use Illuminate\Support\Facades\Log;
 use Nwidart\Modules\Contracts\RepositoryInterface;
-use Nwidart\Modules\Laravel\Module;
+use Nwidart\Modules\Module;
 
 class ModuleHelperTest extends BaseTestCase
 {
@@ -37,20 +36,6 @@ class ModuleHelperTest extends BaseTestCase
     public function test_module_returns_true_when_found()
     {
         $this->assertTrue(module('Blog'));
-    }
-
-    public function test_module_returns_false_and_log_error_when_not_found()
-    {
-        Log::shouldReceive('error')->once()->with("Module 'Blogs' not found.");
-
-        $this->assertFalse(module('Blogs'));
-    }
-
-    public function test_module_returns_false_and_log_error_when_not_found_and_instance_parameter_is_true()
-    {
-        Log::shouldReceive('error')->once()->with("Module 'Blogs' not found.");
-
-        $this->assertFalse(module('Blogs', true));
     }
 
     public function test_module_returns_instance_when_instance_parameter_is_true()


### PR DESCRIPTION
This pull request includes several improvements and cleanups to the `module` helper:

* Refactored variable names for better readability and consistency
* Updated return type from `Nwidart\Modules\Laravel\Module` to the more generic `Nwidart\Modules\Module` to support both Laravel and Lumen. (in helper and tests)
* Removed unnecessary `Log::error` call
* Added handling for `ModuleNotFoundException` when calling the `isEnabled()` method
