### PR TITLE
Fix Module translation loading missing namespace

### DIFF
--- a/src/Support/ModuleServiceProvider.php
+++ b/src/Support/ModuleServiceProvider.php
@@ -116,7 +116,7 @@ abstract class ModuleServiceProvider extends ServiceProvider
             $this->loadJsonTranslationsFrom($langPath);
         } else {
             $moduleLangPath = module_path($this->name, config('modules.paths.generator.lang.path'));
-            $this->loadTranslationsFrom($moduleLangPath);
+            $this->loadTranslationsFrom($moduleLangPath, $this->nameLower);
             $this->loadJsonTranslationsFrom($moduleLangPath);
         }
     }


### PR DESCRIPTION
In commits c4321c5577ce6f69a548cb736ab4d818d29fb47a and 86c277435a086c5bf907043c555fd3ef1ad6e153, the module namespace went missing when registering the module translations. This means `blog::file.key` is not working in the current version (for files in `Modules/Blog/lang`).

This small PR fixes that, readding the namespace.