### PR TITLE
Refactor: Type property with interface instead of concrete class for better extensibility

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -4,11 +4,11 @@ namespace Nwidart\Modules;
 
 use Illuminate\Cache\CacheManager;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
-use Illuminate\Translation\Translator;
 use Nwidart\Modules\Constants\ModuleEvent;
 use Nwidart\Modules\Contracts\ActivatorInterface;
 


### PR DESCRIPTION
This PR refactors the property typing in the class to use an interface (Translator) instead of a concrete class (Illuminate\Translation\Translator). This change allows for better extensibility and flexibility, enabling the use of a custom translator implementation (e.g., for a custom translation service).

Changes:
Replaced the concrete class Illuminate\Translation\Translator with the interface Illuminate\Contracts\Translation\Translator.

This allows for custom translators to be injected into the class, improving flexibility and enabling easier testing and customization.