### PR TITLE
Ensure modules are registered in register phase

### DIFF
--- a/src/FileRepository.php
+++ b/src/FileRepository.php
@@ -3,7 +3,6 @@
 namespace Nwidart\Modules;
 
 use Countable;
-use Illuminate\Cache\CacheManager;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Routing\UrlGenerator;
@@ -59,11 +58,6 @@ abstract class FileRepository implements Countable, RepositoryInterface
      */
     private Filesystem $files;
 
-    /**
-     * Cache Manager
-     */
-    private CacheManager $cache;
-
     private static $modules = [];
 
     /**
@@ -76,7 +70,6 @@ abstract class FileRepository implements Countable, RepositoryInterface
         $this->url = $app['url'];
         $this->config = $app['config'];
         $this->files = $app['files'];
-        $this->cache = $app['cache'];
     }
 
     /**

--- a/src/LaravelModulesServiceProvider.php
+++ b/src/LaravelModulesServiceProvider.php
@@ -23,18 +23,6 @@ class LaravelModulesServiceProvider extends ModulesServiceProvider
     {
         $this->registerNamespaces();
 
-        $this->app->singleton(
-            ModuleManifest::class,
-            fn () => new ModuleManifest(
-                new Filesystem,
-                app(Contracts\RepositoryInterface::class)->getScanPaths(),
-                $this->getCachedModulePath(),
-                app(ActivatorInterface::class)
-            )
-        );
-
-        $this->registerModules();
-
         AboutCommand::add('Laravel-Modules', [
             'Version' => fn () => InstalledVersions::getPrettyVersion('nwidart/laravel-modules'),
         ]);
@@ -58,6 +46,8 @@ class LaravelModulesServiceProvider extends ModulesServiceProvider
         $this->registerTranslations();
 
         $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'modules');
+
+        $this->registerModules();
     }
 
     /**
@@ -98,6 +88,17 @@ class LaravelModulesServiceProvider extends ModulesServiceProvider
             return new $class($app);
         });
         $this->app->alias(Contracts\RepositoryInterface::class, 'modules');
+        
+        $this->app->singleton(
+            ModuleManifest::class,
+            fn() => new ModuleManifest(
+                new Filesystem,
+                app(Contracts\RepositoryInterface::class)->getScanPaths(),
+                $this->getCachedModulePath(),
+                app(ActivatorInterface::class)
+            )
+        );
+
     }
 
     protected function registerMigrations(): void


### PR DESCRIPTION
Moved module registration to the `register()` method to ensure that module service providers are loaded early and take their proper place in the Laravel lifecycle. Previously, module service providers were being registered during the `boot()` phase, which caused their `register()` methods to run too late — during the boot stage — leading to incorrect and unintended behavior.

Additionally, removed the cacheManager dependency from the FileRepository, as it is not available in the `register()` phase and was not being used.