### PR TITLE
Add ListCommands Command

### DIFF
--- a/src/Commands/Actions/ListCommands.php
+++ b/src/Commands/Actions/ListCommands.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace Nwidart\Modules\Commands\Actions;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Nwidart\Modules\Commands\BaseCommand;
+use ReflectionClass;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+
+class ListCommands extends BaseCommand
+{
+    protected $name = 'module:list-commands';
+
+    protected $description = 'List all commands in the specified module(s)';
+
+    public function executeAction($name): void
+    {
+        $module = $this->getModuleModel($name);
+        $commands = $this->findCommands($module);
+
+        if (empty($commands)) {
+            $this->components->info("No commands found in module <fg=cyan;options=bold>{$module->getName()}</>");
+
+            return;
+        }
+
+        // Group commands by directory
+        $groupedCommands = [];
+        foreach ($commands as $command) {
+            $directory = $this->getDirectoryFromNamespace($command['namespace']);
+            if (! isset($groupedCommands[$directory])) {
+                $groupedCommands[$directory] = [];
+            }
+            $groupedCommands[$directory][] = $command;
+        }
+
+        // Display commands by group
+        foreach ($groupedCommands as $directory => $dirCommands) {
+            $this->components->twoColumnDetail("<fg=yellow>{$directory}</>", '');
+
+            foreach ($dirCommands as $command) {
+                $name = $command['name'] ?: '<fg=red>Unknown</>';
+                $this->components->success("  <fg=green>{$name}</>");
+            }
+
+            $this->newLine();
+        }
+    }
+
+    /**
+     * Find all commands in a module
+     *
+     * @return array<string, array<string, string|null>>
+     */
+    protected function findCommands($module): array
+    {
+        $commands = [];
+        $moduleName = $module->getName();
+        $moduleNamespace = $this->getModuleNamespace($moduleName);
+
+        // Check possible command paths
+        $possiblePaths = [
+            $module->getExtraPath('Commands'),
+            $module->getExtraPath('Console/Commands'),
+            $module->getAppPath().'/Commands',
+            $module->getAppPath().'/Console',
+            $module->getAppPath().'/Console/Commands',
+        ];
+
+        foreach ($possiblePaths as $path) {
+            if (! is_dir($path)) {
+                continue;
+            }
+
+            $files = File::allFiles($path);
+
+            foreach ($files as $file) {
+                // Skip if not a PHP file
+                if ($file->getExtension() !== 'php') {
+                    continue;
+                }
+
+                // Get the class name from the file path
+                $relativePath = str_replace($module->getPath().'/', '', $file->getPathname());
+                $className = $this->getClassNameFromPath($relativePath, $moduleNamespace);
+
+                // Try to get command information
+                $commandInfo = $this->getCommandInfo($className);
+
+                if ($commandInfo) {
+                    $commands[] = $commandInfo;
+                }
+            }
+        }
+
+        return $commands;
+    }
+
+    /**
+     * Get module namespace
+     */
+    protected function getModuleNamespace(string $moduleName): string
+    {
+        return config('modules.namespace', 'Modules').'\\'.$moduleName;
+    }
+
+    /**
+     * Convert a file path to a class name with namespace
+     */
+    protected function getClassNameFromPath(string $path, string $moduleNamespace): string
+    {
+        // Remove .php extension
+        $path = str_replace('.php', '', $path);
+
+        // Convert directory separators to namespace separators
+        $path = str_replace('/', '\\', $path);
+
+        // If the path starts with app/, remove it and prepend the module namespace
+        if (Str::startsWith($path, 'app\\')) {
+            $path = $moduleNamespace.'\\'.Str::after($path, 'app\\');
+        } else {
+            $path = $moduleNamespace.'\\'.$path;
+        }
+
+        return $path;
+    }
+
+    /**
+     * Get command information from class
+     */
+    protected function getCommandInfo(string $className): ?array
+    {
+        try {
+            // Extract the short class name from the fully qualified class name
+            $shortClassName = $this->getShortClassName($className);
+
+            if (! class_exists($className)) {
+                return [
+                    'class' => $className,
+                    'name' => $shortClassName,
+                    'namespace' => $this->getNamespaceFromClass($className),
+                ];
+            }
+
+            $reflection = new ReflectionClass($className);
+
+            // Skip if not a command class
+            if (! $reflection->isSubclassOf(SymfonyCommand::class) &&
+                ! $reflection->isSubclassOf('Illuminate\Console\Command')) {
+                return null;
+            }
+
+            // Skip if the class is not instantiable or has required constructor parameters
+            if (! $reflection->isInstantiable() || $reflection->getConstructor()?->getNumberOfRequiredParameters() > 0) {
+                return [
+                    'class' => $className,
+                    'name' => $shortClassName,
+                    'namespace' => $reflection->getNamespaceName(),
+                ];
+            }
+
+            // Create a proper instance of the command
+            $commandInstance = $reflection->newInstance();
+
+            // Get name directly from the instance
+            $name = null;
+
+            if (method_exists($commandInstance, 'getName')) {
+                $name = $commandInstance->getName();
+            }
+
+            return [
+                'class' => $className,
+                'name' => $name ?? $shortClassName,
+                'namespace' => $reflection->getNamespaceName(),
+            ];
+        } catch (\Throwable $e) {
+            // If we can't instantiate the class, just return basic info with the class name
+            return [
+                'class' => $className,
+                'name' => $this->getShortClassName($className),
+                'namespace' => $this->getNamespaceFromClass($className),
+            ];
+        }
+    }
+
+    /**
+     * Get short class name from fully qualified class name
+     */
+    protected function getShortClassName(string $className): string
+    {
+        $parts = explode('\\', $className);
+
+        return end($parts);
+    }
+
+    /**
+     * Get namespace from class name
+     */
+    protected function getNamespaceFromClass(string $className): string
+    {
+        $parts = explode('\\', $className);
+        array_pop($parts); // Remove the class name
+
+        return implode('\\', $parts);
+    }
+
+    /**
+     * Get directory name from namespace
+     */
+    protected function getDirectoryFromNamespace(string $namespace): string
+    {
+        $parts = explode('\\', $namespace);
+
+        // Look for Commands or Console\Commands in the namespace
+        $commandsIndex = array_search('Commands', $parts);
+        if ($commandsIndex !== false) {
+            // If we found 'Commands', check if it's preceded by 'Console'
+            if ($commandsIndex > 0 && $parts[$commandsIndex - 1] === 'Console') {
+                return 'Console/Commands';
+            }
+
+            return 'Commands';
+        }
+
+        // Default to the last two parts of the namespace
+        return implode('/', array_slice($parts, -2, 2));
+    }
+
+    public function getInfo(): ?string
+    {
+        return 'Listing commands...';
+    }
+}

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -31,6 +31,7 @@ class ConsoleServiceProvider extends ServiceProvider
             Commands\Actions\EnableCommand::class,
             Commands\Actions\InstallCommand::class,
             Commands\Actions\ListCommand::class,
