### PR TITLE
Fix module:publish-config skipping all modules after the first

### DIFF
--- a/src/Commands/stubs/scaffold/provider.stub
+++ b/src/Commands/stubs/scaffold/provider.stub
@@ -99,7 +99,10 @@ class $CLASS$ extends ServiceProvider
 
                     $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
-                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
+                    $publishPath = ($config === 'config.php')
+                        ? config_path($this->nameLower.'.php')
+                        : config_path($config);
+                    $this->publishes([$file->getPathname() => $publishPath], 'config');
                     $this->merge_config_from($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_disable__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_disable__1.txt
@@ -99,7 +99,10 @@ class BlogServiceProvider extends ServiceProvider
 
                     $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
-                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
+                    $publishPath = ($config === 'config.php')
+                        ? config_path($this->nameLower.'.php')
+                        : config_path($config);
+                    $this->publishes([$file->getPathname() => $publishPath], 'config');
                     $this->merge_config_from($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__1.txt
@@ -99,7 +99,10 @@ class BlogServiceProvider extends ServiceProvider
 
                     $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
-                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
+                    $publishPath = ($config === 'config.php')
+                        ? config_path($this->nameLower.'.php')
+                        : config_path($config);
+                    $this->publishes([$file->getPathname() => $publishPath], 'config');
                     $this->merge_config_from($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__1.txt
@@ -99,7 +99,10 @@ class BlogServiceProvider extends ServiceProvider
 
                     $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
-                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
+                    $publishPath = ($config === 'config.php')
+                        ? config_path($this->nameLower.'.php')
+                        : config_path($config);
+                    $this->publishes([$file->getPathname() => $publishPath], 'config');
                     $this->merge_config_from($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_namespace_using_studly_case__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_namespace_using_studly_case__1.txt
@@ -99,7 +99,10 @@ class ModuleNameServiceProvider extends ServiceProvider
 
                     $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
-                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
+                    $publishPath = ($config === 'config.php')
+                        ? config_path($this->nameLower.'.php')
+                        : config_path($config);
+                    $this->publishes([$file->getPathname() => $publishPath], 'config');
                     $this->merge_config_from($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__1.txt
@@ -99,7 +99,10 @@ class BlogServiceProvider extends ServiceProvider
 
                     $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
-                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
+                    $publishPath = ($config === 'config.php')
+                        ? config_path($this->nameLower.'.php')
+                        : config_path($config);
+                    $this->publishes([$file->getPathname() => $publishPath], 'config');
                     $this->merge_config_from($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__1.txt
@@ -99,7 +99,10 @@ class BlogServiceProvider extends ServiceProvider
 
                     $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
-                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
+                    $publishPath = ($config === 'config.php')
+                        ? config_path($this->nameLower.'.php')
+                        : config_path($config);
+                    $this->publishes([$file->getPathname() => $publishPath], 'config');
                     $this->merge_config_from($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__1.txt
@@ -99,7 +99,10 @@ class BlogServiceProvider extends ServiceProvider
 
                     $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
-                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
+                    $publishPath = ($config === 'config.php')
+                        ? config_path($this->nameLower.'.php')
+                        : config_path($config);
+                    $this->publishes([$file->getPathname() => $publishPath], 'config');
                     $this->merge_config_from($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -99,7 +99,10 @@ class BlogServiceProvider extends ServiceProvider
 
                     $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
-                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
+                    $publishPath = ($config === 'config.php')
+                        ? config_path($this->nameLower.'.php')
+                        : config_path($config);
+                    $this->publishes([$file->getPathname() => $publishPath], 'config');
                     $this->merge_config_from($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
@@ -99,7 +99,10 @@ class BlogServiceProvider extends ServiceProvider
 
                     $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
-                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
+                    $publishPath = ($config === 'config.php')
+                        ? config_path($this->nameLower.'.php')
+                        : config_path($config);
+                    $this->publishes([$file->getPathname() => $publishPath], 'config');
                     $this->merge_config_from($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_have_custom_migration_resources_location_paths__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_have_custom_migration_resources_location_paths__1.txt
@@ -99,7 +99,10 @@ class BlogServiceProvider extends ServiceProvider
 
                     $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
-                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
+                    $publishPath = ($config === 'config.php')
+                        ? config_path($this->nameLower.'.php')
+                        : config_path($config);
+                    $this->publishes([$file->getPathname() => $publishPath], 'config');
                     $this->merge_config_from($file->getPathname(), $key);
                 }
             }

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_generates_a_master_service_provider_with_resource_loading__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_generates_a_master_service_provider_with_resource_loading__1.txt
@@ -99,7 +99,10 @@ class BlogServiceProvider extends ServiceProvider
 
                     $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
 
-                    $this->publishes([$file->getPathname() => config_path($config)], 'config');
+                    $publishPath = ($config === 'config.php')
+                        ? config_path($this->nameLower.'.php')
+                        : config_path($config);
+                    $this->publishes([$file->getPathname() => $publishPath], 'config');
                     $this->merge_config_from($file->getPathname(), $key);
                 }
             }


### PR DESCRIPTION
Fixes #2122

## What broke

Running `php artisan module:publish-config` and choosing All only successfully publishes the first module. Every subsequent module fails silently with:

```
File [/path/config/config.php] already exists
```

## Root cause

The service provider stub publishes each module's `Config/config.php` using:

```php
$this->publishes([$file->getPathname() => config_path($config)], 'config');
```

Since every module has a file named `config.php`, this resolves to the same destination — `config/config.php` — for all of them. The first one wins; the rest are skipped.

## Fix

When the config file is named `config.php`, publish it to `config/{moduleName}.php` instead:

```php
$publishPath = ($config === 'config.php')
    ? config_path($this->nameLower.'.php')
    : config_path($config);
$this->publishes([$file->getPathname() => $publishPath], 'config');
```

This matches the config key already used for that file (`$this->nameLower`), so existing config merging behaviour is unchanged. All snapshot tests updated to match.