### PR TITLE
Fix publishing config files for modules with multi-word names

### DIFF
--- a/src/Commands/Publish/PublishConfigurationCommand.php
+++ b/src/Commands/Publish/PublishConfigurationCommand.php
@@ -2,8 +2,8 @@
 
 namespace Nwidart\Modules\Commands\Publish;
 
-use Illuminate\Support\Str;
 use Nwidart\Modules\Commands\BaseCommand;
+use Nwidart\Modules\Facades\Module;
 use Symfony\Component\Console\Input\InputOption;
 
 class PublishConfigurationCommand extends BaseCommand
@@ -38,13 +38,15 @@ class PublishConfigurationCommand extends BaseCommand
 
     private function getServiceProviderForModule(string $module): string
     {
+        $moduleModel = Module::find($module);
+
         $namespace = $this->laravel['config']->get('modules.namespace');
-        $studlyName = Str::studly($module);
+        $moduleName = $moduleModel->getName();
         $provider = $this->laravel['config']->get('modules.paths.generator.provider.path');
         $provider = str_replace($this->laravel['config']->get('modules.paths.app_folder'), '', $provider);
         $provider = str_replace('/', '\\', $provider);
 
-        return "$namespace\\$studlyName\\$provider\\{$studlyName}ServiceProvider";
+        return "$namespace\\$moduleName\\$provider\\{$moduleName}ServiceProvider";
     }
 
     protected function getOptions(): array


### PR DESCRIPTION
Hi,

This pull request fixes an issue with publishing configuration files when a module name contains multiple words, such as:
`ActivityLog`, `ProductBundle`, `CloudProvider`, `MotmaenBash`, etc.

**Example:**
For the `ActivityLog` module, the service provider namespace is currently generated incorrectly:

```diff
- Modules\Activitylog\Providers\ActivitylogServiceProvider
+ Modules\ActivityLog\Providers\ActivityLogServiceProvider
```


With this fix, the casing will now correctly match the original module name.
