### PR TITLE
Support 'All' as argument in module:seed command to seed all modules

### DIFF
--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -98,7 +98,7 @@ abstract class BaseCommand extends Command implements PromptsForMissingInput
             ? array_keys($this->laravel['modules']->getOrdered($input->hasOption('direction')))
             : array_keys($this->laravel['modules']->all());
 
-        if ($input->getOption(strtolower(self::ALL))) {
+        if (in_array(strtolower(self::ALL), $input->getArgument('module'))) {
             $input->setArgument('module', $modules);
 
             return;


### PR DESCRIPTION
Previously, the module:seed command required passing each module name individually, or calling the command with no argument (and optionally typing 'all' when prompted).

With this change, you can now do:

php artisan module:seed All

…and it will correctly seed all registered modules.

This improves usability and allows scripting tools or automated workflows to explicitly call seeding for all modules via a single consistent command.