### PR TITLE
Replace Hardcoded Paths with Configurable Values in `UpdatePhpunitCoverage` Command

### DIFF
--- a/src/Commands/UpdatePhpunitCoverage.php
+++ b/src/Commands/UpdatePhpunitCoverage.php
@@ -29,7 +29,7 @@ class UpdatePhpunitCoverage extends Command
         $appFolder = config('modules.paths.app_folder', 'app/');
         $appFolder = rtrim($appFolder, '/').'/';
         $phpunitXmlPath = base_path('phpunit.xml');
-        $modulesStatusPath = base_path('modules_statuses.json');
+        $modulesStatusPath = config('modules.activators.file.statuses-file', base_path('modules_statuses.json'));
 
         if (! file_exists($phpunitXmlPath)) {
             $this->error("phpunit.xml file not found: {$phpunitXmlPath}");
@@ -51,7 +51,7 @@ class UpdatePhpunitCoverage extends Command
             return 98;
         }
 
-        $modulesPath = base_path('Modules/');
+        $modulesPath = rtrim(config('modules.paths.modules', base_path('Modules')), '/').'/';
         $moduleDirs = [];
 
         foreach ($enabledModules as $module => $status) {


### PR DESCRIPTION
Hi, I have an improvement on the `UpdatePhpunitCoverage` command by replacing hardcoded paths with configurable values. Let me know if you’d like any tweaks or more details!