### PR TITLE
[fix] fix return type of method

### DIFF
--- a/src/Support/Migrations/NameParser.php
+++ b/src/Support/Migrations/NameParser.php
@@ -66,7 +66,7 @@ class NameParser
     /**
      * Get the table will be used.
      */
-    public function getTableName(): string
+    public function getTableName(): ?string
     {
         $matches = array_reverse($this->getMatches());
 


### PR DESCRIPTION
Hi,

This pull request fixes #2096.
The `getTableName` method’s return type can be null, so its type declaration has been updated.