### PR TITLE
Fix module config overwriting cached env values with null after config:cache

### DIFF
--- a/src/Commands/stubs/scaffold/provider.stub
+++ b/src/Commands/stubs/scaffold/provider.stub
@@ -111,6 +111,10 @@ class $CLASS$ extends ServiceProvider
      */
     protected function merge_config_from(string $path, string $key): void
     {
+        if (app()->configurationIsCached()) {
+            return;
+        }
+
         $existing = config($key, []);
         $module_config = require $path;
 

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_disable__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_disable__1.txt
@@ -111,6 +111,10 @@ class BlogServiceProvider extends ServiceProvider
      */
     protected function merge_config_from(string $path, string $key): void
     {
+        if (app()->configurationIsCached()) {
+            return;
+        }
+
         $existing = config($key, []);
         $module_config = require $path;
 

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generate_module_when_provider_is_enable_and_route_provider_is_enable__1.txt
@@ -111,6 +111,10 @@ class BlogServiceProvider extends ServiceProvider
      */
     protected function merge_config_from(string $path, string $key): void
     {
+        if (app()->configurationIsCached()) {
+            return;
+        }
+
         $existing = config($key, []);
         $module_config = require $path;
 

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_api_module_with_resources__1.txt
@@ -111,6 +111,10 @@ class BlogServiceProvider extends ServiceProvider
      */
     protected function merge_config_from(string $path, string $key): void
     {
+        if (app()->configurationIsCached()) {
+            return;
+        }
+
         $existing = config($key, []);
         $module_config = require $path;
 

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_namespace_using_studly_case__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_namespace_using_studly_case__1.txt
@@ -111,6 +111,10 @@ class ModuleNameServiceProvider extends ServiceProvider
      */
     protected function merge_config_from(string $path, string $key): void
     {
+        if (app()->configurationIsCached()) {
+            return;
+        }
+
         $existing = config($key, []);
         $module_config = require $path;
 

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_module_resources__1.txt
@@ -111,6 +111,10 @@ class BlogServiceProvider extends ServiceProvider
      */
     protected function merge_config_from(string $path, string $key): void
     {
+        if (app()->configurationIsCached()) {
+            return;
+        }
+
         $existing = config($key, []);
         $module_config = require $path;
 

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources__1.txt
@@ -111,6 +111,10 @@ class BlogServiceProvider extends ServiceProvider
      */
     protected function merge_config_from(string $path, string $key): void
     {
+        if (app()->configurationIsCached()) {
+            return;
+        }
+
         $existing = config($key, []);
         $module_config = require $path;
 

--- a/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__1.txt
+++ b/tests/Commands/Make/__snapshots__/ModuleMakeCommandTest__test_it_generates_web_module_with_resources_when_adding_more_than_one_option__1.txt
@@ -111,6 +111,10 @@ class BlogServiceProvider extends ServiceProvider
      */
     protected function merge_config_from(string $path, string $key): void
     {
+        if (app()->configurationIsCached()) {
+            return;
+        }
+
         $existing = config($key, []);
         $module_config = require $path;
 

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace__1.txt
@@ -111,6 +111,10 @@ class BlogServiceProvider extends ServiceProvider
      */
     protected function merge_config_from(string $path, string $key): void
     {
+        if (app()->configurationIsCached()) {
+            return;
+        }
+
         $existing = config($key, []);
         $module_config = require $path;
 

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_change_the_default_namespace_specific__1.txt
@@ -111,6 +111,10 @@ class BlogServiceProvider extends ServiceProvider
      */
     protected function merge_config_from(string $path, string $key): void
     {
+        if (app()->configurationIsCached()) {
+            return;
+        }
+
         $existing = config($key, []);
         $module_config = require $path;
 

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_have_custom_migration_resources_location_paths__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_can_have_custom_migration_resources_location_paths__1.txt
@@ -111,6 +111,10 @@ class BlogServiceProvider extends ServiceProvider
      */
     protected function merge_config_from(string $path, string $key): void
     {
+        if (app()->configurationIsCached()) {
+            return;
+        }
+
         $existing = config($key, []);
         $module_config = require $path;
 

--- a/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_generates_a_master_service_provider_with_resource_loading__1.txt
+++ b/tests/Commands/Make/__snapshots__/ProviderMakeCommandTest__test_it_generates_a_master_service_provider_with_resource_loading__1.txt
@@ -111,6 +111,10 @@ class BlogServiceProvider extends ServiceProvider
      */
     protected function merge_config_from(string $path, string $key): void
     {
+        if (app()->configurationIsCached()) {
+            return;
+        }
+
         $existing = config($key, []);
         $module_config = require $path;
 


### PR DESCRIPTION
Fixes #2126

## What broke

After running `php artisan config:cache`, module config keys backed by `env()` come back as `null` instead of their real values:

```php
config('testmodule.env_test'); // null (should be 'test')
```

The cached config file itself is correct — the problem only surfaces at runtime.

## Root cause

The provider stub's `merge_config_from()` method is called inside `boot()` on every request. It does:

```php
$module_config = require $path;  // re-executes the config file
config([$key => array_replace_recursive($existing, $module_config)]);
```

When the config is cached, Laravel doesn't load `.env` at runtime, so all `env()` calls inside the required config file return `null`. Those nulls are then merged over the correctly baked cached values, clobbering them.

## Fix

Skip the merge when configuration is already cached. The cached config already has the correct baked-in values — re-requiring and re-merging the config file at runtime is both unnecessary and destructive.

```php
protected function merge_config_from(string $path, string $key): void
{
    if (app()->configurationIsCached()) {
        return;
    }

    // ... existing merge logic
}
```

Snapshot tests updated to match.