### PR TITLE
Add laravel/boost support

### DIFF
--- a/.ai/laravel-modules/1/skill/laravel-modules-development/SKILL.blade.php
+++ b/.ai/laravel-modules/1/skill/laravel-modules-development/SKILL.blade.php
@@ -1,0 +1,177 @@
+---
+name: laravel-modules-development
+description: "Use for any task or question involving nWidart/laravel-modules. Activate if the user mentions modules, module:make, module commands, or a Modules/ directory structure."
+license: MIT
+metadata:
+    author: nWidart
+    ---
+    @php
+    /** @var \Laravel\Boost\Install\GuidelineAssist $assist */
+    @endphp
+    # Laravel Modules Development
+
+    ## Documentation
+
+    Use `search-docs` for detailed laravel-modules patterns and documentation.
+
+    ## Basic Usage
+
+    ### Creating a Module
+
+    ```bash
+    {{ $assist->artisanCommand('module:make Blog') }}
+    ```
+
+    ### Enabling / Disabling a Module
+
+    ```bash
+    {{ $assist->artisanCommand('module:enable Blog') }}
+    {{ $assist->artisanCommand('module:disable Blog') }}
+    ```
+
+    ### Listing Modules
+
+    ```bash
+    {{ $assist->artisanCommand('module:list') }}
+    ```
+
+    ## Module Structure
+
+    A generated module lives under `Modules/Blog/` and contains:
+
+    ```
+    Modules/Blog/
+      app/
+          Http/Controllers/
+              Models/
+                  Providers/
+                    config/
+                      database/
+                          migrations/
+                              seeders/
+                                resources/
+                                    views/
+                                      routes/
+                                          web.php
+                                              api.php
+                                                tests/
+                                                  module.json
+                                                    composer.json
+                                                    ```
+
+                                                    ## Generating Module Components
+
+                                                    ### Controller
+
+                                                    ```bash
+                                                    {{ $assist->artisanCommand('module:make-controller BlogController Blog') }}
+                                                    {{ $assist->artisanCommand('module:make-controller BlogController Blog --api') }}
+                                                    ```
+
+                                                    ### Model
+
+                                                    ```bash
+                                                    {{ $assist->artisanCommand('module:make-model Post Blog') }}
+                                                    {{ $assist->artisanCommand('module:make-model Post Blog --migration') }}
+                                                    ```
+
+                                                    ### Migration
+
+                                                    ```bash
+                                                    {{ $assist->artisanCommand('module:make-migration create_posts_table Blog') }}
+                                                    ```
+
+                                                    ### Seeder
+
+                                                    ```bash
+                                                    {{ $assist->artisanCommand('module:make-seed PostDatabaseSeeder Blog') }}
+                                                    ```
+
+                                                    ### Request
+
+                                                    ```bash
+                                                    {{ $assist->artisanCommand('module:make-request StorePostRequest Blog') }}
+                                                    ```
+
+                                                    ### Provider
+
+                                                    ```bash
+                                                    {{ $assist->artisanCommand('module:make-provider BlogServiceProvider Blog') }}
+                                                    ```
+
+                                                    ### Event & Listener
+
+                                                    ```bash
+                                                    {{ $assist->artisanCommand('module:make-event PostCreated Blog') }}
+                                                    {{ $assist->artisanCommand('module:make-listener SendPostNotification Blog') }}
+                                                    ```
+
+                                                    ### Job
+
+                                                    ```bash
+                                                    {{ $assist->artisanCommand('module:make-job ProcessPost Blog') }}
+                                                    ```
+
+                                                    ### Middleware
+
+                                                    ```bash
+                                                    {{ $assist->artisanCommand('module:make-middleware EnsureUserIsAdmin Blog') }}
+                                                    ```
+
+                                                    ### Command
+
+                                                    ```bash
+                                                    {{ $assist->artisanCommand('module:make-command SyncPosts Blog') }}
+                                                    ```
+
+                                                    ### Policy
+
+                                                    ```bash
+                                                    {{ $assist->artisanCommand('module:make-policy PostPolicy Blog') }}
+                                                    ```
+
+                                                    ### Resource
+
+                                                    ```bash
+                                                    {{ $assist->artisanCommand('module:make-resource PostResource Blog') }}
+                                                    ```
+
+                                                    ## Running Module Migrations
+
+                                                    ```bash
+                                                    {{ $assist->artisanCommand('module:migrate Blog') }}
+                                                    {{ $assist->artisanCommand('module:migrate-rollback Blog') }}
+                                                    {{ $assist->artisanCommand('module:migrate-refresh Blog') }}
+                                                    {{ $assist->artisanCommand('module:migrate-reset Blog') }}
+                                                    ```
+
+                                                    ## Inertia Support
+
+                                                    When using Inertia.js inside a module:
+
+                                                    ```bash
+                                                    # Generate an Inertia-powered module (--inertia flag)
+                                                    {{ $assist->artisanCommand('module:make Blog --inertia') }}
+
+                                                    # Generate an Inertia page inside a module
+                                                    {{ $assist->artisanCommand('module:make-inertia-page Index Blog') }}
+                                                    {{ $assist->artisanCommand('module:make-inertia-page Index Blog --react') }}
+                                                    {{ $assist->artisanCommand('module:make-inertia-page Index Blog --vue') }}
+                                                    {{ $assist->artisanCommand('module:make-inertia-page Index Blog --svelte') }}
+
+                                                    # Generate an Inertia component inside a module
+                                                    {{ $assist->artisanCommand('module:make-inertia-component Button Blog') }}
+
+                                                    # Publish the Inertia app.js entry point
+                                                    {{ $assist->artisanCommand('module:publish-inertia') }}
+                                                    ```
+
+                                                    ## Key Conventions
+
+                                                    - Module classes are namespaced as `Modules\{ModuleName}` (e.g. `Modules\Blog\Http\Controllers\PostController`).
+                                                    - Module routes are loaded from `Modules/{Name}/routes/web.php` and `api.php`.
+                                                    - Module views are referenced as `{lowercase-name}::{view}` (e.g. `blog::index`).
+                                                    - Module configs live in `Modules/{Name}/config/{name}.php` and are merged at `{name}`.
+                                                    - Module service providers are auto-discovered from `module.json` `providers` key.
+                                                    - Keep business logic inside the module; avoid coupling modules together — use events/listeners instead.
+                                                    - Use `module:publish-config`, `module:publish-migration`, or `module:publish-translation` to publish module assets to the host application.

