### PR TITLE
Add .gitginore to Module Scaffolding

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -37,6 +37,7 @@ return [
             'assets/sass/app' => 'resources/assets/sass/app.scss',
             'vite' => 'vite.config.js',
             'package' => 'package.json',
+            'gitignore' => '.gitignore',
         ],
         'replacements' => [
             /**

--- a/src/Commands/stubs/gitignore.stub
+++ b/src/Commands/stubs/gitignore.stub
@@ -1,0 +1,3 @@
+vendor
+node_modules
+.DS_Store


### PR DESCRIPTION
Hi there! I have been using this package for couple months. Let's say I installed module called `Ticketing`. Inside of it there are `Modules/Ticketing/resources/js/app.js`, `Modules/Ticketing/resources/sass/app.scss`, `composer.json`, `package.json`. This mean that we can install isolated dependencies inside of `Ticketing` module without polluting or mixing it with the root project. 

As we know, if deps installed it will generate the `node_modules` and `vendor` directories. Those of directories are not ignored. So, when we switch git branch (for example), the `node_modules` and `vendor` from `Ticketing` module will be exposed. I think it's better to set default `.gitignore` each time module is generated. 😉

I know we can do it manually after generate module. But, as we know sometimes humans tends to forget and sometimes we believe that this package cover this case but it doesn't (yet). Also, I want to help to make this package much better.