### PR TITLE
fix: resolve module helper dependency issues during service provider registration

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -2,9 +2,7 @@
 
 namespace Nwidart\Modules;
 
-use Illuminate\Cache\CacheManager;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -39,19 +37,9 @@ abstract class Module
     protected array $moduleJson = [];
 
     /**
-     * Cache Manager
-     */
-    private CacheManager $cache;
-
-    /**
      * Filesystem
      */
     private Filesystem $files;
-
-    /**
-     * Translator
-     */
-    private Translator $translator;
 
     /**
      * ActivatorInterface
@@ -65,9 +53,7 @@ abstract class Module
     {
         $this->name = $name;
         $this->path = $path;
-        $this->cache = $app['cache'];
         $this->files = $app['files'];
-        $this->translator = $app['translator'];
         $this->activator = $app[ActivatorInterface::class];
         $this->app = $app;
     }
@@ -395,6 +381,9 @@ abstract class Module
      */
     private function loadTranslationsFrom(string $path, string $namespace): void
     {
-        $this->translator->addNamespace($namespace, $path);
+        // Use afterResolving to ensure translations are registered when translator becomes available
+        $this->app->afterResolving('translator', function ($translator) use ($path, $namespace) {
+            $translator->addNamespace($namespace, $path);
+        });
     }
 }


### PR DESCRIPTION
Fixes #2092 

The problem occurs when trying to use the `module()` helper in the register() method 
of any service provider, but some dependencies (cache and translator) are not available 
at that time during the bootstrap process.

Fixed by:
- Cache dependency is completely removed since it's not used
- Translator is accessed only when it's actually available using afterResolving()
- Module helper can be safely used in service provider register() methods without exceptions