### PR TITLE
Rename 'Disabling module' to 'Enabling module' in EnableCommand

### DIFF
--- a/src/Commands/Actions/EnableCommand.php
+++ b/src/Commands/Actions/EnableCommand.php
@@ -35,6 +35,6 @@ class EnableCommand extends BaseCommand
 
     public function getInfo(): ?string
     {
-        return 'Disabling module ...';
+        return 'Enabling module ...';
     }
 }


### PR DESCRIPTION
A simple patch that allows `[INFO] Enabling module ...` to be displayed instead of `[INFO] Disabling module ...` when running the `module:enable` command.

### Before:

<img width="647" height="240" alt="image" src="https://github.com/user-attachments/assets/d701c5a6-ce5d-482a-b507-af03e3106536" />

### After:

<img width="629" height="223" alt="image" src="https://github.com/user-attachments/assets/2e878aef-110e-44c3-9a8c-d8d0379bc36d" />

