### PR TITLE
Refactor BaseCommand to improve module resolution and add support for…

### DIFF
--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Prohibitable;
 use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Support\Collection;
 use Nwidart\Modules\Contracts\ConfirmableCommand;
+use Nwidart\Modules\Module;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -75,8 +76,10 @@ abstract class BaseCommand extends Command implements PromptsForMissingInput
     public function handle()
     {
         if ($this instanceof ConfirmableCommand) {
-            if ($this->isProhibited() ||
-                ! $this->confirmToProceed($this->getConfirmableLabel(), $this->getConfirmableCallback())) {
+            if (
+                $this->isProhibited() ||
+                ! $this->confirmToProceed($this->getConfirmableLabel(), $this->getConfirmableCallback())
+            ) {
                 return Command::FAILURE;
             }
         }
@@ -85,6 +88,7 @@ abstract class BaseCommand extends Command implements PromptsForMissingInput
             $this->components->info($info);
         }
 
+        // Always resolve modules from the argument; ordering is handled in promptForMissingArguments()
         $modules = (array) $this->argument('module');
 
         foreach ($modules as $module) {
@@ -94,9 +98,8 @@ abstract class BaseCommand extends Command implements PromptsForMissingInput
 
     protected function promptForMissingArguments(InputInterface $input, OutputInterface $output): void
     {
-        $modules = $this->hasOption('direction')
-            ? array_keys($this->laravel['modules']->getOrdered($input->hasOption('direction')))
-            : array_keys($this->laravel['modules']->all());
+        // Prefer the order defined in the statuses file (modules.json) as configured in modules.activators.file.statuses-file
+        $modules = $this->getModulesOrderedByStatusesFile();
 
         if ($input->getOption(strtolower(self::ALL))) {
             $input->setArgument('module', $modules);
@@ -129,11 +132,51 @@ abstract class BaseCommand extends Command implements PromptsForMissingInput
         );
     }
 
-    protected function getModuleModel($name)
+    protected function getModuleModel($name): Module
     {
         return $name instanceof \Nwidart\Modules\Module
             ? $name
             : $this->laravel['modules']->findOrFail($name);
+    }
+
+    /**
+     * Read the statuses file defined in config('modules.activators.file.statuses-file')
+     * and return enabled module names preserving the order in that file.
+     * Falls back to repository ordering if file is missing or invalid.
+     */
+    private function getModulesOrderedByStatusesFile(): array
+    {
+        $statusesFile = $this->laravel['config']->get('modules.activators.file.statuses-file');
+        $statusesFile = is_string($statusesFile) && $statusesFile !== ''
+            ? $statusesFile
+            : base_path('modules_statuses.json');
+
+        $sort = $this->option('direction') ?? 'asc';
+
+        if (! is_string($statusesFile) || ! file_exists($statusesFile)) {
+            return array_keys($this->laravel['modules']->getOrdered($sort));
+        }
+
+        $json = @file_get_contents($statusesFile);
+        $data = is_string($json) ? json_decode($json, true) : null;
+
+        if (! is_array($data)) {
+            return array_keys($this->laravel['modules']->getOrdered($sort));
+        }
+
+        $modules = [];
+        foreach ($data as $name => $enabled) {
+            if ($enabled === true || $enabled === 1) {
+                $modules[] = $name; // Keep StudlyCase names as defined
+            }
+        }
+
+        // Fallback if no enabled modules found
+        if (empty($modules)) {
+            return array_keys($this->laravel['modules']->getOrdered($sort));
+        }
+
+        return $modules;
     }
 
     private function configureConfirmable(): void


### PR DESCRIPTION
### Summary
Currently, when running migrations, modules are loaded in ascending (asc) alphabetical order, which causes issues with database tables' foreign key constraints.

For example, suppose an `Entry` module depends on a `Transaction` module, but the Entry module is processed first due to alphabetical ordering. In that case, the migration will fail because the required foreign key (transaction_id) references don't exist yet.

### Describe in detail what you propose, show (preferable) code examples and also signal if you're willing to work on it!
```php
    /**
     * Read the statuses file defined in config('modules.activators.file.statuses-file')
     * and return enabled module names preserving the order in that file.
     * Falls back to repository ordering if file is missing or invalid.
     */
    private function getModulesOrderedByStatusesFile(): array
    {
        $statusesFile = $this->laravel['config']->get('modules.activators.file.statuses-file');
        $statusesFile = is_string($statusesFile) && $statusesFile !== ''
            ? $statusesFile
            : base_path('modules_statuses.json');

        $sort = $this->option('direction') ?? 'asc';

        if (! is_string($statusesFile) || ! file_exists($statusesFile)) {
            return array_keys($this->laravel['modules']->getOrdered($sort));
        }

        $json = @file_get_contents($statusesFile);
        $data = is_string($json) ? json_decode($json, true) : null;

        if (! is_array($data)) {
            return array_keys($this->laravel['modules']->getOrdered($sort));
        }

        $modules = [];
        foreach ($data as $name => $enabled) {
            if ($enabled === true || $enabled === 1) {
                $modules[] = $name; // Keep StudlyCase names as defined
            }
        }

        // Fallback if no enabled modules found
        if (empty($modules)) {
            return array_keys($this->laravel['modules']->getOrdered($sort));
        }

        return $modules;
    }
```

@dcblogdev 