+            Commands\Actions\ListCommands::class,
             Commands\Actions\ModelPruneCommand::class,
             Commands\Actions\ModelShowCommand::class,
             Commands\Actions\ModuleDeleteCommand::class,

--- a/tests/Commands/Actions/ListCommandsTest.php
+++ b/tests/Commands/Actions/ListCommandsTest.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Nwidart\Modules\Tests\Commands\Actions;
+
+use Illuminate\Filesystem\Filesystem;
+use Nwidart\Modules\Contracts\RepositoryInterface;
+use Nwidart\Modules\Tests\BaseTestCase;
+
+class ListCommandsTest extends BaseTestCase
+{
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var string
+     */
+    private $modulePath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->createModule();
+        $this->modulePath = $this->getModuleBasePath();
+        $this->filesystem = $this->app['files'];
+    }
+
+    protected function tearDown(): void
+    {
+        $this->app[RepositoryInterface::class]->delete('Blog');
+        parent::tearDown();
+    }
+
+    public function test_it_can_list_commands_from_module_commands_directory()
+    {
+        // Create a command in the module's Commands directory
+        $this->createModuleCommand('TestCommand', 'Commands');
+
+        // Run the command
+        $code = $this->artisan('module:list-commands', ['module' => 'Blog']);
+
+        // We just want to make sure the command runs without errors
+        $this->assertSame(0, $code);
+    }
+
+    public function test_it_can_list_commands_from_module_console_commands_directory()
+    {
+        // Create a command in the module's Console/Commands directory
+        $this->createModuleCommand('ConsoleTestCommand', 'Console/Commands');
+
+        // Run the command
+        $code = $this->artisan('module:list-commands', ['module' => 'Blog']);
+
+        // We just want to make sure the command runs without errors
+        $this->assertSame(0, $code);
+    }
+
+    public function test_it_can_list_commands_from_module_app_commands_directory()
+    {
+        // Create a command in the module's app/Commands directory
+        $this->createModuleCommand('AppTestCommand', 'app/Commands');
+
+        // Run the command
+        $code = $this->artisan('module:list-commands', ['module' => 'Blog']);
+
+        // We just want to make sure the command runs without errors
+        $this->assertSame(0, $code);
+    }
+
+    public function test_it_can_list_commands_from_module_app_console_commands_directory()
+    {
+        // Create a command in the module's app/Console/Commands directory
+        $this->createModuleCommand('AppConsoleTestCommand', 'app/Console/Commands');
+
+        // Run the command
+        $code = $this->artisan('module:list-commands', ['module' => 'Blog']);
+
+        // We just want to make sure the command runs without errors
+        $this->assertSame(0, $code);
+    }
+
+    public function test_it_can_list_commands_from_multiple_directories()
+    {
+        // Create commands in different directories
+        $this->createModuleCommand('TestCommand1', 'Commands');
+        $this->createModuleCommand('TestCommand2', 'Console/Commands');
+        $this->createModuleCommand('TestCommand3', 'app/Commands');
+        $this->createModuleCommand('TestCommand4', 'app/Console/Commands');
+
+        // Run the command
+        $code = $this->artisan('module:list-commands', ['module' => 'Blog']);
+
+        // We just want to make sure the command runs without errors
+        $this->assertSame(0, $code);
+    }
+
+    public function test_it_shows_message_when_no_commands_found()
+    {
+        // Run the command without creating any commands
+        $code = $this->artisan('module:list-commands', ['module' => 'Blog']);
+
+        // We just want to make sure the command runs without errors
+        $this->assertSame(0, $code);
+    }
+
+    public function test_it_ignores_non_command_classes()
+    {
+        // Create a non-command class in the Commands directory
+        $this->createNonCommandClass('NonCommandClass', 'Commands');
+
+        // Create a regular command
+        $this->createModuleCommand('RegularCommand', 'Commands');
+
+        // Run the command
+        $code = $this->artisan('module:list-commands', ['module' => 'Blog']);
+
+        // We just want to make sure the command runs without errors
+        $this->assertSame(0, $code);
+    }
+
+    /**
+     * Create a command file in the specified directory of the module
+     */
+    private function createModuleCommand(string $commandName, string $directory): void
+    {
+        $path = $this->modulePath . '/' . $directory;
+
+        // Create directory if it doesn't exist
+        if (!$this->filesystem->isDirectory($path)) {
+            $this->filesystem->makeDirectory($path, 0755, true);
+        }
+
+        $namespace = $this->getNamespaceFromDirectory($directory);
+
+        $content = <<<EOT
+<?php
+
+namespace Modules\\Blog\\{$namespace};
+
+use Illuminate\\Console\\Command;
+
+class {$commandName} extends Command
+{
+    protected \$name = 'blog:{$commandName}';
+
+    protected \$description = 'Test command for {$commandName}';
+
+    public function handle()
+    {
+        \$this->info('Command executed successfully!');
+    }
+}
+EOT;
+
+        $this->filesystem->put($path . '/' . $commandName . '.php', $content);
+    }
+
+    /**
+     * Create a non-command class in the specified directory of the module
+     */
+    private function createNonCommandClass(string $className, string $directory): void
+    {
+        $path = $this->modulePath . '/' . $directory;
+
+        // Create directory if it doesn't exist
+        if (!$this->filesystem->isDirectory($path)) {
+            $this->filesystem->makeDirectory($path, 0755, true);
+        }
+
+        $namespace = $this->getNamespaceFromDirectory($directory);
+
+        $content = <<<EOT
+<?php
+
+namespace Modules\\Blog\\{$namespace};
+
+class {$className}
+{
+    public function someMethod()
+    {
+        return 'This is not a command class';
+    }
+}
+EOT;
+
+        $this->filesystem->put($path . '/' . $className . '.php', $content);
+    }
+
+    /**
+     * Get namespace from directory
+     */
+    private function getNamespaceFromDirectory(string $directory): string
+    {
+        // Convert directory separators to namespace separators
+        $namespace = str_replace('/', '\\', $directory);
+
+        // Remove 'app\' from the beginning if it exists
+        if (strpos($namespace, 'app\\') === 0) {
+            $namespace = substr($namespace, 4);
+        }
+
+        return $namespace;
+    }
+}