--- a/.ai/laravel-modules/core.blade.php
+++ b/.ai/laravel-modules/core.blade.php
@@ -1,0 +1,7 @@
+# Laravel Modules
+
+- Laravel Modules is a package for managing large Laravel applications using a modular architecture.
+- Each module is an independent unit with its own controllers, models, views, routes, migrations, and configuration.
+- Use `module:make ModuleName` to scaffold a new module. Modules live in the `Modules/` directory by default.
+- Module namespaces follow the pattern `Modules\ModuleName` (e.g. `Modules\Blog\Http\Controllers\BlogController`).
+- Always place module-specific logic inside the module directory, not in the application's `app/` folder.


### PR DESCRIPTION
## Description

This PR adds [laravel/boost](https://github.com/laravel/boost) support to `nWidart/laravel-modules` by introducing a `.ai` directory with Boost-compatible skill files.

[Laravel Boost](https://laravel.com/docs/13.x/boost) is a Laravel-focused MCP (Model Context Protocol) server that provides AI assistants with the essential context and guidelines needed to generate high-quality, Laravel-specific code. Other Laravel packages (Livewire, Inertia, Pennant, Folio, etc.) already ship their own `.ai` skill files so that AI tools know how to work with them correctly.

This PR brings the same capability to `laravel-modules`.

## Changes

### New Files

| File | Purpose |
|---|---|
| `.ai/laravel-modules/core.blade.php` | Short summary of laravel-modules that Boost injects into every AI context |
| `.ai/laravel-modules/1/skill/laravel-modules-development/SKILL.blade.php` | Full development skill covering module creation, generators, migrations, Inertia support, and key conventions |

## What the Skill Covers

- Creating and managing modules (`module:make`, `module:enable`, `module:disable`, `module:list`)
- - Module directory structure
- - All generator commands (controller, model, migration, seeder, request, provider, event, listener, job, middleware, command, policy, resource)
- - Running module migrations
- - Inertia support (`--inertia` flag, `module:make-inertia-page`, `module:make-inertia-component`, `module:publish-inertia`)
- - Key conventions (namespacing, routing, views, config, service providers, decoupling via events)
## Prerequisites

Users need [laravel/boost](https://github.com/laravel/boost) installed in their Laravel application for these skill files to be picked up automatically by AI assistants.

## Related

- [laravel/boost](https://github.com/laravel/boost)