### PR TITLE
Add `PLURAL_UPPER_NAME` to Module Creation Replacement Variables

### DIFF
--- a/src/Generators/ModuleGenerator.php
+++ b/src/Generators/ModuleGenerator.php
@@ -585,6 +585,14 @@ class ModuleGenerator extends Generator
     }
 
     /**
+     * Get the module name in plural upper case.
+     */
+    protected function getPluralUpperNameReplacement(): string
+    {
+        return Str::of($this->getName())->upper()->plural();
+    }
+
+    /**
      * Get replacement for $VENDOR$.
      */
     protected function getVendorReplacement(): string


### PR DESCRIPTION
Hi,

This pull request adds a new replacement variable `PLURAL_UPPER_NAME` to the module creation process. This variable can be used in stubs and templates to easily reference the plural, uppercase form of the module name.

Fixes #2079.