### PR TITLE
fix: correct Module parameter type in ActivatorInterface

### DIFF
--- a/src/Contracts/ActivatorInterface.php
+++ b/src/Contracts/ActivatorInterface.php
@@ -19,7 +19,7 @@ interface ActivatorInterface
     /**
      * Determine whether the given status same with a module status.
      */
-    public function hasStatus(Module $module, bool $status): bool;
+    public function hasStatus(Module|string $module, bool $status): bool;
 
     /**
      * Set active state for a module.


### PR DESCRIPTION
Hi,

In the class `\Nwidart\Modules\Activators\FileActivator`, the `hasStatus` method is implemented as follows:

```php
    public function hasStatus(Module|string $module, bool $status): bool
    {
        $name = $module instanceof Module ? $module->getName() : $module;
        // other code ...
    }
```

This pull request updates the `ActivatorInterface` to match the method signature used in `FileActivator`.

[comment link](https://github.com/nWidart/laravel-modules/commit/704eea8267ea48dce0698b4ca2f75ba0bea80f4e#r167898820)
fixed: #2123