--- a/tests/Commands/Actions/ListCommandsTest.php
+++ b/tests/Commands/Actions/ListCommandsTest.php
@@ -124,10 +124,10 @@ class ListCommandsTest extends BaseTestCase
      */
     private function createModuleCommand(string $commandName, string $directory): void
     {
-        $path = $this->modulePath . '/' . $directory;
+        $path = $this->modulePath.'/'.$directory;
 
         // Create directory if it doesn't exist
-        if (!$this->filesystem->isDirectory($path)) {
+        if (! $this->filesystem->isDirectory($path)) {
             $this->filesystem->makeDirectory($path, 0755, true);
         }
 
@@ -153,7 +153,7 @@ class {$commandName} extends Command
 }
 EOT;
 
-        $this->filesystem->put($path . '/' . $commandName . '.php', $content);
+        $this->filesystem->put($path.'/'.$commandName.'.php', $content);
     }
 
     /**
@@ -161,10 +161,10 @@ EOT;
      */
     private function createNonCommandClass(string $className, string $directory): void
     {
-        $path = $this->modulePath . '/' . $directory;
+        $path = $this->modulePath.'/'.$directory;
 
         // Create directory if it doesn't exist
-        if (!$this->filesystem->isDirectory($path)) {
+        if (! $this->filesystem->isDirectory($path)) {
             $this->filesystem->makeDirectory($path, 0755, true);
         }
 
@@ -184,7 +184,7 @@ class {$className}
 }
 EOT;
 
-        $this->filesystem->put($path . '/' . $className . '.php', $content);
+        $this->filesystem->put($path.'/'.$className.'.php', $content);
     }
 
     /**


### PR DESCRIPTION
add a new command `module:list-commands` this will scan your active modules and show a list of all found commands

```
 ┌ Select Modules ──────────────────────────────────────────────┐
 │ All                                                          │
 └──────────────────────────────────────────────────────────────┘

   INFO  Listing commands...  

  Billing/Console ........................................................................................................  

   SUCCESS  app:collect-upcoming-orders-payments.  


  Marketing/Console ......................................................................................................  

   SUCCESS  marketing:send-historical-orders-to-klaviyo.  

   SUCCESS  marketing:send-product-review-notifications-command.  

   SUCCESS  marketing:send-review-products-notification.  

   SUCCESS  active-campaign:sync.  
```