### PR TITLE
fix: respect generate flag in generateFiles() method

### DIFF
--- a/src/Generators/ModuleGenerator.php
+++ b/src/Generators/ModuleGenerator.php
@@ -374,6 +374,11 @@ class ModuleGenerator extends Generator
                 continue;
             }
 
+            $generatorKey = $this->getGeneratorKeyForFile($file);
+            if ($generatorKey !== null && GenerateConfigReader::read($generatorKey)->generate() === false) {
+                continue;
+            }
+
             $path = $this->module->getModulePath($this->getName()).$file;
 
             $this->component->task("Generating file {$path}", function () use ($stub, $path) {
@@ -544,6 +549,28 @@ class ModuleGenerator extends Generator
         }
 
         return $replaces;
+    }
+
+    /**
+     * Get the generator key that corresponds to the given file path.
+     */
+    private function getGeneratorKeyForFile(string $filePath): ?string
+    {
+        $matchedKey = null;
+        $matchedLength = 0;
+
+        foreach ($this->getFolders() as $key => $folder) {
+            $generatorPath = GenerateConfigReader::read($key)->getPath();
+            if ($generatorPath !== null
+                && str_starts_with($filePath, $generatorPath.'/')
+                && strlen($generatorPath) > $matchedLength
+            ) {
+                $matchedKey = $key;
+                $matchedLength = strlen($generatorPath);
+            }
+        }
+
+        return $matchedKey;
     }
 
     /**

--- a/tests/Commands/Make/ModuleMakeCommandTest.php
+++ b/tests/Commands/Make/ModuleMakeCommandTest.php
@@ -324,6 +324,18 @@ class ModuleMakeCommandTest extends BaseTestCase
         $this->assertSame(0, $code);
     }
 
+    public function test_it_does_not_generate_files_for_disabled_generators()
+    {
+        $this->app['config']->set('modules.paths.generator.assets', ['path' => 'resources/assets', 'generate' => false]);
+
+        $code = $this->artisan('module:make', ['name' => ['Blog']]);
+
+        $this->assertDirectoryDoesNotExist($this->modulePath.'/resources/assets');
+        $this->assertFileDoesNotExist($this->modulePath.'/resources/assets/js/app.js');
+        $this->assertFileDoesNotExist($this->modulePath.'/resources/assets/sass/app.scss');
+        $this->assertSame(0, $code);
+    }
+
     public function test_it_can_ignore_resource_folders_to_generate()
     {
         $this->app['config']->set('modules.paths.generator.seeder', ['path' => 'Database/Seeders', 'generate' => false]


### PR DESCRIPTION
## Summary

Fixes #2148

When `modules.paths.generator.assets.generate` is set to `false`, the `resources/assets` directory is still created during module generation. This happens because `generateFiles()` creates stub files (and their parent directories) without checking the `generate` flag.

## Root Cause

The `generate()` method in `ModuleGenerator` calls three methods sequentially:

1. `generateFolders()` - checks `generate` flag before creating directories
2. `generateFiles()` - does **not** check `generate` flag
3. `generateResources()` - checks `generate` flag before creating resources

`generateFiles()` iterates over `stubs.files` config and creates both files and their parent directories via `makeDirectory()`. Even though `generateFolders()` correctly skips `resources/assets`, `generateFiles()` recreates it as a side effect when writing `resources/assets/js/app.js` and `resources/assets/sass/app.scss`.

## Fix

- Added a `generate` flag check in `generateFiles()` that maps each stub file to its corresponding generator by matching the output file path against generator paths
- If the file belongs to a disabled generator (`generate = false`), it is skipped
- Files that don't belong to any generator (e.g. `composer.json`, `package.json`) are always generated
- Uses longest path match to correctly handle generators with nested paths (e.g. `resources/views` vs `resources/views/components`)

## Test Plan

- [x] Added `test_it_does_not_generate_files_for_disabled_generators` that sets `assets.generate = false` and verifies neither the directory nor the stub files are created
- [x] Full test suite passes (387 tests, 866 assertions)